### PR TITLE
Address CodeQL alerts: lost exception in log, missing workflow permissions

### DIFF
--- a/.github/workflows/cff-validator.yml
+++ b/.github/workflows/cff-validator.yml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch:
 
 name: CITATION.cff
+
+permissions:
+  contents: read
+
 jobs:
   Validate-CITATION-cff:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,6 +25,9 @@ concurrency:
   # fix as ponder-lab/ML#217.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')) }}
+permissions:
+  contents: read
+  packages: read
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -446,7 +446,7 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 							LOG.info(String.format(
 									"Can't determine FQN of function call expression: %s in selection: %s, module: %s, file: %s, and project: %s.",
-									NodeUtils.getFullRepresentationString(call), selectedText, moduleName, file, project, e));
+									NodeUtils.getFullRepresentationString(call), selectedText, moduleName, file, project), e);
 						}
 
 						if (fqn != null)


### PR DESCRIPTION
## Summary

- Fix lost exception in `EvaluateHybridizeFunctionRefactoringHandler#visitCall` log call — passes `e` as the throwable argument to `LOG.info` instead of as a 6th `String.format` argument the format string had no slot for. Resolves [code-scanning alert #21](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/21).
- Add explicit `permissions:` blocks to `maven.yml` (`contents: read`, `packages: read` — the latter is required because the build authenticates to GitHub Packages to fetch Ariadne) and `cff-validator.yml` (`contents: read`). Resolves [#26](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/26) and [#2](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/2), matching the direction of already-fixed [#1](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/1) and [#23](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/23).

## Test Plan

- [ ] CI is green (Maven build + spotless + Black).
- [ ] CodeQL re-scan confirms #21, #26, #2 closed.