### PR TITLE
Trim `python-tooling` Dependabot patterns to current reality

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,13 +32,13 @@ updates:
           - "patch"
 
   # Python tooling for the test/format requirements. Grouped patch+minor;
-  # majors land as their own PRs. `patterns:` is explicit (rather than
-  # implicit-catch-all) so the group's scope stays scoped to actual tooling
-  # even if a future `directories:` expansion broadens what the pip updater
-  # sees: without `patterns:`, the group would bundle every pip dep under
-  # the updater's root, which would include test-fixture runtime deps
-  # (matplotlib, numpy, etc.) and produce grouped PRs that don't match the
-  # "tooling" framing.
+  # majors land as their own PRs. `patterns:` lists the tooling deps
+  # actually present in `/requirements.txt` today; extend it when adding
+  # new tooling. Keeping the list tight (instead of anticipatory globs
+  # like `pytest*`) prevents accidental capture of test-fixture runtime
+  # deps if a future `directories:` expansion ever broadens what the pip
+  # updater sees — `pytest*` would match the `pytest` line in a fixture's
+  # `requirements.txt`, for instance.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -49,12 +49,6 @@ updates:
         applies-to: version-updates
         patterns:
           - "black"
-          - "pytest*"
-          - "mypy"
-          - "ruff"
-          - "flake8*"
-          - "coverage*"
-          - "pre-commit"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/ponder-lab/Hybridize-Functions-Refactoring/pull/446. That PR introduced a `python-tooling` Dependabot group with anticipatory `patterns:` (`pytest*`, `mypy`, `ruff`, `flake8*`, `coverage*`, `pre-commit`) for tooling deps that aren't actually in `/requirements.txt` yet. Copilot review flagged that `pytest*` would match a fixture-side `pytest` requirement under `edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testIsHybridMultipleAttributes/in/requirements.txt` if a future `directories:` expansion broadened the pip updater's scope — undermining the very goal of keeping fixtures out of the tooling group.

## What This Does

Trims `patterns:` to only the tooling deps actually present in `/requirements.txt` today (just `black`). The comment block now says "extend when adding new tooling" so future tooling additions go alongside the manifest change rather than ahead of it.

## On the "fixture deps competing for slots" concern

The sibling Copilot thread on PR 446 worried about fixture deps consuming the 3-PR slot limit. Empirical check against this repo's history: every Dependabot pip PR ever opened on this repo has been `black` (12 of them, going back to 2024) — Dependabot's `directory: "/"` only sees `/requirements.txt`, not fixture directories. So that concern doesn't materialize against current behavior. If the pip ecosystem's behavior changes or `directories:` is expanded later, the tight pattern list here will already be the right defense.

## Test Plan

- [x] `dependabot.yml` syntax valid (no schema errors).
- [ ] Verify on the next weekly Dependabot run that the `python-tooling` group is still honored for `black` bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)