### PR TITLE
Adding Python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,19 @@ cache:
   - "$HOME/.m2"
   - "$HOME/.p2"
   - $HOME/.cache/pip
+before_install:
+  - sudo apt install software-properties-common -y
+  - sudo add-apt-repository ppa:deadsnakes/ppa -y
+  - sudo apt install python3.10
 addons:
   apt:
     packages: python3
 services:
 - xvfb
 install: skip # The below script command already does the installation.
-before_script: python3 --version
+before_script: 
+  - python3 --version
+  - python3.10 --version
 script: mvn clean verify -Pjacoco coveralls:report
 notifications:
   slack:


### PR DESCRIPTION
This is against the main branch. 

On this PR, we see on lines 12-15, we are installing python 3.10. But this PR passes because we are still installing python3 on line 18, so when the build runs `python3` it is running python 3.8 as seen on line 23.

Takeaway: 

- Works because we are just adding the installation of python 3.10 but we are not using it, so it is just there. We are actually using python version 3.8 which is `python3`