### PR TITLE
Adding assertions that the function is hybrid in testComputeParameters test cases

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -579,6 +579,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function function = functions.iterator().next();
 		assertNotNull(function);
 
+		assertTrue(function.isHybrid());
+
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
@@ -599,6 +601,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function function = functions.iterator().next();
 		assertNotNull(function);
 
+		assertTrue(function.isHybrid());
+
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
@@ -617,6 +621,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(1, functions.size());
 		Function function = functions.iterator().next();
 		assertNotNull(function);
+
+		assertTrue(function.isHybrid());
 
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
@@ -637,6 +643,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function function = functions.iterator().next();
 		assertNotNull(function);
 
+		assertTrue(function.isHybrid());
+
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
@@ -655,6 +663,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(1, functions.size());
 		Function function = functions.iterator().next();
 		assertNotNull(function);
+
+		assertTrue(function.isHybrid());
 
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
@@ -694,6 +704,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function function = functions.iterator().next();
 		assertNotNull(function);
 
+		assertTrue(function.isHybrid());
+
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
@@ -712,6 +724,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(1, functions.size());
 		Function function = functions.iterator().next();
 		assertNotNull(function);
+
+		assertTrue(function.isHybrid());
 
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
@@ -732,6 +746,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function function = functions.iterator().next();
 		assertNotNull(function);
 
+		assertTrue(function.isHybrid());
+
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
@@ -750,6 +766,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(1, functions.size());
 		Function function = functions.iterator().next();
 		assertNotNull(function);
+
+		assertFalse(function.isHybrid());
 
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 
@@ -773,6 +791,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function function = functions.iterator().next();
 		assertNotNull(function);
 
+		assertTrue(function.isHybrid());
+
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		// This test is with a custom decorator `@custom.decorator` that contains a parameter `input_signature`
 		// like `tf.function`. But it also has a tf.function decorator, therefore args should not be Null.
@@ -794,6 +814,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(1, functions.size());
 		Function function = functions.iterator().next();
 		assertNotNull(function);
+
+		assertTrue(function.isHybrid());
 
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);


### PR DESCRIPTION
Fixes #126 .

## Commits

- [x] I slowed down and took a deep breath before committing. Otherwise, I will start a pristine branch and reissue this pull request.
- [x] Before committing my changes, I checked my working directory carefully. I only staged the changes I wanted and ensured it was of the utmost quality.
- [x] I used `git diff` and `git status` to check my work carefully before committing.
- [x] I completely understand what I am committing and why.
- [x] I completely understand why things are the way they are.
- [x] The change I am proposing makes complete sense to me.
- [x] For the most part, the changes in this pull request correspond to the problem or task I am solving or performing. In other words, only the changes that are supposed to be there are the ones included in this pull request.

## Expectations

<!-- Describe the expectations for this pull request. Examples:

- "Instead of using version 9.3.1, we should now be using 9.3.2."
- "New should see modified and new JARs. No JARs should be deleted." -->

I have added an assertion to the `testComputeParameters` test cases to verify that the functions are, in fact, hybrid because if the function is not hybrid, it should not have hybridization arguments.

## Testing

- [ ] If this is a bug fix, I was able to reproduce the problem locally **before** I made any changes (can use `git stash` to temporarily reset the working directory). 
- [ ] When I made (or put back) my changes, the problem I reproduced above was fixed.

<!-- Please describe the tests that you ran (locally) to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Added to all `testComputeParameters`, and the tests pass. 

## Final Checks

- [x] The changes I am proposing meet the expectations I have described above.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation if applicable.
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable.
- [x] New and existing unit tests pass locally with my changes.
