### PR TITLE
Sync Spotless config from Ariadne: bump versions, enable `<toggleOffOn/>`, exclude submodule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <logging.config.file>${maven.multiModuleProjectDirectory}/logging.properties</logging.config.file>
-    <spotless.version>2.44.5</spotless.version>
+    <spotless.version>3.4.0</spotless.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -158,6 +158,9 @@
                   <exclude>**/.pytest_cache/</exclude>
                   <exclude>**/*.log</exclude>
                   <exclude>**/v1_astmanager/</exclude>
+                  <exclude>**/*.pdf</exclude>
+                  <!-- Exclude Git submodules -->
+                  <exclude>Formatting/</exclude>
                 </excludes>
                 <trimTrailingWhitespace/>
                 <endWithNewline/>
@@ -182,6 +185,7 @@
                   <include>**/*.xml</include>
                   <include>**/.pydevproject</include>
                 </includes>
+                <toggleOffOn/>
                 <excludes>
                   <exclude>**/plugin.xml</exclude>
                   <exclude>**/feature.xml</exclude>
@@ -189,6 +193,8 @@
                   <exclude>**/dependency-reduced-pom.xml</exclude>
                   <exclude>**/gradle.xml</exclude>
                   <exclude>**/target/</exclude>
+                  <!-- Exclude Git submodules -->
+                  <exclude>Formatting/</exclude>
                 </excludes>
                 <eclipseWtp>
                   <type>XML</type>
@@ -208,7 +214,7 @@
                 <exclude>**/target/</exclude>
               </excludes>
               <eclipse>
-                <version>4.27</version>
+                <version>4.39</version>
                 <file>${maven.multiModuleProjectDirectory}/eclipse-formatter.xml</file>
               </eclipse>
               <importOrder>

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,8 @@
                 </includes>
                 <excludes>
                   <exclude>**/target/</exclude>
+                  <!-- Exclude Git submodules -->
+                  <exclude>Formatting/</exclude>
                 </excludes>
                 <trimTrailingWhitespace/>
                 <endWithNewline/>


### PR DESCRIPTION
## Summary

Aligns Hybridize's Spotless setup with Ariadne master's pattern (with one deliberate divergence — see below), fixing the `tensorflow.xml` doc-comment marker issue that's blocking CI on `upgrade-tycho-5-java-25`.

## Changes

- **Bump Spotless plugin**: `2.44.5` → `3.4.0` (latest). No format-rule regressions — `spotless:check` clean across the repo.
- **Bump Eclipse Java formatter**: `4.27` → `4.39`. Matches the Eclipse target Hybridize is upgrading to; also clean.
- **Add `<toggleOffOn/>`** to the XML format block. Enables `<!-- spotless:off --> ... <!-- spotless:on -->` markers inside XML. The markers already exist in `tensorflow.xml` on `upgrade-tycho-5-java-25`; once this lands and that branch merges `main`, the existing CI Spotless violation resolves without further action.
- **Add `**/*.pdf`** to the global excludes. Binary; no formatting applies.
- **Add `Formatting/`** to both global and XML format excludes. Matches Ariadne's pattern of excluding `IDE/`/`jython3/` submodules — each submodule should carry its own Spotless config in its own repo rather than inheriting the parent's. (If you ever want the `Formatting` repo formatted, add Spotless to `ponder-lab/Formatting` directly.)

## Deliberate Divergence from Ariadne

**Java formatter stays on Eclipse 4.39 + custom `eclipse-formatter.xml`** rather than adopting Ariadne's `googleJavaFormat`. google-java-format is forced on Ariadne for upstream-contribution alignment but is considered a poorer formatter for the Hybridize codebase. Not changing.

## Test Plan

- [x] `mvn spotless:check` passes locally on JDK 17 with all changes (`spotless:3.4.0:check ... BUILD SUCCESS`, no violations).
- [ ] CI green.
- [ ] Once merged, merge `main` into `upgrade-tycho-5-java-25` to pick up the fix and unblock that branch's Spotless CI failure.

## Why on Main Rather Than `upgrade-tycho-5-java-25`

These config changes don't relate to the Tycho 5 / Java 25 upgrade work specifically — they're general-purpose Spotless infrastructure improvements. Done on `main` so they're available repo-wide; `upgrade-tycho-5-java-25` will inherit via merge.
