### PR TITLE
Process positional arguments to `@tf.function` (#108)

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -163,6 +163,18 @@ public class Function {
 		private static final String REDUCE_RETRACING = "reduce_retracing";
 
 		/**
+		 * The positional parameter order of {@code tf.function} as of TensorFlow 2.9 (the version this tool's tests target). When a user
+		 * writes {@code @tf.function(some_callable, [tf.TensorSpec(...)])} the second argument binds to {@code input_signature} by
+		 * position, etc. This array lets us map a positional index back to the parameter name without consulting PyDev's symbol-resolution
+		 * machinery (which is brittle across PyDev versions and TF stub variants). The TF API is stable across the [2.0, 2.11] range we
+		 * support; if a future TF version shuffles parameters, this array — and `Util.isHybrid`'s acceptance window — would need an update.
+		 * Tracks #108.
+		 */
+		private static final String[] TF_FUNCTION_POSITIONAL_PARAMS = { FUNC, INPUT_SIGNATURE, AUTOGRAPH, JIT_COMPILE, REDUCE_RETRACING,
+				EXPERIMENTAL_IMPLEMENTS, EXPERIMENTAL_AUTOGRAPH_OPTIONS, EXPERIMENTAL_RELAX_SHAPES, EXPERIMENTAL_COMPILE,
+				EXPERIMENTAL_FOLLOW_TYPE_HINTS };
+
+		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter autograph.
 		 */
 		private boolean autoGraphParamExists;
@@ -214,45 +226,53 @@ public class Function {
 			// tfFunctionDecorator must be an instance of Call, because that's the only way we have parameters.
 			if (tfFunctionDecorator.func instanceof Call) {
 				Call callFunction = (Call) tfFunctionDecorator.func;
-				// We only care about the actual keywords for now.
-				// TODO: Parse positional arguments (#108).
+
+				// Process positional arguments (#108). `tf.function`'s parameter order is hardcoded above in
+				// `TF_FUNCTION_POSITIONAL_PARAMS`; arg[i] binds to that array's i-th name. Excess positional args
+				// past the array length are silently ignored (Python would raise `TypeError` at decoration time,
+				// which we don't try to mirror — the precondition framework would later flag the function as
+				// non-hybridizable for unrelated reasons).
+				exprType[] positionalArgs = callFunction.args;
+				if (positionalArgs != null) {
+					int limit = Math.min(positionalArgs.length, TF_FUNCTION_POSITIONAL_PARAMS.length);
+					for (int i = 0; i < limit; i++)
+						this.markParamExists(TF_FUNCTION_POSITIONAL_PARAMS[i]);
+				}
+
+				// Process keyword arguments. Keyword args are unordered; each carries its parameter name
+				// directly. A user can mix positional and keyword in the same call (e.g.
+				// `@tf.function(my_func, autograph=False)`); both branches mark the same fields.
 				keywordType[] keywords = callFunction.keywords;
 				for (keywordType keyword : keywords)
 					if (keyword.arg instanceof NameTok) {
 						NameTok name = (NameTok) keyword.arg;
-						if (name.id.equals(FUNC))
-							// Found parameter func
-							this.funcParamExists = true;
-						else if (name.id.equals(INPUT_SIGNATURE))
-							// Found parameter input_signature
-							this.inputSignatureParamExists = true;
-						else if (name.id.equals(AUTOGRAPH))
-							// Found parameter autograph
-							this.autoGraphParamExists = true;
-						// The version of the API we are using allows
-						// parameter names jit_compile and
-						// deprecated name experimental_compile
-						else if (name.id.equals(JIT_COMPILE) || name.id.equals(EXPERIMENTAL_COMPILE))
-							// Found parameter jit_compile/experimental_compile
-							this.jitCompileParamExists = true;
-						// The version of the API we are using allows
-						// parameter names reduce_retracing
-						// and deprecated name experimental_relax_shapes
-						else if (name.id.equals(REDUCE_RETRACING) || name.id.equals(EXPERIMENTAL_RELAX_SHAPES))
-							// Found parameter reduce_retracing
-							// or experimental_relax_shapes
-							this.reduceRetracingParamExists = true;
-						else if (name.id.equals(EXPERIMENTAL_IMPLEMENTS))
-							// Found parameter experimental_implements
-							this.experimentalImplementsParamExists = true;
-						else if (name.id.equals(EXPERIMENTAL_AUTOGRAPH_OPTIONS))
-							// Found parameter experimental_autograph_options
-							this.experimentalAutographOptionsParamExists = true;
-						else if (name.id.equals(EXPERIMENTAL_FOLLOW_TYPE_HINTS))
-							// Found parameter experimental_follow_type_hints
-							this.experimentaFollowTypeHintsParamExists = true;
+						this.markParamExists(name.id);
 					}
 			} // else, tf.function is used without parameters.
+		}
+
+		/**
+		 * Set the appropriate {@code *ParamExists} field for the given {@code tf.function} parameter name. Recognizes both current names
+		 * and the deprecated aliases ({@code experimental_compile} → {@code jit_compile}, {@code experimental_relax_shapes} →
+		 * {@code reduce_retracing}). Unknown names are silently ignored — they may belong to a future TF version we don't model yet.
+		 */
+		private void markParamExists(String paramName) {
+			if (paramName.equals(FUNC))
+				this.funcParamExists = true;
+			else if (paramName.equals(INPUT_SIGNATURE))
+				this.inputSignatureParamExists = true;
+			else if (paramName.equals(AUTOGRAPH))
+				this.autoGraphParamExists = true;
+			else if (paramName.equals(JIT_COMPILE) || paramName.equals(EXPERIMENTAL_COMPILE))
+				this.jitCompileParamExists = true;
+			else if (paramName.equals(REDUCE_RETRACING) || paramName.equals(EXPERIMENTAL_RELAX_SHAPES))
+				this.reduceRetracingParamExists = true;
+			else if (paramName.equals(EXPERIMENTAL_IMPLEMENTS))
+				this.experimentalImplementsParamExists = true;
+			else if (paramName.equals(EXPERIMENTAL_AUTOGRAPH_OPTIONS))
+				this.experimentalAutographOptionsParamExists = true;
+			else if (paramName.equals(EXPERIMENTAL_FOLLOW_TYPE_HINTS))
+				this.experimentaFollowTypeHintsParamExists = true;
 		}
 
 		/**

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testMixedPositionalAndKeyword/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testMixedPositionalAndKeyword/in/A.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+
+# Positional `func=None` plus keyword `autograph=False`.
+# Tests #108: a single decorator that mixes positional and keyword args should
+# have BOTH parameter-existence flags set (`func` from position 0,
+# `autograph` from the keyword).
+@tf.function(None, autograph=False)
+def func(x):
+    return x
+
+
+if __name__ == "__main__":
+    number = tf.constant([1.0, 1.0])
+    func(number)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testPositionalParameterAutograph/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testPositionalParameterAutograph/in/A.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+# Three positional args: `func=None`, `input_signature=None`, `autograph=False`.
+# Equivalent to `@tf.function(autograph=False)` but written with positional args.
+# Tests #108: positional `autograph` (position 2) should be detected.
+@tf.function(None, None, False)
+def func(x):
+    return x
+
+
+if __name__ == "__main__":
+    number = tf.constant([1.0, 1.0])
+    func(number)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testPositionalParameterInputSignature/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testPositionalParameterInputSignature/in/A.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+# Positional `func=None` (position 0) followed by positional `input_signature` (position 1).
+# Equivalent to `@tf.function(input_signature=(...,))` but written with positional args.
+# Tests #108: positional args to @tf.function should be detected.
+@tf.function(None, (tf.TensorSpec(shape=[None], dtype=tf.float32),))
+def func(x):
+    return x
+
+
+if __name__ == "__main__":
+    number = tf.constant([1.0, 1.0])
+    func(number)

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -833,8 +833,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #108. Positional `autograph` argument at position 2: `@tf.function(None, None, False)`. We expect
-	 * `funcParamExists`, `inputSignatureParamExists`, and `autoGraphParamExists` to all be true.
+	 * Test for #108. Positional `autograph` argument at position 2: `@tf.function(None, None, False)`. We expect `funcParamExists`,
+	 * `inputSignatureParamExists`, and `autoGraphParamExists` to all be true.
 	 */
 	@Test
 	public void testPositionalParameterAutograph() throws Exception {
@@ -857,9 +857,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #108. Mixed positional + keyword in the same decorator: `@tf.function(None, autograph=False)`. The position-0 `func`
-	 * slot is occupied positionally; `autograph` is bound by keyword. We expect both `funcParamExists` and `autoGraphParamExists` true,
-	 * and notably `inputSignatureParamExists` false (no slot occupied at position 1, no `input_signature` keyword).
+	 * Test for #108. Mixed positional + keyword in the same decorator: `@tf.function(None, autograph=False)`. The position-0 `func` slot is
+	 * occupied positionally; `autograph` is bound by keyword. We expect both `funcParamExists` and `autoGraphParamExists` true, and notably
+	 * `inputSignatureParamExists` false (no slot occupied at position 1, no `input_signature` keyword).
 	 */
 	@Test
 	public void testMixedPositionalAndKeyword() throws Exception {

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -808,6 +808,80 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Test for #108. Positional `input_signature` argument: `@tf.function(None, (tf.TensorSpec(...),))` passes `func=None` and
+	 * `input_signature=(...)` positionally. We expect both `funcParamExists` and `inputSignatureParamExists` to be true (the position-0
+	 * `func` slot is occupied even though its value is `None`; presence of the positional slot is what's detected, not its value).
+	 */
+	@Test
+	public void testPositionalParameterInputSignature() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertNotNull(functions);
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+		assertNotNull(function);
+
+		assertTrue(function.isHybrid());
+
+		Function.HybridizationParameters args = function.getHybridizationParameters();
+		assertNotNull(args);
+
+		assertTrue(args.isFuncParamExists());
+		assertTrue(args.isInputSignatureParamExists());
+		assertTrue(!args.isAutoGraphParamExists() && !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists()
+				&& !args.isExperimentalImplementsParamExists() && !args.isExperimentalAutographOptParamExists()
+				&& !args.isExperimentalFollowTypeHintsParamExists());
+	}
+
+	/**
+	 * Test for #108. Positional `autograph` argument at position 2: `@tf.function(None, None, False)`. We expect
+	 * `funcParamExists`, `inputSignatureParamExists`, and `autoGraphParamExists` to all be true.
+	 */
+	@Test
+	public void testPositionalParameterAutograph() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertNotNull(functions);
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+		assertNotNull(function);
+
+		assertTrue(function.isHybrid());
+
+		Function.HybridizationParameters args = function.getHybridizationParameters();
+		assertNotNull(args);
+
+		assertTrue(args.isFuncParamExists());
+		assertTrue(args.isInputSignatureParamExists());
+		assertTrue(args.isAutoGraphParamExists());
+		assertTrue(!args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
+				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+	}
+
+	/**
+	 * Test for #108. Mixed positional + keyword in the same decorator: `@tf.function(None, autograph=False)`. The position-0 `func`
+	 * slot is occupied positionally; `autograph` is bound by keyword. We expect both `funcParamExists` and `autoGraphParamExists` true,
+	 * and notably `inputSignatureParamExists` false (no slot occupied at position 1, no `input_signature` keyword).
+	 */
+	@Test
+	public void testMixedPositionalAndKeyword() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertNotNull(functions);
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+		assertNotNull(function);
+
+		assertTrue(function.isHybrid());
+
+		Function.HybridizationParameters args = function.getHybridizationParameters();
+		assertNotNull(args);
+
+		assertTrue(args.isFuncParamExists());
+		assertTrue(args.isAutoGraphParamExists());
+		assertTrue(!args.isInputSignatureParamExists() && !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists()
+				&& !args.isExperimentalImplementsParamExists() && !args.isExperimentalAutographOptParamExists()
+				&& !args.isExperimentalFollowTypeHintsParamExists());
+	}
+
+	/**
 	 * Test for #30. This simply tests whether we can parse the tf.function argument experimental_autograph_options
 	 */
 	@Test


### PR DESCRIPTION
## Summary

Implements #108 — `@tf.function` invoked with positional arguments was previously invisible to `HybridizationParameters.computeParameterExistance` (which only iterated keyword args). This PR adds positional-arg parsing by hardcoding `tf.function`'s parameter order and mapping `args[i]` to that array's i-th name.

Closes #108 and #125. Supersedes the stale #134 (31 files / 624 lines via PyDev `Definition` machinery; this is 5 files / ~170 lines via a hardcoded position table).

## Why Hardcode the Positional Order?

The alternative is what #134 attempted: walk PyDev's `Definition` machinery to look up `tf.function`'s formal parameter names from the imported library at analysis time. That approach has two problems:

1. **PyDev version sensitivity** — the `Definition` API has shifted across PyDev releases.
2. **TF stub variants** — `tf.function`'s formal parameter list lives in TensorFlow's typeshed stubs (or in TF source if no stubs); presence and accuracy varies by environment.

The hardcoded approach has one weakness: a future TF version that shuffles parameter order would silently break this matcher. Mitigation: the existing keyword matcher *also* hardcodes the parameter set (the `static final String FUNC = "func"` etc. constants), so this PR doesn't introduce a *new* class of brittleness — it inherits the same constraint already imposed by the keyword path. The `[2.0, 2.11]` TF range we support has stable parameter order.

## Changes

- `Function.java`:
  - New `TF_FUNCTION_POSITIONAL_PARAMS` array mapping position → parameter name.
  - `computeParameterExistance` now iterates positional args first, then keyword args. Both paths route through a new `markParamExists(String)` helper.
  - The previous keyword-only `if/else if` ladder (33 lines) collapses into a single `markParamExists` call.

- 3 new fixtures in `resources/HybridizeFunction/`:
  - `testPositionalParameterInputSignature`: `@tf.function(None, (tf.TensorSpec(...),))`.
  - `testPositionalParameterAutograph`: `@tf.function(None, None, False)`.
  - `testMixedPositionalAndKeyword`: `@tf.function(None, autograph=False)`.

- 3 new test methods in `HybridizeFunctionRefactoringTest.java` covering each fixture, asserting the exact set of `*ParamExists` flags expected.

## Marked Draft

Filed during off-hours as solo work (per user direction). Marked draft so user can:
1. Verify the design choice (hardcoded positional table vs PR #134's `Definition`-based approach).
2. Decide whether more positional fixtures are wanted (e.g., positions 4-9 cover deprecated/experimental params; not exercised by the 3 fixtures above).
3. Confirm test naming (`testPositionalParameterX` vs PR #134's `testPositionalParametersX`).

## Test Plan

- [ ] CI: build + Tycho-Surefire on the new fixtures
- [ ] Confirm pre-existing keyword-arg tests (`testComputeParameters` family) still pass — the helper refactor must preserve their behaviour
- [ ] Confirm tests with no decorator args still pass (`@tf.function` and `@tf.function()` cases)
