### PR TITLE
Add `numArgs` to 24 multi-arg synthetic `<call>` summaries (`wala/ML#445`)

### DIFF
--- a/edu.cuny.hunter.hybridize.core/tensorflow.xml
+++ b/edu.cuny.hunter.hybridize.core/tensorflow.xml
@@ -979,7 +979,7 @@
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self inputs name">
           <getfield class="Llist" field="0" fieldType="LRoot" ref="inputs" def="x" />
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1014,7 +1014,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/abs -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1022,7 +1022,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_all -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input_tensor axis keepdims name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1030,7 +1030,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_prod -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input_tensor axis keepdims name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1038,7 +1038,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tanh -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1046,7 +1046,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/l2_normalize -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self x axis epsilon name dim">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1054,7 +1054,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_max -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1062,7 +1062,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_logsumexp -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input_tensor axis keepdims name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1070,7 +1070,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/acos -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1390,7 +1390,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/identity -->
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="input name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input" def="x" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input" numArgs="2" def="x" />
           <return value="x" />
         </method>
       </class>
@@ -1410,7 +1410,7 @@
         <method name="read_data" descriptor="()LRoot;">
           <new def="x" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" def="y" />
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
           <return value="x" />
         </method>
@@ -1424,7 +1424,7 @@
         <method name="read_data" descriptor="()LRoot;">
           <new def="x" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" def="y" />
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
           <return value="x" />
         </method>
@@ -1437,7 +1437,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/rank -->
         <method name="read_data" descriptor="()LRoot;">
           <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" def="x" />
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="x" />
           <return value="x" />
         </method>
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="input name">
@@ -1449,7 +1449,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/size -->
         <method name="read_data" descriptor="()LRoot;">
           <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" def="x" />
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="x" />
           <return value="x" />
         </method>
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="input out_type name">
@@ -1460,7 +1460,7 @@
       <class name="tensor_scatter_nd_update" allocatable="true">
         <method name="read_data" descriptor="()LRoot;">
           <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" def="x" />
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="x" />
           <return value="x" />
         </method>
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tensor_scatter_nd_update -->
@@ -1515,7 +1515,7 @@
         <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="tensor name">
           <new def="x" class="Ltuple" />
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="tensor" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="tensor" numArgs="2" def="y" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
           <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="y" />
           <return value="x" />
@@ -1527,10 +1527,10 @@
           <new def="x" class="Ltuple" />
           <new def="y" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" def="yy" />
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="yy" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="y" value="yy" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" def="yyy" />
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="yyy" />
           <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="yyy" />
           <return value="x" />
         </method>
@@ -1604,7 +1604,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/random/shuffle -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="value seed name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="value" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="value" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1612,7 +1612,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/sort -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="values axis direction name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="values" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="values" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1706,7 +1706,7 @@
         <method name="read_data" descriptor="()LRoot;">
           <new def="x" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" def="y" />
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
           <return value="x" />
         </method>
@@ -1720,7 +1720,7 @@
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="data partitions num_partitions name">
           <new def="x" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" def="y" />
+          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
           <return value="x" />
         </method>
@@ -1730,7 +1730,7 @@
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="indices data name">
           <getfield class="Llist" field="0" fieldType="LRoot" ref="data" def="x" />
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
@@ -1802,7 +1802,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/bias_add -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self value bias data_format name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="value" def="y" />
+          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="value" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>


### PR DESCRIPTION
## Summary

Per [`XMLMethodSummaryReader.processCallSite`](https://github.com/wala/WALA/blob/master/core/src/main/java/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java#L413), when a `<call>` has `descriptor=\"()LRoot;\"` and `type=\"virtual\"`, the reader infers `nParams = 1` (just the receiver) unless `numArgs` is provided. The loop then reads only `arg0` and **silently drops** `arg1` and beyond.

24 synthetic `<call>` elements in `tensorflow.xml` invoke `convert_to_tensor.do` / `constant.do` (and analogues) with `arg0=\"...\" arg1=\"...\"` but no `numArgs` override. The receiver-only `PythonInvokeInstruction`s those produce caused [`wala/ML#445`](https://github.com/wala/ML/issues/445)'s `ArrayIndexOutOfBoundsException` in `handlePassThroughOp`.

Add `numArgs=\"2\"` (purely additive — no semantic change for any working call). Reader now correctly allocates `params[2]` and the synthetic invoke carries both the receiver and the value.

## Excluded

One outlier at line 2686 (`tensorflow.app.run.do`) has `arg1=\"\"` — adding `numArgs` would crash `Integer.parseInt(\"\")` instead of dropping silently. Treating as a separate issue.

## Validation

Full suite on `upgrade-tycho-5-java-25` against `0.42.0-SNAPSHOT`:

| State | Failures | Errors |
|---|---|---|
| Pre-bump (`fac28ee` on `0.41.0`) | 32 | 40 |
| Post-bump baseline (`6dc8473` on `0.42.0-SNAPSHOT` carrying `ponder-lab/ML#190`/`#191`/`#192`) | 33 | 25 |
| Post `ponder-lab/ML#193`/`#194` (also on `0.42.0-SNAPSHOT`) | 33 | 23 |
| **This PR** | **34** | **5** |

19 tests recovered (all 18 `AIOOB`-bucket tests from `wala/ML#445` + 1 holdover):

`testAbs`, `testAbs2`, `testAddN`, `testAddN2`, `testAddN3`, `testAddN4`, `testDynamicStitch`, `testDynamicStitch2`, `testEigenDecomposition`, `testEigenDecomposition2`, `testHasLikelyTensorParameter16`, `testIdentity`, `testRetracing3`, `testRetracing4`, `testRetracing5`, `testShuffle`, `testSort`, `testSort2`.

The `+1 AssertionError` is a pre-existing classification regression whose bucket shifted as the analysis ran further; it's covered by [`wala/ML#437`](https://github.com/wala/ML/issues/437).

## Test Plan

- [x] `./mvnw -U verify -Pjacoco` locally on `upgrade-tycho-5-java-25` + this PR — counts above.
- [x] Spotless clean.

Closes wala/ML#445.