### PR TITLE
Suppress dependabot PRs on test-fixture pip manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,39 @@ updates:
       # safely propose. Drop the ignore once the test corpus migrates.
       - dependency-name: "tensorflow"
 
+  # Test scaffolding pip manifests:
+  # - `edu.cuny.hunter.hybridize.tests/requirements.txt` (CI install set)
+  # - `edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/*/in/requirements.txt`
+  #   (per-fixture pins so the analyzer resolves the same TF surface the
+  #   test was authored against)
+  #
+  # The pin is intentional: the refactoring plug-in does not import or
+  # execute these libraries at runtime — they are inputs to Ariadne's
+  # static analysis, and the static call graphs depend on the exact
+  # 2.9.3 API surface. We want NO dependabot PRs (version-update OR
+  # security-update) against these manifests:
+  #   - `open-pull-requests-limit: 0` suppresses version-update PRs.
+  #   - `ignore: dependency-name: "*"` suppresses security-update PRs
+  #     (per github docs, ignore conditions also block security-update
+  #     PR creation when no `update-types` filter is set).
+  #
+  # Without this block, security-update PRs were being opened against
+  # individual fixture manifests (#459 was the first such PR) because
+  # dependabot security updates auto-discover ALL manifests in the repo,
+  # but ignore rules from other blocks only apply to their declared
+  # `directory:`. Existing security alerts on these manifests are
+  # bulk-dismissed with reason `not_used`; this config prevents new
+  # ones from spawning PRs.
+  - package-ecosystem: "pip"
+    directories:
+      - "/edu.cuny.hunter.hybridize.tests"
+      - "/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/**"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+
   # GitHub Actions versions in `.github/workflows/*.yml`. These are
   # security-relevant (action supply-chain) and shift slowly; check
   # weekly, no grouping (each action is independent).


### PR DESCRIPTION
## Summary

The existing `ignore: tensorflow` rule was scoped to `directory: "/"`, which only covers `/requirements.txt` (which contains `black` only). Dependabot security updates auto-discover all manifests in the repo, but ignore rules from other blocks only apply to their declared directory — so security-update PRs were opening against per-fixture manifests at `edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/*/in/requirements.txt`. #459 (Bump tensorflow 2.9.3 → 2.12.1 in one fixture) was the first such PR.

Add a separate pip block scoped via `directories:` (plural, with `**` glob) covering the test top-level and all fixture manifests. Disable both PR types:

- `open-pull-requests-limit: 0` suppresses version-update PRs.
- `ignore: dependency-name: "*"` suppresses security-update PRs (per [GitHub docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore), ignore conditions also block security-update PR creation when no `update-types` filter is set).

The fixture pins are intentional: the refactoring plug-in does not import or execute these libraries at runtime; they are inputs to Ariadne's static analysis and the call graphs depend on the exact 2.9.3 API surface. The existing security alerts on these manifests were bulk-dismissed today with reason `not_used` (2728 → 0 open); this config prevents new ones from spawning PRs.

## Followup

Once this lands, #459 should be closed (it's not safe to merge — bumping to TF 2.12.x would invalidate the analyzer's assumptions about the 2.9 API surface).

## Test Plan

- [ ] Dependabot validates `dependabot.yml` (visible at the next scheduled run / on push to default branch).
- [ ] No new TF version-update or security-update PRs against fixture manifests after this lands.