### PR TITLE
Bump Ariadne to 0.40.0

### DIFF
--- a/hybridize.target
+++ b/hybridize.target
@@ -29,7 +29,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.39.0-SNAPSHOT</version>
+					<version>0.40.0</version>
 					<type>jar</type>
 				</dependency>
 			</dependencies>


### PR DESCRIPTION
Re-applies the change from 90e9308 (reverted at 91ba29a) now that a stable test baseline is in place after 8fa92f2 suppressed the env-dependent testModule13-16 cluster.

## Expectations

This PR is opened in **draft** for diagnostic confirmation. It is not intended to merge in its current state.

- Locally (Linux, JDK 17, Tycho 2.7.5), `mvn clean verify -U` fails at dependency resolution with `osgi.ee=UNKNOWN` because Ariadne 0.40.0 was compiled with `maven.compiler.release=25` (bytecode class file v69) and Tycho 2.7.5 doesn't know `JavaSE-25` as an OSGi execution environment, so the wrapped bundle's EE requirement can't be satisfied by the Java 17 target platform.
- **Expectation: CI surfaces the same failure mode.** If CI agrees, the followup is upgrading Tycho (likely 5.x, current is 2.7.5), tracked separately. If CI surfaces something different, the diagnosis needs revision.
- Downgrading Ariadne to `release=17` is not a viable option — Ariadne uses records and is consumed by other clients whose roadmap is independent of Hybridize.

## Testing

Local `mvn clean verify -U -B` against this branch on Linux + JDK 17:

```
[ERROR] wrapped.com.ibm.wala.com.ibm.wala.cast.python.ml 0.40.0
        requires Execution Environment that matches (osgi.ee=UNKNOWN)
        but the current resolution context uses [a.jre.javase 17.0.0]
[ERROR] Cannot resolve dependencies of MavenProject:
        edu.cuny.hunter.hybridize:edu.cuny.hunter.hybridize.core:1.4.0-SNAPSHOT
```

Tests do not run — failure is at dependency resolution.

CI is the oracle here; awaiting its verdict before drawing conclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)