### PR TITLE
Update to Python 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ cache:
   - "$HOME/.p2"
   - $HOME/.cache/pip
 before_install:
-  - sudo apt install software-properties-common -y
-  - sudo add-apt-repository ppa:deadsnakes/ppa -y
-  - sudo apt install python3.10
+  - sudo apt install -y software-properties-common
+  - sudo add-apt-repository -y ppa:deadsnakes/ppa
+  - sudo apt install -y python3.10
   - sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
   - sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 2
   - sudo update-alternatives --auto python3 
-  - sudo apt-get install python3.10-distutils
+  - sudo apt install -y python3.10-distutils
   - curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 services:
 - xvfb


### PR DESCRIPTION
This is against the ishybridfragile branch.

On this PR, we see on lines 12-15, we are installing python 3.10. But this PR passes because we are still installing python3 on line 18, so when the build runs python3 it is running python 3.8 as seen on line 24.

Takeaway:

Works because we are just adding the installation of python 3.10 but we are not using it, so it is just there. We are actually using python version 3.8 which is python3

References for the changes: 
1. https://discuss.python.org/t/unable-to-upgrade-python-3-8-10-to-3-10-solved/15753/6
2. https://linuxhint.com/update_alternatives_ubuntu/
3. https://linuxize.com/post/how-to-install-pip-on-ubuntu-20.04/
4. https://askubuntu.com/questions/1239829/modulenotfounderror-no-module-named-distutils-util
5. https://stackoverflow.com/questions/70431655/importerror-cannot-import-name-html5lib-from-pip-vendor-usr-lib-python3