### PR TITLE
Use static `TRUE`/`FALSE` instead of `Boolean.TRUE`/`Boolean.FALSE`

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1612,7 +1612,7 @@ public class Function {
 							Set<Attribute> allAttributes = getAllAttributes(node);
 
 							if (this.attributesHaveTensorTypeHints(allAttributes, monitor.slice(IProgressMonitor.UNKNOWN))) {
-								this.hasTensorParameter = Boolean.TRUE;
+								this.hasTensorParameter = TRUE;
 								LOG.info(this + " likely has a tensor parameter: " + paramName + " due to a type hint.");
 								monitor.worked(1);
 								this.addInfo(TYPE_INFERENCING, "Used a type hint to infer tensor type for parameter: " + paramName + ".");
@@ -1627,7 +1627,7 @@ public class Function {
 						// pointer key, then we know it's a tensor if the TensorType is not null.
 						if (this.tensorAnalysisIncludesParameter(tensorAnalysis, paramExpr, paramName,
 								monitor.slice(IProgressMonitor.UNKNOWN))) {
-							this.hasTensorParameter = Boolean.TRUE;
+							this.hasTensorParameter = TRUE;
 							LOG.info(this + " likely has a tensor parameter: " + paramName + " due to tensor analysis.");
 							monitor.worked(1);
 							continue; // next parameter.
@@ -1636,7 +1636,7 @@ public class Function {
 						// Check for containers of tensors.
 						if (this.tensorAnalysisIncludesParameterContainer(tensorAnalysis, paramInx, callGraph, builder,
 								monitor.slice(IProgressMonitor.UNKNOWN))) {
-							this.hasTensorParameter = Boolean.TRUE;
+							this.hasTensorParameter = TRUE;
 							LOG.info(this + " likely has a tensor-like parameter: " + paramName + " due to tensor analysis.");
 						}
 					}
@@ -1651,7 +1651,7 @@ public class Function {
 				if (this.hasTensorParameter == null && actualParams.length > 0 && !onlySelfParam)
 					// check a special case where we consider context.
 					if (this.getUseSpeculativeAnalysis() && this.hasTensorContext()) {
-						this.hasTensorParameter = Boolean.TRUE;
+						this.hasTensorParameter = TRUE;
 						LOG.info(this + " likely has a tensor parameter due to context.");
 						this.addInfo(SPECULATIVE_ANALYSIS, "Used function context to infer parameter tensor types.");
 					} else if (nodes.isEmpty())
@@ -1662,7 +1662,7 @@ public class Function {
 		} // end params != null.
 
 		if (this.hasTensorParameter == null) {
-			this.hasTensorParameter = Boolean.FALSE;
+			this.hasTensorParameter = FALSE;
 			LOG.info(this + " does not likely have a tensor parameter.");
 		}
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -438,7 +438,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		FileUtils.IN_TESTS = true;
 		PydevTestUtils.setTestPlatformStateLocation();
 		AbstractAdditionalDependencyInfo.TESTING = true;
-		InterpreterGeneralPreferences.FORCE_USE_TYPESHED = Boolean.TRUE;
+		InterpreterGeneralPreferences.FORCE_USE_TYPESHED = TRUE;
 		PythonNature.IN_TESTS = true;
 		PythonModuleManager.setTesting(true);
 
@@ -453,7 +453,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 			for (String t : toAsk)
 				if (s.contains(StringUtils.replaceAllSlashes(t.toLowerCase())))
 					l.add(t);
-			return Boolean.TRUE;
+			return TRUE;
 		};
 
 		// System Python paths.

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -17,6 +17,7 @@ import static edu.cuny.hunter.hybridize.core.analysis.Refactoring.CONVERT_EAGER_
 import static edu.cuny.hunter.hybridize.core.analysis.Refactoring.OPTIMIZE_HYBRID_FUNCTION;
 import static edu.cuny.hunter.hybridize.core.analysis.Transformation.CONVERT_TO_EAGER;
 import static edu.cuny.hunter.hybridize.core.analysis.Transformation.CONVERT_TO_HYBRID;
+import static java.lang.Boolean.TRUE;
 import static java.lang.Integer.MAX_VALUE;
 import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
 import static java.util.Collections.singleton;


### PR DESCRIPTION
## Summary

Per the review note on #463 (`Function.java:1649` — `Boolean.TRUE` should be statically imported), sweep the qualified references in the two files that still had them.

- `Function.java`: the file already had `import static java.lang.Boolean.{TRUE,FALSE}` (lines 18 and 19), but five qualified references slipped through. Swapped.
- `HybridizeFunctionRefactoringTest.java`: added `import static java.lang.Boolean.TRUE`; two qualified references swapped.
- `HybridizeFunctionRefactoringProcessor.java`: already clean (had the import, no qualified usage).

No behavioural change. House-style sweep only.

## Test Plan

- [ ] Tycho build is green
- [ ] No remaining `Boolean.TRUE`/`Boolean.FALSE` in the touched source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)