### PR TITLE
Address CodeQL `non-short-circuit-evaluation` alerts in tests

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -802,7 +802,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && args.isInputSignatureParamExists() & !args.isAutoGraphParamExists()
+		assertTrue(!args.isFuncParamExists() && args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
 				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
 				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
 	}
@@ -898,7 +898,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() & !args.isAutoGraphParamExists()
+		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
 				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
 				&& args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
 	}
@@ -919,7 +919,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() & !args.isAutoGraphParamExists()
+		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
 				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
 				&& !args.isExperimentalAutographOptParamExists() && args.isExperimentalFollowTypeHintsParamExists());
 	}
@@ -940,7 +940,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() & !args.isAutoGraphParamExists()
+		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
 				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && args.isExperimentalImplementsParamExists()
 				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
 	}
@@ -961,7 +961,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() & !args.isAutoGraphParamExists()
+		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
 				&& args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
 				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
 	}
@@ -980,7 +980,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() & !args.isAutoGraphParamExists()
+		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
 				&& !args.isJitCompileParamExists() && args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
 				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
 	}
@@ -1001,7 +1001,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() & args.isAutoGraphParamExists()
+		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && args.isAutoGraphParamExists()
 				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
 				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
 	}
@@ -1022,7 +1022,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() & !args.isAutoGraphParamExists()
+		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
 				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
 				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
 	}
@@ -1043,7 +1043,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && args.isInputSignatureParamExists() & args.isAutoGraphParamExists()
+		assertTrue(!args.isFuncParamExists() && args.isInputSignatureParamExists() && args.isAutoGraphParamExists()
 				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
 				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
 	}
@@ -1091,7 +1091,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		// like `tf.function`. But it also has a tf.function decorator, therefore args should not be Null.
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() & args.isAutoGraphParamExists()
+		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && args.isAutoGraphParamExists()
 				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
 				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
 
@@ -1123,7 +1123,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() & !args.isAutoGraphParamExists()
+		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
 				&& args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
 				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
 	}


### PR DESCRIPTION
## Summary

Eleven `assertTrue(...)` expressions in `HybridizeFunctionRefactoringTest` mixed `&&` with a single bitwise `&` mid-expression (`isInputSignatureParamExists() & ...AutoGraphParamExists()`). The operands are pure boolean getters with no side effects, so behavior is unchanged, but CodeQL flags the inconsistency. Switch the bare `&` to `&&` to match the surrounding operators.

Resolves [#10](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/10), [#11](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/11), [#12](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/12), [#13](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/13), [#14](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/14), [#15](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/15), [#16](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/16), [#17](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/17), [#18](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/18), [#19](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/19), [#20](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/20).

## Test Plan

- [ ] Existing test suite passes unchanged (no behavior change since operands are side-effect-free).
- [ ] CodeQL re-scan confirms the 11 alerts closed.