### PR TITLE
Adding failing test

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameter32/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameter32/in/A.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+def func2(t):
+  pass
+
+@tf.function
+def func():
+  a = tf.constant([[1.0, 2.0], [3.0, 4.0]])
+  b = tf.constant([[1.0, 1.0], [0.0, 1.0]])
+  c = tf.matmul(a, b)
+  tensor = tf.Tensor(c.op, 0, tf.float32)
+  func2(tensor)
+
+func()

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameter32/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameter32/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
@@ -2314,6 +2315,39 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("b", paramName);
 
 		assertTrue("Expecting function with likely tensor parameter.", function.getLikelyHasTensorParameter());
+	}
+
+	/**
+	 * Test for #2 for TF API `tf.Tensor`.
+	 */
+	@Test
+	public void testHasLikelyTensorParameter32() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertNotNull(functions);
+		assertEquals(2, functions.size());
+
+		Function functionToBeEvaluated = null;
+
+		for (Function func : functions) {
+			if (Objects.equals(func.getSimpleName(), "func2"))
+				functionToBeEvaluated = func;
+		}
+
+		assertNotNull(functionToBeEvaluated);
+
+		argumentsType params = functionToBeEvaluated.getParameters();
+
+		// one param.
+		exprType[] actualParams = params.args;
+		assertEquals(1, actualParams.length);
+
+		exprType actualParameter = actualParams[0];
+		assertNotNull(actualParameter);
+
+		String paramName = NodeUtils.getRepresentationString(actualParameter);
+		assertEquals("t", paramName);
+
+		assertTrue("Expecting function with likely tensor parameter.", functionToBeEvaluated.getLikelyHasTensorParameter());
 	}
 
 	// TODO: Test arbitrary expression.


### PR DESCRIPTION
Failing test where the tensor analysis is coming up blank.

## Commits

- [ ] I slowed down and took a deep breadth before committing. Otherwise, I will start a pristine branch and reissue this pull request.
- [ ] Before committing my changes, I checked my working directory carefully. I only staged the changes I wanted and ensured it was of the utmost quality.
- [ ] I used `git diff` and `git status` to check my work carefully before committing.
- [ ] I completely understand what I am committing and why.
- [ ] I completely understand why things are the way they are.
- [ ] The change I am proposing makes complete sense to me.
- [ ] For the most part, the changes in this pull request correspond to the problem or task I am solving or performing. In other words, only the changes that are supposed to be there are the ones included in this pull request.

## Expectations

<!-- Describe the expectations for this pull request. Examples:

- "Instead of using version 9.3.1, we should now be using 9.3.2."
- "New should see modified and new JARs. No JARs should be deleted." -->

## Testing

- [ ] If this is a bug fix, I was able to reproduce the problem locally **before** I made any changes (can use `git stash` to temporarily reset the working directory). 
- [ ] When I made (or put back) my changes, the problem I reproduced above was fixed.

<!-- Please describe the tests that you ran (locally) to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->


## Final Checks

- [ ] The changes I am proposing meet the expectations I have described above.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation if applicable.
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable.
- [ ] New and existing unit tests pass locally with my changes.
