### PR TITLE
Disable CodeQL `actions/unpinned-tag` rule + drop `security-and-quality` suite

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,17 +1,25 @@
-# CodeQL configuration for the `actions` analysis.
+# CodeQL configuration.
 #
-# Disables the `actions/unpinned-tag` rule (which flags `uses: foo/bar@v6`-style
-# tag references on non-GitHub-owned actions, asking for a SHA pin). For this
-# repo the rule fires as a build-reproducibility concern more than a
-# supply-chain-attack concern, and version-tag pinning is an acceptable
-# trade-off — see the parallel change at ponder-lab/ML#231.
-# Re-enable by removing the `actions/unpinned-tag` exclusion below.
+# 1. Drops the `security-and-quality` query suite (kept only `security-extended`).
+#    Running both suites on the `actions` language can produce >5000 results —
+#    over CodeQL's 5000-result-per-analysis storage limit, with the overflow
+#    silently dropped. `security-and-quality` adds code-quality lint queries on
+#    top of `security-extended`'s already-broad security set; the marginal
+#    signal for our codebase is mostly noise on YAML workflows. Keeping just
+#    `security-extended` brings the result count under the cap while preserving
+#    every security-relevant query. (Same change as ponder-lab/ML#231.)
+#
+# 2. Disables the `actions/unpinned-tag` rule (which flags `uses: foo/bar@v6`-style
+#    tag references on non-GitHub-owned actions, asking for a SHA pin). For this
+#    repo the rule fires as a build-reproducibility concern more than a
+#    supply-chain-attack concern, and version-tag pinning is an acceptable
+#    trade-off — mirrors the parallel change at ponder-lab/ML#231.
+#    Re-enable by removing the `actions/unpinned-tag` exclusion below.
 
 name: "ponder-lab/Hybridize-Functions-Refactoring CodeQL config"
 
 queries:
   - uses: security-extended
-  - uses: security-and-quality
 
 query-filters:
   - exclude:

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,18 @@
+# CodeQL configuration for the `actions` analysis.
+#
+# Disables the `actions/unpinned-tag` rule (which flags `uses: foo/bar@v6`-style
+# tag references on non-GitHub-owned actions, asking for a SHA pin). For this
+# repo the rule fires as a build-reproducibility concern more than a
+# supply-chain-attack concern, and version-tag pinning is an acceptable
+# trade-off — see the parallel change at ponder-lab/ML#231.
+# Re-enable by removing the `actions/unpinned-tag` exclusion below.
+
+name: "ponder-lab/Hybridize-Functions-Refactoring CodeQL config"
+
+queries:
+  - uses: security-extended
+  - uses: security-and-quality
+
+query-filters:
+  - exclude:
+      id: actions/unpinned-tag

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          queries: security-extended,security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - if: matrix.language == 'java-kotlin'
         name: Install with Maven


### PR DESCRIPTION
## Summary

Mirrors ponder-lab/ML#231. Two coordinated changes to the CodeQL config:

### 1. Disable `actions/unpinned-tag` rule

The rule flags third-party action references like `uses: codecov/codecov-action@v6` and asks for a SHA pin. For this repo the rule fires as a build-reproducibility concern more than a supply-chain-attack one — CI doesn't push to PyPI, doesn't sign release artifacts, and the threat model that would justify SHA-pinning every third-party action doesn't apply. Version-tag pinning is the accepted trade-off.

### 2. Drop `security-and-quality` query suite

Running both `security-extended` and `security-and-quality` on the `actions` language can produce >5000 results — over CodeQL's 5000-result-per-analysis storage limit, with overflow silently dropped (visible as the "Only 5000 were stored" status warning).

`security-and-quality` adds code-quality lint queries on top of `security-extended`'s already-broad security set; the marginal signal for this codebase is mostly noise on YAML workflows. Keeping just `security-extended` retains every security-relevant query while staying under the cap.

## What This Does

1. Adds `.github/codeql/codeql-config.yml` with `query-filters` excluding `actions/unpinned-tag` and using only `security-extended`.
2. Points the workflow's `init` step at the config file instead of the inline `queries:` list.

## Reverting

If supply-chain hardening becomes a concern (e.g., the project gains release-deploy gates) or if missed lint warnings prove costly, edit `codeql-config.yml` to re-add the rule / suite.

## Test Plan

- [x] CodeQL workflow YAML is syntactically valid.
- [x] Config file `query-filters` syntax matches CodeQL docs.
- [ ] Verify on the next CodeQL run that result count is under 5000 and the `actions/unpinned-tag` rule no longer fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)