### PR TITLE
Trigger Maven CI on `merge_group` events

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,6 +5,7 @@ name: Java CI with Maven
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
   - cron: "0 2 * * 5"
 concurrency:


### PR DESCRIPTION
## Summary

The merge queue creates a `merge_group` event when a PR enters its slot, then waits for required status checks to report on the combined-with-base commit. `maven.yml` was not triggering on `merge_group:`, so the `build` check never ran against the merged commit, and the queue evicted the PR after a 1-hour timeout with "removed from the merge queue due to no response for status checks" — observed on #436.

`codeql.yml` already triggers on `merge_group` (commit https://github.com/ponder-lab/Hybridize-Functions-Refactoring/commit/acee892); this PR aligns `maven.yml` to the same convention so the queue sees both required checks report.

Ariadne's `continuous-integration.yml` already has the same `merge_group:` trigger, so this is purely a Hybridize-side gap.

## Test Plan

- [ ] CI green on this PR
- [ ] Re-add #436 to the merge queue and confirm it advances cleanly