### PR TITLE
Rename `inferTensorTensorParameters` to `inferTensorParameters`

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1566,7 +1566,7 @@ public class Function {
 	/**
 	 * Infer which parameters are likely tensor parameters.
 	 */
-	public void inferTensorTensorParameters(TensorTypeAnalysis tensorAnalysis, CallGraph callGraph,
+	public void inferTensorParameters(TensorTypeAnalysis tensorAnalysis, CallGraph callGraph,
 			PythonSSAPropagationCallGraphBuilder builder, IProgressMonitor monitor) throws Exception {
 		monitor.beginTask("Analyzing whether function has a tensor parameter.", IProgressMonitor.UNKNOWN);
 

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1566,8 +1566,8 @@ public class Function {
 	/**
 	 * Infer which parameters are likely tensor parameters.
 	 */
-	public void inferTensorParameters(TensorTypeAnalysis tensorAnalysis, CallGraph callGraph,
-			PythonSSAPropagationCallGraphBuilder builder, IProgressMonitor monitor) throws Exception {
+	public void inferTensorParameters(TensorTypeAnalysis tensorAnalysis, CallGraph callGraph, PythonSSAPropagationCallGraphBuilder builder,
+			IProgressMonitor monitor) throws Exception {
 		monitor.beginTask("Analyzing whether function has a tensor parameter.", IProgressMonitor.UNKNOWN);
 
 		Set<CGNode> nodes = this.getNodes(callGraph);

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
@@ -335,7 +335,7 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 				func.computeHybridization(subMonitor.split(IProgressMonitor.UNKNOWN));
 
 				try {
-					func.inferTensorTensorParameters(analysis, callGraph, builder, subMonitor.split(IProgressMonitor.UNKNOWN));
+					func.inferTensorParameters(analysis, callGraph, builder, subMonitor.split(IProgressMonitor.UNKNOWN));
 				} catch (CantInferTensorParametersException e) {
 					LOG.warn("Unable to compute whether " + func + " has tensor parameters.", e);
 					func.addFailure(PreconditionFailure.UNDETERMINABLE_TENSOR_PARAMETER,


### PR DESCRIPTION
## Summary

Drop the accidentally-duplicated `Tensor` in `Function.inferTensorTensorParameters`. The Javadoc summary ("Infer which parameters are likely tensor parameters") already reflects the intended name.

Two occurrences on `main`:

- `Function.java:1569` (declaration)
- `HybridizeFunctionRefactoringProcessor.java:338` (only caller)

Internal-only rename — the method is exported via OSGi (`edu.cuny.hunter.hybridize.core.analysis`) but the only consumers are the sibling bundles in this reactor (`ui`, `eval`, `tests`), so no deprecation shim is needed.

## Test Plan

- [ ] Tycho build is green
- [ ] No remaining textual references to `inferTensorTensorParameters`

🤖 Generated with [Claude Code](https://claude.com/claude-code)