### PR TITLE
Bump Ariadne to 0.43.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Eclipse PDE refactoring plug-ins (Tycho-built) that automate hybridization of Python TensorFlow functions — i.e., deciding when to add/remove `@tf.function` and applying the transformation. Runs inside Eclipse on top of PyDev and uses WALA/Ariadne for static analysis of Python.
 
-The tool is **not compatible with stock PyDev**: it depends on the ponder-lab fork (`pydev_9_3` branch). See `hybridize.target` for the active target platform (Eclipse 4.25, PyDev 9.3.x, WALA 1.6, Ariadne via `maven.pkg.github.com/ponder-lab/ML`).
+The tool is **not compatible with stock PyDev**: it depends on the ponder-lab fork (`pydev_9_3` branch). See `hybridize.target` for the active target platform (Eclipse 4.25, PyDev 9.3.x, WALA 1.7, Ariadne via `maven.pkg.github.com/ponder-lab/ML`).
 
 ## Build / test commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ The Eclipse-side dependency is shallow. The project uses exactly two classes fro
 - `com.ibm.wala.ide.classloader.EclipseSourceDirectoryTreeModule`, which the project already wraps with a local copy because the upstream class's `rootIPath` field is private.
 - `com.ibm.wala.ide.util.ProgressMonitorDelegate`, an Eclipse-to-WALA `IProgressMonitor` adapter.
 
-**Implication for Ariadne bumps:** when an Ariadne release advances its WALA dependency (e.g., 0.42.0 to 0.43.0 bumped WALA `1.6.12` to `1.7.1`), `ponder-lab/WALA` must publish a matching branch (e.g., `v1.7`) carrying p2 artifacts for that WALA version. Otherwise the Tycho build will compile (Maven Central provides the framework jars) but fail at test runtime with `AbstractMethodError`, because the older `com.ibm.wala.ide` bundle was compiled against an older `AstTranslator` API surface. Bumping Ariadne is therefore a two-step coordination: publish the new WALA p2 branch first, then bump `hybridize.target`.
+**Implication for Ariadne bumps:** when an Ariadne release advances its WALA dependency (e.g., 0.42.0 to 0.43.0 bumped WALA `1.6.12` to `1.7.1`), `ponder-lab/WALA` must publish a matching branch (e.g., `v1.7`) carrying p2 artifacts for that WALA version. Otherwise the Tycho build will compile (Maven Central provides the framework jars) but fail at test runtime with `AbstractMethodError`, because the older `com.ibm.wala.ide` bundle was compiled against an older `AstTranslator` API surface. Bumping Ariadne is therefore a two-step coordination: publish the new WALA p2 branch first, then bump `hybridize.target`. The mechanics of cutting that branch live in two wiki pages — [Updating WALA][updating-wala] on this repo's wiki, which points at [Cut a New Release][cut-wala-release] on the `ponder-lab/WALA` wiki for the actual release procedure.
 
 Switching to Maven Central is not a drop-in escape: `com.ibm.wala.ide` is **not** on Maven Central (Maven Central carries `com.ibm.wala.core`, `com.ibm.wala.cast`, `com.ibm.wala.util`, etc., but not the Eclipse-specific IDE bundle), and upstream `wala/WALA` does not publish p2 binaries itself (its `com.ibm.wala-repository/` directory contains only `category.xml` Tycho metadata, not built artifacts). Inlining `ProgressMonitorDelegate` would be trivial, but `EclipseSourceDirectoryTreeModule` cascades into `EclipseProjectPath`, `EclipseSourceFileModule`, and further `com.ibm.wala.ide.*` types — effectively forcing Hybridize to maintain its own fork of `com.ibm.wala.ide`, which is strictly worse than the current `ponder-lab/WALA` arrangement. The practical path for each Ariadne bump that changes WALA versions is to publish the matching `ponder-lab/WALA` branch first.
 
@@ -81,6 +81,8 @@ You can run the evaluator in several different ways, including as a command or a
 
 [wiki]: https://github.com/ponder-lab/Hybridize-Functions-Refactoring/wiki
 [evaluator wiki]: https://github.com/ponder-lab/Hybridize-Functions-Refactoring/wiki/Running-the-Evaluator
+[updating-wala]: https://github.com/ponder-lab/Hybridize-Functions-Refactoring/wiki/Updating-WALA
+[cut-wala-release]: https://github.com/ponder-lab/WALA/wiki/Cut-a-new-release
 [PyDev]: https://github.com/ponder-lab/Pydev/tree/pydev_9_3
 [Common Eclipse Refactoring Framework]: https://github.com/ponder-lab/Common-Eclipse-Refactoring-Framework
 [Ariadne]: https://github.com/ponder-lab/ML

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The other projects should be obtained from the target definition. If, for any re
 
 1. [PyDev 9.3 branch][PyDev].
 1. [Ariadne ponder-lab fork][Ariadne]
-1. [WALA v1.6 branch][WALA]
+1. [WALA v1.7 branch][WALA]
 
 Having PyDev in your workspace in its own "working set" is helpful to visualize the structure of the project. Import it into your Eclipse workspace under a working set named "PyDev." PyDev is already structured as Eclipse projects; you can simply import it as an existing Eclipse project (select the "search for nested projects" option). You'll need to close the "Mylyn" projects that are imported; they won't build since Mylyn has been removed from Eclipse's standard distribution.
 
@@ -45,7 +45,7 @@ Dependency | Update Site
 --- | ---
 [Common Eclipse Refactoring Framework] | https://raw.githubusercontent.com/ponder-lab/Common-Eclipse-Java-Refactoring-Framework/master/edu.cuny.citytech.refactoring.common.updatesite
 [PyDev] | https://raw.githubusercontent.com/ponder-lab/Pydev/pydev_9_3/org.python.pydev.updatesite
-[WALA] | https://raw.githubusercontent.com/ponder-lab/WALA/v1.6/com.ibm.wala-repository
+[WALA] | https://raw.githubusercontent.com/ponder-lab/WALA/v1.7/com.ibm.wala-repository
 
 These update sites are also listed in the [target definition file]. Thus, you shouldn't need them unless you plan to make changes to them.
 
@@ -62,7 +62,7 @@ This whole pattern is consumer-side technical debt; the broader fix (thin-jar Ar
 
 ### Why WALA Comes From the `ponder-lab/WALA` p2 Update Site
 
-The core bundle `Require-Bundle`s `com.ibm.wala.ide`, the Eclipse-PDE-aware WALA bundle. That bundle ships only via p2 update sites; WALA's Maven Central artifacts cover the framework jars (`com.ibm.wala.core`, `com.ibm.wala.cast`, etc.) but not the Eclipse-specific IDE bundle. Upstream `wala/WALA` does not publish a p2 repository; the `ponder-lab/WALA` fork's `v1.6` branch is a downstream-maintained p2 service for Eclipse-plug-in consumers like this one.
+The core bundle `Require-Bundle`s `com.ibm.wala.ide`, the Eclipse-PDE-aware WALA bundle. That bundle ships only via p2 update sites; WALA's Maven Central artifacts cover the framework jars (`com.ibm.wala.core`, `com.ibm.wala.cast`, etc.) but not the Eclipse-specific IDE bundle. Upstream `wala/WALA` does not publish a p2 repository; the `ponder-lab/WALA` fork's `v1.7` branch is a downstream-maintained p2 service for Eclipse-plug-in consumers like this one.
 
 The Eclipse-side dependency is shallow. The project uses exactly two classes from `com.ibm.wala.ide.*`:
 
@@ -85,7 +85,7 @@ You can run the evaluator in several different ways, including as a command or a
 [Common Eclipse Refactoring Framework]: https://github.com/ponder-lab/Common-Eclipse-Refactoring-Framework
 [Ariadne]: https://github.com/ponder-lab/ML
 [Ariadne packages]: https://github.com/orgs/ponder-lab/packages?repo_name=ML
-[WALA]: https://github.com/ponder-lab/WALA/tree/v1.6
+[WALA]: https://github.com/ponder-lab/WALA/tree/v1.7
 [GitHub Packages Documentation]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-to-github-packages
 [target definition file]: https://github.com/ponder-lab/Hybridize-Functions-Refactoring/blob/02cbd028d09f063f3e4ecd048e2435262abdde64/hybridize.target
 [wala/ML#418]: https://github.com/wala/ML/issues/418

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Dependency | Update Site
 --- | ---
 [Common Eclipse Refactoring Framework] | https://raw.githubusercontent.com/ponder-lab/Common-Eclipse-Java-Refactoring-Framework/master/edu.cuny.citytech.refactoring.common.updatesite
 [PyDev] | https://raw.githubusercontent.com/ponder-lab/Pydev/pydev_9_3/org.python.pydev.updatesite
-[WALA] | https://raw.githubusercontent.com/ponder-lab/WALA/v1.6/com.ibm.wala-repository
+[WALA] | https://raw.githubusercontent.com/ponder-lab/WALA/v1.7/com.ibm.wala-repository
 
 ## Contributing
 

--- a/edu.cuny.hunter.hybridize.core/build.properties
+++ b/edu.cuny.hunter.hybridize.core/build.properties
@@ -9,7 +9,9 @@ bin.includes = META-INF/,\
                functools.xml,\
                tensorflow.xml,\
                numpy.xml,\
+               numpy_turtle.xml,\
                pytest.xml,\
                click.xml,\
-               abseil.xml
+               abseil.xml,\
+               turtles.xml
 jre.compilation.profile = JavaSE-25

--- a/edu.cuny.hunter.hybridize.core/numpy_turtle.xml
+++ b/edu.cuny.hunter.hybridize.core/numpy_turtle.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<!DOCTYPE summary-spec>
+<!-- Pandas model -->
+<summary-spec>
+  <classloader name="PythonLoader">
+    <class name="numpy" allocatable="true">
+      <method name="import" static="true" descriptor="()Lnumpy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+  </classloader>
+</summary-spec>

--- a/edu.cuny.hunter.hybridize.core/numpy_turtle.xml
+++ b/edu.cuny.hunter.hybridize.core/numpy_turtle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Pandas model -->
+<!-- NumPy turtle stubs (placeholder summaries for unmodeled NumPy ops). -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">

--- a/edu.cuny.hunter.hybridize.core/numpy_turtle.xml
+++ b/edu.cuny.hunter.hybridize.core/numpy_turtle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- NumPy turtle stubs (placeholder summaries for unmodeled NumPy ops). -->
+<!-- Pandas model -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
@@ -124,7 +124,7 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 		InterpreterGeneralPreferences.FORCE_USE_TYPESHED = TRUE;
 
 		// Have WALA dump the call graph if appropriate.
-		CAstCallGraphUtil.AVOID_DUMP = !this.dumpCallGraph;
+		CAstCallGraphUtil.AVOID_DUMP.set(!this.dumpCallGraph);
 	}
 
 	public HybridizeFunctionRefactoringProcessor(boolean alwaysCheckPythonSideEffects) {

--- a/edu.cuny.hunter.hybridize.core/tensorflow.xml
+++ b/edu.cuny.hunter.hybridize.core/tensorflow.xml
@@ -14,6 +14,39 @@
                 Often `LRoot` in synthetic models unless a specific class is needed.
   - fieldType : The type of the field itself (the type of the slot). Often `LRoot`.
 -->
+<!--
+  Allocation-class convention for <new> inside <method name="do"> bodies:
+
+  1. Object-typed API result with its own method surface (Estimator, Variable,
+     Optimizer, Model, Layer, Dataset, SparseTensor, RaggedTensor, ...): the
+     class itself (i.e., `Ltensorflow/.../Variable`, `Ltensorflow/.../SparseTensor`,
+     etc.). The class declares the result's API surface (.train, .minimize,
+     .batch, .indices, .values, etc.); virtual dispatch on the result resolves
+     through the class hierarchy. `Tensor` belongs to case (2) below —
+     tensor-producing functions allocate canonical Tensor; the `Tensor` class
+     is itself the substrate that case (2) names.
+
+  2. Function-typed API producing a tensor result (e.g., tf.math.sigmoid,
+     tf.math.add, tf.reshape, tf.math.argmax, tf.math.less, ...): canonical
+     `Ltensorflow/python/framework/ops/Tensor`. The function name is not a
+     method dispatcher — Tensor methods (.shape, .dtype, .numpy(), ...) are
+     declared on `Tensor`. Per-op alloc classes here would only duplicate the
+     function name without carrying any dispatchable members; ponder-lab/ML#219
+     migrated 66 such allocations to canonical `Tensor`.
+
+  3. Wrapper for callback storage + virtual dispatch (Estimator's `train`
+     class, future `Dataset.map`-style modeling): per-op class. The class
+     identity is load-bearing for the <getfield ... field="$callback" />
+     followed by <call type="virtual" arg0="..." /> invocation chain — the
+     virtual dispatch needs the alloc class to declare the invocable method.
+     Such allocations are structurally protected from migration: their `def`
+     is field-stored (via <putfield value="..."/>) rather than returned.
+
+  Background: wala/ML#459 (function-typed migration; ponder-lab/ML#219 was
+  the migration PR); Dolby et al., MAPL '18, *Ariadne: Analysis for Machine
+  Learning Programs* (the per-op alloc-class pattern's original API-modeling
+  rationale, Figures 7 and 8).
+-->
 <!-- spotless:on -->
 <summary-spec>
   <classloader name="PythonLoader">
@@ -71,6 +104,10 @@
         <putfield class="LRoot" field="image" fieldType="LRoot" ref="x" value="image" />
         <new def="io" class="Lobject" />
         <putfield class="LRoot" field="io" fieldType="LRoot" ref="x" value="io" />
+        <new def="strings" class="Lobject" />
+        <putfield class="LRoot" field="strings" fieldType="LRoot" ref="x" value="strings" />
+        <new def="as_string" class="Ltensorflow/strings/as_string" />
+        <putfield class="LRoot" field="as_string" fieldType="LRoot" ref="strings" value="as_string" />
         <putfield class="LRoot" field="mnist" fieldType="LRoot" ref="datasets" value="keras_mnist" />
         <new def="load_data" class="Ltensorflow/keras/datasets/mnist/load_data" />
         <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_mnist" value="load_data" />
@@ -78,6 +115,26 @@
         <putfield class="LRoot" field="cifar10" fieldType="LRoot" ref="datasets" value="keras_cifar10" />
         <new def="cifar10_load_data" class="Ltensorflow/keras/datasets/cifar10/load_data" />
         <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_cifar10" value="cifar10_load_data" />
+        <new def="keras_imdb" class="Lobject" />
+        <putfield class="LRoot" field="imdb" fieldType="LRoot" ref="datasets" value="keras_imdb" />
+        <new def="imdb_load_data" class="Ltensorflow/keras/datasets/imdb/load_data" />
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_imdb" value="imdb_load_data" />
+        <new def="keras_fashion_mnist" class="Lobject" />
+        <putfield class="LRoot" field="fashion_mnist" fieldType="LRoot" ref="datasets" value="keras_fashion_mnist" />
+        <new def="fashion_mnist_load_data" class="Ltensorflow/keras/datasets/fashion_mnist/load_data" />
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_fashion_mnist" value="fashion_mnist_load_data" />
+        <new def="keras_cifar100" class="Lobject" />
+        <putfield class="LRoot" field="cifar100" fieldType="LRoot" ref="datasets" value="keras_cifar100" />
+        <new def="cifar100_load_data" class="Ltensorflow/keras/datasets/cifar100/load_data" />
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_cifar100" value="cifar100_load_data" />
+        <new def="keras_reuters" class="Lobject" />
+        <putfield class="LRoot" field="reuters" fieldType="LRoot" ref="datasets" value="keras_reuters" />
+        <new def="reuters_load_data" class="Ltensorflow/keras/datasets/reuters/load_data" />
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_reuters" value="reuters_load_data" />
+        <new def="keras_boston_housing" class="Lobject" />
+        <putfield class="LRoot" field="boston_housing" fieldType="LRoot" ref="datasets" value="keras_boston_housing" />
+        <new def="boston_housing_load_data" class="Ltensorflow/keras/datasets/boston_housing/load_data" />
+        <putfield class="LRoot" field="load_data" fieldType="LRoot" ref="keras_boston_housing" value="boston_housing_load_data" />
         <new def="app" class="Lobject" />
         <putfield class="LRoot" field="app" fieldType="LRoot" ref="x" value="app" />
         <new def="run" class="Ltensorflow/app/run" />
@@ -180,6 +237,12 @@
         <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="x" value="argmax" />
         <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="math" value="argmax" />
         <putfield class="LRoot" field="argmax" fieldType="LRoot" ref="math_ops" value="argmax" />
+        <!-- Same aliasing for `tf.argmin` / `tf.math.argmin`. -->
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmin -->
+        <new def="argmin" class="Ltensorflow/math/argmin" />
+        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="x" value="argmin" />
+        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="math" value="argmin" />
+        <putfield class="LRoot" field="argmin" fieldType="LRoot" ref="math_ops" value="argmin" />
         <!-- Same aliasing for `tf.equal` / `tf.math.equal`. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/equal -->
         <new def="equal" class="Ltensorflow/math/equal" />
@@ -261,39 +324,32 @@
         <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="x" value="not_equal" />
         <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="math" value="not_equal" />
         <putfield class="LRoot" field="not_equal" fieldType="LRoot" ref="math_ops" value="not_equal" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/log -->
-        <putfield class="LRoot" field="log" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="log" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reciprocal -->
-        <putfield class="LRoot" field="reciprocal" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="reciprocal" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
+        <!-- The four ordering comparison ops (`tf.less`, `tf.less_equal`, `tf.greater`, `tf.greater_equal`) round out the comparison family started by `equal`/`not_equal`; same alias structure (top-level `tf.X`, `tf.math.X`, `tf.math_ops.X`). Each routes to `ComparisonOperation` and emits `bool` per
+          wala/ML#427. -->
+        <new def="less" class="Ltensorflow/math/less" />
+        <putfield class="LRoot" field="less" fieldType="LRoot" ref="x" value="less" />
+        <putfield class="LRoot" field="less" fieldType="LRoot" ref="math" value="less" />
+        <putfield class="LRoot" field="less" fieldType="LRoot" ref="math_ops" value="less" />
+        <new def="less_equal" class="Ltensorflow/math/less_equal" />
+        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="x" value="less_equal" />
+        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="math" value="less_equal" />
+        <putfield class="LRoot" field="less_equal" fieldType="LRoot" ref="math_ops" value="less_equal" />
+        <new def="greater" class="Ltensorflow/math/greater" />
+        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="x" value="greater" />
+        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="math" value="greater" />
+        <putfield class="LRoot" field="greater" fieldType="LRoot" ref="math_ops" value="greater" />
+        <new def="greater_equal" class="Ltensorflow/math/greater_equal" />
+        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="x" value="greater_equal" />
+        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="math" value="greater_equal" />
+        <putfield class="LRoot" field="greater_equal" fieldType="LRoot" ref="math_ops" value="greater_equal" />
+        <!-- `tf.{sqrt,log,sin,cos}` and their aliases (`tf.math.*`, `tf.gen_math_ops.{log,sin,cos}`, `tf.math_ops.sqrt`) now route through dedicated `<class>` blocks defined later in this file (search for `class name="sqrt"`, etc.). -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/lgamma -->
         <putfield class="LRoot" field="lgamma" fieldType="LRoot" ref="math" value="pass_through" />
         <putfield class="LRoot" field="lgamma" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/erf -->
-        <putfield class="LRoot" field="erf" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="erf" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/square -->
-        <putfield class="LRoot" field="square" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="square" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="square" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/maximum -->
-        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/minimum -->
-        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/less -->
-        <!-- TODO: Return a dtype of bool instead of the input. -->
-        <putfield class="LRoot" field="less" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="less" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="less" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/cos -->
-        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
+        <!-- `tf.{math,gen_math_ops}.{reciprocal,erf}` and `tf.square` (plus its `tf.{math,gen_math_ops}.square` aliases) now route through dedicated `<class>` blocks defined later in this file (search for `class name="reciprocal"`, etc.). `tf.reciprocal` and `tf.erf` are not real TF 2 top-level names,
+          so no `ref="x"` putfield is needed for those. -->
+        <!-- `tf.{maximum,minimum}` and `tf.{math,gen_math_ops}.{maximum,minimum}` now route through dedicated `<class>` blocks dispatched to `ElementWiseOperation` (broadcast shape, unified dtype). -->
+        <!-- `tf.less`'s legacy `pass_through` aliasing was removed: the modern `<class name="less">` block + `ComparisonOperation` dispatch (wala/ML#427) now handle bool dtype directly. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/tanh -->
         <new def="tanh" class="Ltensorflow/math/tanh" />
         <putfield class="LRoot" field="tanh" fieldType="LRoot" ref="x" value="tanh" />
@@ -319,10 +375,6 @@
         <putfield class="LRoot" field="l2_normalize" fieldType="LRoot" ref="math" value="l2_normalize" />
         <putfield class="LRoot" field="l2_normalize" fieldType="LRoot" ref="nn" value="l2_normalize" />
         <putfield class="LRoot" field="l2_normalize" fieldType="LRoot" ref="nn_impl" value="l2_normalize" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/sin -->
-        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="gen_math_ops" value="pass_through" />
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/pow -->
         <putfield class="LRoot" field="pow" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math" value="pass_through" />
@@ -337,10 +389,6 @@
         <putfield class="LRoot" field="reduce_max" fieldType="LRoot" ref="x" value="reduce_max" />
         <putfield class="LRoot" field="reduce_max" fieldType="LRoot" ref="math" value="reduce_max" />
         <putfield class="LRoot" field="reduce_max" fieldType="LRoot" ref="math_ops" value="reduce_max" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/sqrt -->
-        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="math" value="pass_through" />
-        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="math_ops" value="pass_through" />
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/rsqrt -->
         <new def="rsqrt" class="Ltensorflow/math/rsqrt" />
         <putfield class="LRoot" field="rsqrt" fieldType="LRoot" ref="math" value="rsqrt" />
@@ -405,15 +453,16 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/ones_like -->
         <putfield class="LRoot" field="ones_like" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="ones_like" fieldType="LRoot" ref="array_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/shape -->
-        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/shape — at runtime allocates a fresh 1-D int32 tensor whose values are `input`'s shape. The model here is partial: `<new>+<return>` allocates a `Ltensorflow/python/framework/ops/Tensor` of unknown dtype and unknown rank/shape (no
+          dedicated generator yet wired to encode int32 dtype or the statically-1 rank). That's enough to fix wala/ML#489's specific symptom &mdash; the dedicated allocation breaks the prior `pass_through` aliasing that caused `getShapesFromShapeArgument` to mis-parse `tf.shape(y)` as if `y`'s data were a shape
+          spec. Tightening the result to int32 dtype / rank-1 shape is tracked at wala/ML#473. -->
+        <new def="shape" class="Ltensorflow/math/shape" />
+        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="x" value="shape" />
+        <putfield class="LRoot" field="shape" fieldType="LRoot" ref="array_ops" value="shape" />
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/transpose -->
         <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="transpose" fieldType="LRoot" ref="array_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_value -->
-        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="clip_ops" value="pass_through" />
+        <!-- `tf.clip_by_value` and `clip_ops.clip_by_value` now route through the dedicated `<class name="clip_by_value">` block defined later in this file. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_global_norm -->
         <new def="clip_by_global_norm" class="Ltensorflow/functions/clip_by_global_norm" />
         <putfield class="LRoot" field="clip_by_global_norm" fieldType="LRoot" ref="x" value="clip_by_global_norm" />
@@ -498,15 +547,15 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/solve -->
         <putfield class="LRoot" field="solve" fieldType="LRoot" ref="linalg" value="pass_through" />
         <putfield class="LRoot" field="solve" fieldType="LRoot" ref="gen_linalg_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/broadcast_to -->
-        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="gen_array_ops" value="pass_through" />
+        <!-- https://www.tensorflow.org/api_docs/python/tf/broadcast_to — fresh allocation routed to the dedicated `BroadcastTo` generator (wala/ML#449 Tier 7). Pre-fix used `value="pass_through"` aliasing, which routed the result through `PassThrough`'s identity semantics rather than computing the actual
+          broadcast shape from the `shape` argument. -->
+        <new def="broadcast_to" class="Ltensorflow/functions/broadcast_to" />
+        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="x" value="broadcast_to" />
+        <putfield class="LRoot" field="broadcast_to" fieldType="LRoot" ref="gen_array_ops" value="broadcast_to" />
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tile -->
         <putfield class="LRoot" field="tile" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="tile" fieldType="LRoot" ref="gen_array_ops" value="pass_through" />
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims -->
-        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="x" value="pass_through" />
-        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="array_ops" value="pass_through" />
+        <!-- `tf.expand_dims` and `array_ops.expand_dims` now route through the dedicated `<class name="expand_dims">` block defined later in this file. -->
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather -->
         <putfield class="LRoot" field="gather" fieldType="LRoot" ref="x" value="pass_through" />
         <putfield class="LRoot" field="gather" fieldType="LRoot" ref="array_ops" value="pass_through" />
@@ -668,6 +717,9 @@
         <new def="sparse_add" class="Ltensorflow/functions/sparse_add" />
         <putfield class="LRoot" field="add" fieldType="LRoot" ref="sparse" value="sparse_add" />
         <putfield class="LRoot" field="sparse_add" fieldType="LRoot" ref="sparse_ops" value="sparse_add" />
+        <new def="sparse_from_dense" class="Ltensorflow/functions/sparse_from_dense" />
+        <putfield class="LRoot" field="from_dense" fieldType="LRoot" ref="sparse" value="sparse_from_dense" />
+        <putfield class="LRoot" field="sparse_from_dense" fieldType="LRoot" ref="sparse_ops" value="sparse_from_dense" />
         <new def="convert_to_tensor" class="Ltensorflow/functions/convert_to_tensor" />
         <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="x" value="convert_to_tensor" />
         <putfield class="LRoot" field="convert_to_tensor" fieldType="LRoot" ref="ops" value="convert_to_tensor" />
@@ -729,6 +781,133 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/custom_gradient -->
         <new def="custom_gradient" class="Ltensorflow/class/custom_gradient" />
         <putfield class="LRoot" field="custom_gradient" fieldType="LRoot" ref="x" value="custom_gradient" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu -->
+        <new def="relu" class="Ltensorflow/functions/relu" />
+        <putfield class="LRoot" field="relu" fieldType="LRoot" ref="nn" value="relu" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/cast -->
+        <new def="cast" class="Ltensorflow/functions/cast" />
+        <putfield class="LRoot" field="cast" fieldType="LRoot" ref="x" value="cast" />
+        <putfield class="LRoot" field="cast" fieldType="LRoot" ref="dtypes" value="cast" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims -->
+        <new def="expand_dims" class="Ltensorflow/functions/expand_dims" />
+        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="x" value="expand_dims" />
+        <putfield class="LRoot" field="expand_dims" fieldType="LRoot" ref="array_ops" value="expand_dims" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_value -->
+        <new def="clip_by_value" class="Ltensorflow/functions/clip_by_value" />
+        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="x" value="clip_by_value" />
+        <putfield class="LRoot" field="clip_by_value" fieldType="LRoot" ref="clip_ops" value="clip_by_value" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/leaky_relu -->
+        <new def="leaky_relu" class="Ltensorflow/functions/leaky_relu" />
+        <putfield class="LRoot" field="leaky_relu" fieldType="LRoot" ref="nn" value="leaky_relu" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_min -->
+        <new def="reduce_min" class="Ltensorflow/math/reduce_min" />
+        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="x" value="reduce_min" />
+        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="math" value="reduce_min" />
+        <putfield class="LRoot" field="reduce_min" fieldType="LRoot" ref="math_ops" value="reduce_min" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/pow -->
+        <new def="pow" class="Ltensorflow/math/pow" />
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="x" value="pow" />
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math" value="pow" />
+        <putfield class="LRoot" field="pow" fieldType="LRoot" ref="math_ops" value="pow" />
+        <!-- Tier-A pure-passthrough math ops (wala/ML#422). Each modeled with direct `<new>+<return>` and a per-op Java generator extending `PassThroughUnaryTensorGenerator`; output shape and dtype both inherit from `x`. Pre-this-PR, several of these ops (sqrt, log, sin, cos) were earlier-bound to a
+          generic `pass_through` field-write that aliases the result to the input rather than allocating a fresh tensor &mdash; the result was reachable via the receiver's modeling but had no per-op precision. The per-op `<new>+<return>` here replaces that for `tf` / `tf.math` callers, and the `gen_math_ops` /
+          `math_ops` aliases below restore the precision under those internal modules too (`sqrt` had `math_ops`; `log`/`sin`/`cos` had `gen_math_ops` in the prior model). -->
+        <new def="sqrt" class="Ltensorflow/math/sqrt" />
+        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="x" value="sqrt" />
+        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="math" value="sqrt" />
+        <putfield class="LRoot" field="sqrt" fieldType="LRoot" ref="math_ops" value="sqrt" />
+        <new def="log" class="Ltensorflow/math/log" />
+        <putfield class="LRoot" field="log" fieldType="LRoot" ref="x" value="log" />
+        <putfield class="LRoot" field="log" fieldType="LRoot" ref="math" value="log" />
+        <putfield class="LRoot" field="log" fieldType="LRoot" ref="gen_math_ops" value="log" />
+        <new def="negative" class="Ltensorflow/math/negative" />
+        <putfield class="LRoot" field="negative" fieldType="LRoot" ref="x" value="negative" />
+        <putfield class="LRoot" field="negative" fieldType="LRoot" ref="math" value="negative" />
+        <new def="sin" class="Ltensorflow/math/sin" />
+        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="x" value="sin" />
+        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="math" value="sin" />
+        <putfield class="LRoot" field="sin" fieldType="LRoot" ref="gen_math_ops" value="sin" />
+        <new def="cos" class="Ltensorflow/math/cos" />
+        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="x" value="cos" />
+        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="math" value="cos" />
+        <putfield class="LRoot" field="cos" fieldType="LRoot" ref="gen_math_ops" value="cos" />
+        <new def="floor" class="Ltensorflow/math/floor" />
+        <putfield class="LRoot" field="floor" fieldType="LRoot" ref="x" value="floor" />
+        <putfield class="LRoot" field="floor" fieldType="LRoot" ref="math" value="floor" />
+        <new def="ceil" class="Ltensorflow/math/ceil" />
+        <putfield class="LRoot" field="ceil" fieldType="LRoot" ref="x" value="ceil" />
+        <putfield class="LRoot" field="ceil" fieldType="LRoot" ref="math" value="ceil" />
+        <new def="sign" class="Ltensorflow/math/sign" />
+        <putfield class="LRoot" field="sign" fieldType="LRoot" ref="x" value="sign" />
+        <putfield class="LRoot" field="sign" fieldType="LRoot" ref="math" value="sign" />
+        <!-- Tier-A math ops (continued, wala/ML#422). Most are shape and dtype passthrough on their primary tensor argument (named `x` for the unary ops; `features` for `softplus` / `softsign`). The binary ops `atan2` / `maximum` / `minimum` later in this block are the exception &mdash; they're routed
+          through `ElementWiseOperation`, which derives dtype from the `x` parameter at position 0 and computes broadcast shape from both operands. -->
+        <new def="tan" class="Ltensorflow/math/tan" />
+        <putfield class="LRoot" field="tan" fieldType="LRoot" ref="x" value="tan" />
+        <putfield class="LRoot" field="tan" fieldType="LRoot" ref="math" value="tan" />
+        <putfield class="LRoot" field="tan" fieldType="LRoot" ref="gen_math_ops" value="tan" />
+        <new def="asin" class="Ltensorflow/math/asin" />
+        <putfield class="LRoot" field="asin" fieldType="LRoot" ref="x" value="asin" />
+        <putfield class="LRoot" field="asin" fieldType="LRoot" ref="math" value="asin" />
+        <putfield class="LRoot" field="asin" fieldType="LRoot" ref="gen_math_ops" value="asin" />
+        <new def="atan" class="Ltensorflow/math/atan" />
+        <putfield class="LRoot" field="atan" fieldType="LRoot" ref="x" value="atan" />
+        <putfield class="LRoot" field="atan" fieldType="LRoot" ref="math" value="atan" />
+        <putfield class="LRoot" field="atan" fieldType="LRoot" ref="gen_math_ops" value="atan" />
+        <new def="sinh" class="Ltensorflow/math/sinh" />
+        <putfield class="LRoot" field="sinh" fieldType="LRoot" ref="x" value="sinh" />
+        <putfield class="LRoot" field="sinh" fieldType="LRoot" ref="math" value="sinh" />
+        <putfield class="LRoot" field="sinh" fieldType="LRoot" ref="gen_math_ops" value="sinh" />
+        <new def="cosh" class="Ltensorflow/math/cosh" />
+        <putfield class="LRoot" field="cosh" fieldType="LRoot" ref="x" value="cosh" />
+        <putfield class="LRoot" field="cosh" fieldType="LRoot" ref="math" value="cosh" />
+        <new def="asinh" class="Ltensorflow/math/asinh" />
+        <putfield class="LRoot" field="asinh" fieldType="LRoot" ref="x" value="asinh" />
+        <putfield class="LRoot" field="asinh" fieldType="LRoot" ref="math" value="asinh" />
+        <new def="acosh" class="Ltensorflow/math/acosh" />
+        <putfield class="LRoot" field="acosh" fieldType="LRoot" ref="x" value="acosh" />
+        <putfield class="LRoot" field="acosh" fieldType="LRoot" ref="math" value="acosh" />
+        <new def="atanh" class="Ltensorflow/math/atanh" />
+        <putfield class="LRoot" field="atanh" fieldType="LRoot" ref="x" value="atanh" />
+        <putfield class="LRoot" field="atanh" fieldType="LRoot" ref="math" value="atanh" />
+        <new def="log1p" class="Ltensorflow/math/log1p" />
+        <putfield class="LRoot" field="log1p" fieldType="LRoot" ref="x" value="log1p" />
+        <putfield class="LRoot" field="log1p" fieldType="LRoot" ref="math" value="log1p" />
+        <new def="expm1" class="Ltensorflow/math/expm1" />
+        <putfield class="LRoot" field="expm1" fieldType="LRoot" ref="x" value="expm1" />
+        <putfield class="LRoot" field="expm1" fieldType="LRoot" ref="math" value="expm1" />
+        <new def="round" class="Ltensorflow/math/round" />
+        <putfield class="LRoot" field="round" fieldType="LRoot" ref="x" value="round" />
+        <putfield class="LRoot" field="round" fieldType="LRoot" ref="math" value="round" />
+        <new def="reciprocal" class="Ltensorflow/math/reciprocal" />
+        <putfield class="LRoot" field="reciprocal" fieldType="LRoot" ref="math" value="reciprocal" />
+        <putfield class="LRoot" field="reciprocal" fieldType="LRoot" ref="gen_math_ops" value="reciprocal" />
+        <new def="softplus" class="Ltensorflow/math/softplus" />
+        <putfield class="LRoot" field="softplus" fieldType="LRoot" ref="math" value="softplus" />
+        <putfield class="LRoot" field="softplus" fieldType="LRoot" ref="nn" value="softplus" />
+        <new def="softsign" class="Ltensorflow/math/softsign" />
+        <putfield class="LRoot" field="softsign" fieldType="LRoot" ref="math" value="softsign" />
+        <putfield class="LRoot" field="softsign" fieldType="LRoot" ref="nn" value="softsign" />
+        <new def="square" class="Ltensorflow/math/square" />
+        <putfield class="LRoot" field="square" fieldType="LRoot" ref="x" value="square" />
+        <putfield class="LRoot" field="square" fieldType="LRoot" ref="math" value="square" />
+        <putfield class="LRoot" field="square" fieldType="LRoot" ref="gen_math_ops" value="square" />
+        <new def="erf" class="Ltensorflow/math/erf" />
+        <putfield class="LRoot" field="erf" fieldType="LRoot" ref="math" value="erf" />
+        <putfield class="LRoot" field="erf" fieldType="LRoot" ref="gen_math_ops" value="erf" />
+        <new def="erfc" class="Ltensorflow/math/erfc" />
+        <putfield class="LRoot" field="erfc" fieldType="LRoot" ref="math" value="erfc" />
+        <!-- Element-wise binary ops (broadcast shape, unified dtype) — routed through ElementWiseOperation. -->
+        <new def="atan2" class="Ltensorflow/math/atan2" />
+        <putfield class="LRoot" field="atan2" fieldType="LRoot" ref="math" value="atan2" />
+        <new def="maximum" class="Ltensorflow/math/maximum" />
+        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="x" value="maximum" />
+        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="math" value="maximum" />
+        <putfield class="LRoot" field="maximum" fieldType="LRoot" ref="gen_math_ops" value="maximum" />
+        <new def="minimum" class="Ltensorflow/math/minimum" />
+        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="x" value="minimum" />
+        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="math" value="minimum" />
+        <putfield class="LRoot" field="minimum" fieldType="LRoot" ref="gen_math_ops" value="minimum" />
         <return value="x" />
       </method>
     </class>
@@ -849,11 +1028,19 @@
       </class>
     </package>
     <package name="tensorflow/math">
+      <class name="shape" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/shape — returns a 1-D int32 tensor whose values are `input`'s runtime shape. Modeled as `<new>+<return>` (fresh allocation, not pass-through) so `getShapesFromShapeArgument` doesn't conflate the shape-tensor with `input`'s data
+          structure (wala/ML#489). The result is a tensor whose rank is statically 1 but whose dim depends on `input`'s rank, which static analysis can't compute in general — left at ⊤ (no per-op generator wired up here). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input out_type name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
       <class name="sigmoid" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/sigmoid. Modeled as `<new>+<return>` (fresh allocation, not pass-through) to match add/matmul and reflect actual TF semantics: sigmoid returns a new tensor with the same shape/dtype as its input, not the input object itself.
           Shape/dtype inference lives in the `Sigmoid` generator. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <new def="res" class="Ltensorflow/math/sigmoid" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
@@ -861,7 +1048,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/add -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
           <!-- Even though tf.add() isn't a tensor "generator," it can convert its non-tensor arguments to tensors. -->
-          <new def="res" class="Ltensorflow/math/add" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
@@ -869,7 +1056,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/multiply -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
           <!-- Even though tf.multiply() isn't a tensor "generator," it can convert its non-tensor arguments to tensors. -->
-          <new def="res" class="Ltensorflow/math/multiply" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
@@ -881,102 +1068,76 @@
         </method>
       </class>
       <class name="reduce_sum" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_sum -->
-        <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_sum. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="argmax" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmax — index of the maximum value across an axis. The dedicated `Argmax` generator reads the `output_type` argument when explicitly passed (e.g. `output_type=tf.int32`) and falls back to the TF default of `int64` otherwise; output shape
+          is currently ⊤ pending wala/ML#462. The legacy `dimension` parameter (a TF 1.x alias for `axis`) is retained in `paramNames` for back-compat. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self input axis output_type name dimension">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
-        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input axis name dimension">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
-          <return value="xx" />
+      </class>
+      <class name="argmin" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/argmin — index of the minimum value across an axis. Mirrors the `argmax` modeling above (same param signature, same direct `<new>+<return>` per wala/ML#380, same `output_type`-overrideable output dtype via the dedicated `Argmin` generator). -->
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self input axis output_type name dimension">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="equal" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/equal -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/equal. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <!-- TODO: Return a Tensor whose dtype is bool (see wala/ML#427). -->
-        <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="rsqrt" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/rsqrt -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/math/rsqrt" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/rsqrt. Modeled as `<new>+<return>` (fresh allocation, not `read_data` pass-through) so the factory can dispatch to the dedicated `Rsqrt` generator (wala/ML#449 Tier 2). Shape/dtype inference reads the `x` argument's PTS via
+          `PassThroughUnaryTensorGenerator`. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="log_softmax" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/log_softmax -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/math/log_softmax" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/log_softmax. Modeled as `<new>+<return>` for the same reason — wala/ML#449 Tier 2. Note the parameter name `logits` (vs. `x` for the other Tier-2 unary math ops). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self logits axis name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="exp" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/exp -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/math/exp" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/exp. Modeled as `<new>+<return>` for the same reason — wala/ML#449 Tier 2. -->
         <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="tensordot" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/tensordot -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/math/tensordot" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="a b axes name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
-          <return value="xx" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/tensordot. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self a b axes name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="trace" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/trace -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/math/trace" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="x name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
-          <return value="xx" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/trace. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="einsum" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/einsum -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/math/einsum" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="equation *inputs **kwargs">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
-          <return value="xx" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/einsum. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self equation *inputs **kwargs">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="add_n" allocatable="true">
@@ -989,28 +1150,52 @@
         </method>
       </class>
       <class name="not_equal" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/not_equal -->
-        <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/not_equal. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
-          <return value="xx" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="less" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/less — elementwise `x < y`. Direct `<new>+<return>` per wala/ML#380's preference (no `read_data` materialization chain). Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="less_equal" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/less_equal — elementwise `x <= y`. Direct `<new>+<return>` per wala/ML#380's preference. Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="greater" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/greater — elementwise `x > y`. Direct `<new>+<return>` per wala/ML#380's preference. Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="greater_equal" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/math/greater_equal — elementwise `x >= y`. Direct `<new>+<return>` per wala/ML#380's preference. Routes to `ComparisonOperation` for bool output dtype (wala/ML#427). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="top_k" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/math/top_k" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/top_k -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/top_k. Direct `<new>+<putfield>` per wala/ML#380 (was a `read_data` materialization chain). Returns a `(values, indices)` NamedTuple — both fields point at fresh `Tensor` allocations. The `values`/`indices` named-field aliases
+          (in addition to the numeric `0`/`1` fields) handle the NamedTuple attribute-access pattern: `result.values` reads field `"values"` (a string property name) and the alias makes that resolve to the same `xx` alloc as field `0`. Without the alias, `result.values` reads an empty field-PTS and falls through
+          to ⊤, even though `values, indices = result` (numeric destructuring) worked fine. See wala/ML#480 for the full diagnosis. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input k sorted name">
           <new def="x" class="Ltuple" />
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
+          <new def="xx" class="Ltensorflow/python/framework/ops/Tensor" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="xx" />
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="yy" />
+          <putfield class="LRoot" field="values" fieldType="LRoot" ref="x" value="xx" />
+          <new def="yy" class="Ltensorflow/python/framework/ops/Tensor" />
           <putfield class="LRoot" field="1" fieldType="LRoot" ref="x" value="yy" />
+          <putfield class="LRoot" field="indices" fieldType="LRoot" ref="x" value="yy" />
           <return value="x" />
         </method>
       </class>
@@ -1023,19 +1208,18 @@
         </method>
       </class>
       <class name="reduce_all" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_all -->
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input_tensor axis keepdims name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
-          <return value="y" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_all. Modeled as `<new>+<return>` so the factory dispatches to the dedicated `ReduceAll` generator (wala/ML#449 Tier 3); the `convert_to_tensor` chain preserved input's shape, but reductions collapse dims along `axis`.
+          Shape logic lives in `ReduceMean`'s axis/keepdims handling, which `ReduceAll` reuses by inheritance; dtype is always `BOOL`. -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="reduce_prod" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_prod -->
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input_tensor axis keepdims name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
-          <return value="y" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_prod. Modeled as `<new>+<return>` for the same reason — wala/ML#449 Tier 3. Output dtype inherits from input (no int→float32 promotion like `reduce_mean`). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="tanh" allocatable="true">
@@ -1055,19 +1239,203 @@
         </method>
       </class>
       <class name="reduce_max" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_max -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_max. Modeled as `<new>+<return>` for the same reason as `reduce_all`/`reduce_prod` — wala/ML#449 Tier 3. Output dtype inherits from input (no int→float32 promotion like `reduce_mean`). -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
-          <return value="y" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="reduce_min" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_min. Mirrors reduce_max — same axis-collapse / keepdims shape semantics, dtype inherited from input. -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="pow" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/pow. Element-wise binary op (`x ** y`); routed through `ElementWiseOperation` for broadcast shape and dtype-from-`x` (TF requires `x`/`y` to share dtype, so this is sound). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <!-- Tier-A pure-passthrough math ops (wala/ML#422). Each is shape and dtype passthrough on `x`. -->
+      <class name="sqrt" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="log" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="negative" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="sin" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="cos" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="floor" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="ceil" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="sign" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <!-- Tier-A pure-passthrough math ops (continued, wala/ML#422). Each is shape and dtype passthrough on `x`. -->
+      <class name="tan" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="asin" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="atan" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="sinh" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="cosh" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="asinh" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="acosh" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="atanh" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="log1p" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="expm1" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="round" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="reciprocal" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="softplus" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self features name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="softsign" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self features name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="square" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="erf" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="erfc" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <!-- Element-wise binary ops — routed through ElementWiseOperation for shape (broadcast) and dtype (unified). -->
+      <class name="atan2" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self y x name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="maximum" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="minimum" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="reduce_logsumexp" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reduce_logsumexp -->
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input_tensor axis keepdims name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input_tensor" numArgs="2" def="y" />
-          <return value="y" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/math/reduce_logsumexp. Modeled as `<new>+<return>` for the same reason — wala/ML#449 Tier 3. Output dtype inherits from input (`reduce_logsumexp` requires float input at runtime; static analysis just preserves whatever the input
+          dtype was). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self input_tensor axis keepdims name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="acos" allocatable="true">
@@ -1090,7 +1458,7 @@
       </class>
       <class name="convert_to_tensor" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/framework/ops/convert_to_tensor" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
@@ -1111,31 +1479,31 @@
     <package name="tensorflow/python/ops/array_ops">
       <class name="zeros" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/zeros" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="zeros_like" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/zeros_like" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="fill" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/fill" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="reshape" allocatable="true">
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="tensor shape name">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/reshape" />
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self tensor shape name">
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="one_hot" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/one_hot" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
@@ -1143,7 +1511,7 @@
     <package name="tensorflow/python/ops/linalg_ops">
       <class name="eye" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/ops/linalg_ops/eye" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
@@ -1151,31 +1519,31 @@
     <package name="tensorflow/python/ops/random_ops">
       <class name="uniform" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/ops/random_ops/uniform" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="gamma" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/ops/random_ops/gamma" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="normal" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/ops/random_ops/normal" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="poisson" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/ops/random_ops/poisson" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="truncated_normal" allocatable="true">
         <method name="read_data" descriptor="()LRoot;" numArgs="1">
-          <new def="x" class="Ltensorflow/python/ops/random_ops/truncated_normal" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
@@ -1200,7 +1568,7 @@
     <package name="tensorflow/functions">
       <class name="from_nested_value_rowids" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self flat_values nested_value_rowids nested_nrows name validate">
-          <new def="res" class="Ltensorflow/functions/from_nested_value_rowids" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
@@ -1255,7 +1623,7 @@
       <class name="reshape" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/reshape -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input shape name">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/reshape" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
@@ -1266,14 +1634,11 @@
         </method>
       </class>
       <class name="concat" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/concat" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="values axis name">
-          <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/concat -->
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/concat. Direct `<new>+<return>` paired with the dedicated `Concat` generator (wala/ML#449 Tier 5): the generator computes the precise output shape by walking every entry in the `values` list, summing each input's dim along the resolved
+          `axis`, and inheriting the rest of the shape from the first input. Pre-fix the XML routed through `convert_to_tensor` which inherited the first input's shape verbatim — sound on dtype but unsound on shape (missed the per-input axis-dim sum). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self values axis name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="Variable" allocatable="true">
@@ -1284,7 +1649,7 @@
       </class>
       <class name="constant" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self value dtype shape name">
-          <new def="res" class="Ltensorflow/python/framework/constant_op/constant" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <!-- The `value` putfield was removed (wala/ML#451 reopen): binding the user-supplied value to the alloc's `value` field caused Hybridize's `Function.containsPrimitive` to traverse fields of the alloc and find a `ConstantKey<Integer>`/`ConstantKey<Float>` for `tf.constant(N)`-style calls, classifying
             parameters that receive the result (e.g. `recursive_fn(tf.constant(5))`'s `n`) as having primitive parameters. The Ariadne-side `Constant` generator reads dtype/shape directly from the call's `value` argument PTS via `getArgumentPointsToSet`, so dtype/shape inference is unaffected. The Java-side `TensorGenerator.getShapesFromShapeArgument`'s
             `CONSTANT_OP_CONSTANT` branch falls back to walking back to the allocating call's value arg when the field is empty. -->
@@ -1294,7 +1659,7 @@
       </class>
       <class name="zeros" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self shape dtype name">
-          <new def="res" class="Ltensorflow/python/ops/array_ops/zeros" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
@@ -1328,150 +1693,130 @@
       <class name="sparse_add" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/sparse/add. Fresh allocation, not pass-through; shape / dtype inference lives in the `SparseAdd` generator. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self a b threshold name">
-          <new def="res" class="Ltensorflow/functions/sparse_add" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="sparse_from_dense" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/sparse/from_dense. Fresh allocation, not pass-through; shape and dtype inheritance from the `tensor` argument lives in the `SparseFromDense` generator. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self tensor name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
       <class name="fill" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self dims value name">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/fill" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
+        </method>
+      </class>
+      <class name="broadcast_to" allocatable="true">
+        <!-- https://www.tensorflow.org/api_docs/python/tf/broadcast_to — direct `<new>+<return>` per wala/ML#380's preferred pattern. Routes to `BroadcastTo` for shape-from-`shape` and dtype-from-`input` (wala/ML#449 Tier 7). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input shape name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="sequence_mask" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/sequence_mask" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/sequence_mask -->
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="lengths maxlen dtype name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/sequence_mask. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self lengths maxlen dtype name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="stop_gradient" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/stop_gradient" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/stop_gradient -->
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="input name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/stop_gradient. Modeled as `<new>+<return>` (fresh allocation, not `read_data` pass-through) to match `identity` and `sigmoid` and enable factory dispatch to the dedicated `StopGradient` generator (wala/ML#449 Tier 1). Shape/dtype
+          inference reads the `input` argument's PTS via `StopGradient.shapesOfArg` / `dtypesOfArg`. The alloc class matches this `<class>`'s declared type (`Ltensorflow/functions/stop_gradient`) so the heap model can resolve the `<new>` to a concrete InstanceKey — a separate undeclared `Ltensorflow/python/ops/array_ops/stop_gradient`
+          would silently fail PA propagation (see `project_synthetic_method_implicit_pts` note). -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="zeros_like" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input dtype name">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/zeros_like" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="embedding_lookup" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/ops/embedding_ops/embedding_lookup" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/embedding_lookup -->
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="params ids max_norm name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/embedding_lookup. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self params ids max_norm name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="one_hot" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="8" paramNames="self indices depth on_value off_value axis dtype name">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/one_hot" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="convert_to_tensor" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self value dtype dtype_hint name">
-          <new def="x" class="Ltensorflow/python/framework/ops/convert_to_tensor" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="identity" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/identity -->
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="input name">
-          <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
-          <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="input" numArgs="2" def="x" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/identity. Modeled as `<new>+<return>` (fresh allocation, not pass-through) to match `sigmoid`/`softmax` and enable factory dispatch to the dedicated `Identity` generator (wala/ML#449 Tier 1). Shape/dtype inference reads the `input`
+          argument's PTS via `Identity.shapesOfArg` / `dtypesOfArg`. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="where" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/where" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/where -->
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="condition x y name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="xx" />
-          <return value="xx" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/where. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self condition x y name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="meshgrid" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/meshgrid -->
-        <method name="read_data" descriptor="()LRoot;">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/meshgrid. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a list whose first element is a constant-materialized tensor. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self *args **kwargs">
           <new def="x" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
           <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="*args **kwargs">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
           <return value="x" />
         </method>
       </class>
       <class name="split" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/split -->
-        <method name="read_data" descriptor="()LRoot;">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/split. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a list whose first element is a constant-materialized tensor. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self *args **kwargs">
           <new def="x" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
           <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
           <return value="x" />
         </method>
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="*args **kwargs">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
-        </method>
       </class>
       <class name="rank" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/rank -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="x" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="input name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/rank. Modeled as `<new>+<return>` so the factory dispatches to the dedicated `Rank` generator (wala/ML#449 Tier 4); pre-fix routed through the `read_data → constant.do(z, 1)` materialization chain which gave ⊤ via `ReadDataFallback`.
+          Output is intrinsic to the API (scalar int32 = number of dims of `input`); shape/dtype are hardcoded in the generator rather than read from any arg. Param shape `self input name` matches `sigmoid`. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self input name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="size" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/size -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="z" class="Ltensorflow/functions/constant" />
-          <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="x" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="input out_type name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/size. Modeled as `<new>+<return>` for the same reason as `rank` — wala/ML#449 Tier 4. Output is intrinsic (scalar = total number of elements). Default dtype is int32; the `out_type` arg can override to int64 (the analysis' DType
+          lattice models int32, int64, and a handful of others — uint32/uint64 from the runtime API aren't in the lattice). The generator currently hardcodes int32 — extending to honor `out_type` is a clean follow-up if a fixture surfaces the need. -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input out_type name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="tensor_scatter_nd_update" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tensor_scatter_nd_update. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a constant-materialized tensor. -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self tensor indices updates name">
           <new def="z" class="Ltensorflow/functions/constant" />
           <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="x" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/tensor_scatter_nd_update -->
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="tensor indices updates name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
           <return value="x" />
         </method>
       </class>
@@ -1499,26 +1844,26 @@
       </class>
       <class name="ragged_range" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self starts limits deltas dtype name row_splits_dtype">
-          <new def="x" class="Ltensorflow/python/ops/ragged/ragged_math_ops/range" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="ragged_constant" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self pylist dtype ragged_rank inner_shape name row_splits_dtype">
-          <new def="x" class="Ltensorflow/python/ops/ragged/ragged_factory_ops/constant" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <putfield class="Ltensorflow/python/ops/ragged/ragged_factory_ops/constant" field="value" fieldType="LRoot" ref="x" value="pylist" />
           <return value="x" />
         </method>
       </class>
       <class name="eye" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self num_rows num_columns batch_shape dtype name">
-          <new def="x" class="Ltensorflow/python/ops/linalg_ops/eye" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="eigh" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linalg/eigh -->
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="tensor name">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self tensor name">
           <new def="x" class="Ltuple" />
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
           <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="tensor" numArgs="2" def="y" />
@@ -1529,7 +1874,7 @@
       </class>
       <class name="clip_by_global_norm" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_global_norm -->
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="t_list clip_norm use_norm name">
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self t_list clip_norm use_norm name">
           <new def="x" class="Ltuple" />
           <new def="y" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
@@ -1544,71 +1889,63 @@
       <class name="map_fn" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/map_fn -->
         <!-- TODO: Call `map_fn()` on each of the elements of `elems`. -->
-        <method name="do" descriptor="()LRoot;" numArgs="9" paramNames="fn elems dtype parallel_iterations back_prop swap_memory infer_shape name fn_output_signature">
+        <method name="do" descriptor="()LRoot;" numArgs="10" paramNames="self fn elems dtype parallel_iterations back_prop swap_memory infer_shape name fn_output_signature">
           <return value="elems" />
         </method>
       </class>
       <class name="py_function" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/functions/py_function" />
-          <return value="x" />
-        </method>
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/py_function -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/py_function. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <!-- TODO: Call `func` per https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/py_function#returns -->
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="func inp Tout name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self func inp Tout name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="uniform" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self shape minval maxval dtype seed name">
-          <new def="x" class="Ltensorflow/python/ops/random_ops/uniform" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="gamma" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self shape alpha beta dtype seed name">
-          <new def="x" class="Ltensorflow/python/ops/random_ops/gamma" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="normal" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self shape mean stddev dtype seed name">
-          <new def="x" class="Ltensorflow/python/ops/random_ops/normal" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="poisson" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self shape lam dtype seed name">
-          <new def="x" class="Ltensorflow/python/ops/random_ops/poisson" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="gather_nd" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/ops/array_ops/gather_nd" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="params indices name batch_dims">
-          <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather_nd -->
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/gather_nd. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self params indices batch_dims name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="truncated_normal" allocatable="true">
         <!-- Allocation moved to do() to avoid 1-CFA aliasing issues with shared read_data(). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self shape mean stddev dtype seed name">
-          <new def="x" class="Ltensorflow/python/ops/random_ops/truncated_normal" />
+          <new def="x" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="x" />
         </method>
       </class>
       <class name="shuffle" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/random/shuffle -->
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="value seed name">
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self value seed name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
           <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="value" numArgs="2" def="y" />
           <return value="y" />
@@ -1616,114 +1953,96 @@
       </class>
       <class name="sort" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/sort -->
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="values axis direction name">
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self values axis direction name">
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
           <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="values" numArgs="2" def="y" />
           <return value="y" />
         </method>
       </class>
       <class name="Input" allocatable="true">
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/functions/Input" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="8" paramNames="shape batch_size name dtype sparse tensor ragged type_spec">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <!-- Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). Mirrors `tensorflow/keras/layers/Input` below. -->
+        <method name="do" descriptor="()LRoot;" numArgs="9" paramNames="self shape batch_size name dtype sparse tensor ragged type_spec">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="from_nested_row_lengths" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self flat_values nested_row_lengths name validate">
-          <new def="res" class="Ltensorflow/functions/from_nested_row_lengths" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
       <class name="from_nested_row_splits" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self flat_values nested_row_splits name validate">
-          <new def="res" class="Ltensorflow/functions/from_nested_row_splits" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
       <class name="from_row_lengths" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self values row_lengths name validate">
-          <new def="res" class="Ltensorflow/functions/from_row_lengths" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
       <class name="from_row_limits" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self values row_limits name validate">
-          <new def="res" class="Ltensorflow/functions/from_row_limits" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
       <class name="from_row_splits" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self values row_splits name validate">
-          <new def="res" class="Ltensorflow/functions/from_row_splits" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
       <class name="from_row_starts" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self values row_starts name validate">
-          <new def="res" class="Ltensorflow/functions/from_row_starts" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
       <class name="from_value_rowids" allocatable="true">
         <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self values value_rowids nrows name validate">
-          <new def="res" class="Ltensorflow/functions/from_value_rowids" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
       <class name="boolean_mask" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/boolean_mask -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/functions/boolean_mask" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="tensor mask axis name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/boolean_mask. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self tensor mask axis name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="linspace" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/linspace -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/functions/linspace" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="start stop num name axis">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/api_docs/python/tf/linspace — direct `<new>+<return>` per wala/ML#380's preferred pattern (was `read_data`). Routes to `Linspace` for shape-from-`num` and dtype-from-`start` (wala/ML#449 Tier 7). -->
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self start stop num name axis">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="stack" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/stack -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/functions/stack" />
-          <return value="x" />
-        </method>
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="value axis name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/stack. Direct `<new>+<return>` paired with the dedicated `Stack` generator (wala/ML#449 Tier 5): the generator computes the precise output shape `t.shape[:axis] + (len(values),) + t.shape[axis:]` from the `values` list's PTS-derived
+          length and the first element's shape, and inherits the dtype from the first element. Pre-fix the XML routed through `convert_to_tensor` which inherited the first element's shape verbatim — sound on dtype but unsound on shape (missed the new axis). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self values axis name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
       <class name="unstack" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/unstack -->
-        <method name="read_data" descriptor="()LRoot;">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/unstack. Inlined per wala/ML#380 (was a `read_data` materialization chain). Returns a list whose first element is a constant-materialized tensor. -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self value num axis name">
           <new def="x" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
           <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="x" value="y" />
           <return value="x" />
         </method>
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="value num axis name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
-        </method>
       </class>
       <class name="dynamic_partition" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dynamic_partition -->
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="data partitions num_partitions name">
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self data partitions num_partitions name">
           <new def="x" class="Llist" />
           <new def="z" class="Ltensorflow/functions/constant" />
           <call class="Ltensorflow/functions/constant" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="1" numArgs="2" def="y" />
@@ -1733,7 +2052,7 @@
       </class>
       <class name="dynamic_stitch" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/dynamic_stitch -->
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="indices data name">
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self indices data name">
           <getfield class="Llist" field="0" fieldType="LRoot" ref="data" def="x" />
           <new def="z" class="Ltensorflow/functions/convert_to_tensor" />
           <call class="Ltensorflow/functions/convert_to_tensor" name="do" descriptor="()LRoot;" type="virtual" arg0="z" arg1="x" numArgs="2" def="y" />
@@ -1792,7 +2111,7 @@
       <class name="softmax" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/softmax. Fresh allocation (not pass-through); shape / dtype inferred from `logits` by the `Softmax` generator. See the rationale on `sigmoid.do()` in this file. -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self logits axis name">
-          <new def="res" class="Ltensorflow/functions/softmax" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
@@ -1800,7 +2119,7 @@
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/sparse_softmax_cross_entropy_with_logits -->
         <!-- Returns a fresh loss tensor of shape `logits.shape[:-1]` and dtype float32 — does NOT return `labels`. `SoftmaxCrossEntropy` computes the output type. -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self labels logits name">
-          <new def="res" class="Ltensorflow/functions/sparse_softmax_cross_entropy_with_logits" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <return value="res" />
         </method>
       </class>
@@ -1812,17 +2131,51 @@
           <return value="y" />
         </method>
       </class>
+      <class name="relu" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/relu. Direct `<new>+<return>` intended to be paired with the dedicated `Relu` generator (full-passthrough on shape and dtype). CURRENT LIMITATION: the dispatch is bypassed by the retained `tf.nn.relu` `pass_through` alias (kept
+          because removing it risks breaking chained consumers; same integration shape as `cast`, see wala/ML#509). Tracked together with wala/ML#481. -->
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self features name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="cast" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/cast. Direct `<new>+<return>` paired with the dedicated `Cast` generator: shape inherits from `x`; dtype intended to be the explicit `dtype` argument. CURRENT LIMITATION: the dispatch is bypassed by the retained `tf.cast` `pass_through`
+          alias (kept because removing it breaks chained consumers; see wala/ML#509), so the analyzer reports the input dtype today. Tracked by wala/ML#481. -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self x dtype name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="expand_dims" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/expand_dims. Direct `<new>+<return>` paired with the dedicated `ExpandDims` generator: dtype inherits from `input`; shape is `input.shape` with a length-1 dim inserted at `axis` (currently emitted as ⊤ pending the axis-aware shape
+          composer). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self input axis name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="clip_by_value" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/clip_by_value. Direct `<new>+<return>` paired with the dedicated `ClipByValue` generator (full-passthrough on shape and dtype of `t`). -->
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self t clip_value_min clip_value_max name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
+      <class name="leaky_relu" allocatable="true">
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/nn/leaky_relu. Direct `<new>+<return>` paired with the dedicated `LeakyRelu` generator (full-passthrough on shape and dtype of `features`). -->
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self features alpha name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
+        </method>
+      </class>
     </package>
     <package name="tensorflow/functions/image">
       <class name="extract_patches" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/extract_patches#example -->
-        <method name="read_data" descriptor="()LRoot;">
-          <new def="x" class="Ltensorflow/python/functions/image/extract_patches" />
-          <return value="x" />
-        </method>
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/image/extract_patches#example. Direct `<new>+<return>` per wala/ML#380 (was a `read_data` materialization chain). -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self images sizes strides rates padding name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" def="x" />
-          <return value="x" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
     </package>
@@ -1839,7 +2192,7 @@
       <class name="EstimatorSpec" allocatable="true">
         <!-- https://www.tensorflow.org/api_docs/python/tf/estimator/EstimatorSpec — fresh allocation (not pass-through) so the resulting spec is a distinct object from any input. Each named parameter is stored as a field on the result, mirroring the namedtuple shape of the real API. See wala/ML#429. -->
         <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self mode predictions loss train_op eval_metric_ops export_outputs">
-          <new def="res" class="Ltensorflow/estimator/EstimatorSpec" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
           <putfield class="LRoot" field="mode" fieldType="LRoot" ref="res" value="mode" />
           <putfield class="LRoot" field="predictions" fieldType="LRoot" ref="res" value="predictions" />
           <putfield class="LRoot" field="loss" fieldType="LRoot" ref="res" value="loss" />
@@ -2015,9 +2368,10 @@
         </method>
       </class>
       <class name="gradient" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/GradientTape#gradient -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/GradientTape#gradient — fresh allocation (not pass-through of `sources`). The dedicated `Gradient` generator inherits shape and dtype from the `sources` argument. See wala/ML#430. -->
         <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self target sources output_gradients unconnected_gradients">
-          <return value="sources" />
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
     </package>
@@ -2374,10 +2728,10 @@
         </method>
       </class>
       <class name="reduce" allocatable="true">
-        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#reduce -->
+        <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#reduce. `Dataset.reduce(initial_state, reduce_func, name)` returns the *final state* — a tensor (or structure of tensors) with the same shape/dtype as `initial_state`, not a Dataset. Pre-fix this was modeled as `read_data(arg0)`
+          virtually on the receiver, but the `reduce` class doesn't define `read_data` — the call couldn't resolve and the result was ⊤. Pass `initial_state` through directly so its tensor type flows to the caller. See wala/ML#456. -->
         <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self initial_state reduce_func name">
-          <call class="LRoot" name="read_data" descriptor="()LRoot;" type="virtual" arg0="arg0" numArgs="1" def="xx" />
-          <return value="xx" />
+          <return value="initial_state" />
         </method>
       </class>
       <class name="enumerate" allocatable="true">
@@ -2416,7 +2770,7 @@
     <package name="tensorflow/data/Dataset">
       <class name="from_tensors" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#from_tensors -->
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="tensors name">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self tensors name">
           <!-- FIXME: We should encode the tensors argument here. See https://github.com/wala/ML/issues/164. -->
           <new def="x" class="Ltensorflow/data/Dataset" />
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. Because WALA uses 1-CFA context sensitivity for general methods, if we were to centralize this logic into a single shared helper method (like `read_dataset` or an `init_fields` method), 1-CFA would merge all
@@ -2449,7 +2803,7 @@
       </class>
       <class name="from_tensor_slices" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#from_tensor_slices -->
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="tensors name">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self tensors name">
           <!-- NOTE: This block of dataset field initializations is duplicated across all dataset methods (e.g., from_tensor_slices, shuffle, batch) intentionally. Because WALA uses 1-CFA context sensitivity for general methods, if we were to centralize this logic into a single shared helper method (like
             `read_dataset` or an `init_fields` method), 1-CFA would merge all calls from the user's script to that helper. This would cause all dataset instances in the user's program to share the exact same internal object fields, leading to massive aliasing and loss of precision for tensor shapes/dtypes in chained
             operations. By inlining these allocations directly into each endpoint's `do` method, each dataset operation gets a unique allocation site, preserving the call site context and preventing aliasing. -->
@@ -2484,7 +2838,7 @@
       </class>
       <class name="sample_from_datasets" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#sample_from_datasets -->
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="datasets weights seed stop_on_empty_dataset">
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self datasets weights seed stop_on_empty_dataset">
           <new def="x" class="Ltensorflow/data/Dataset" />
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. Because WALA uses 1-CFA context sensitivity for general methods, if we were to centralize this logic into a single shared helper method (like `read_dataset` or an `init_fields` method), 1-CFA would merge all
             calls from the user's script to that helper. This would cause all dataset instances in the user's program to share the exact same internal object fields, leading to massive aliasing and loss of precision for tensor shapes/dtypes in chained operations. By inlining these allocations directly into each
@@ -2516,7 +2870,7 @@
       </class>
       <class name="list_files" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#list_files -->
-        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="file_pattern shuffle seed name">
+        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="self file_pattern shuffle seed name">
           <new def="x" class="Ltensorflow/data/Dataset" />
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. Because WALA uses 1-CFA context sensitivity for general methods, if we were to centralize this logic into a single shared helper method (like `read_dataset` or an `init_fields` method), 1-CFA would merge all
             calls from the user's script to that helper. This would cause all dataset instances in the user's program to share the exact same internal object fields, leading to massive aliasing and loss of precision for tensor shapes/dtypes in chained operations. By inlining these allocations directly into each
@@ -2548,7 +2902,7 @@
       </class>
       <class name="choose_from_datasets" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#choose_from_datasets -->
-        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="datasets choice_dataset stop_on_empty_dataset">
+        <method name="do" descriptor="()LRoot;" numArgs="4" paramNames="self datasets choice_dataset stop_on_empty_dataset">
           <new def="x" class="Ltensorflow/data/Dataset" />
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. Because WALA uses 1-CFA context sensitivity for general methods, if we were to centralize this logic into a single shared helper method (like `read_dataset` or an `init_fields` method), 1-CFA would merge all
             calls from the user's script to that helper. This would cause all dataset instances in the user's program to share the exact same internal object fields, leading to massive aliasing and loss of precision for tensor shapes/dtypes in chained operations. By inlining these allocations directly into each
@@ -2580,7 +2934,7 @@
       </class>
       <class name="from_generator" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#from_generator -->
-        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="generator output_types output_shapes args output_signature name">
+        <method name="do" descriptor="()LRoot;" numArgs="7" paramNames="self generator output_types output_shapes args output_signature name">
           <new def="x" class="Ltensorflow/data/Dataset" />
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. Because WALA uses 1-CFA context sensitivity for general methods, if we were to centralize this logic into a single shared helper method (like `read_dataset` or an `init_fields` method), 1-CFA would merge all
             calls from the user's script to that helper. This would cause all dataset instances in the user's program to share the exact same internal object fields, leading to massive aliasing and loss of precision for tensor shapes/dtypes in chained operations. By inlining these allocations directly into each
@@ -2612,7 +2966,7 @@
       </class>
       <class name="zip" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#zip -->
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="datasets name">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self datasets name">
           <new def="x" class="Ltensorflow/data/Dataset" />
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. Because WALA uses 1-CFA context sensitivity for general methods, if we were to centralize this logic into a single shared helper method (like `read_dataset` or an `init_fields` method), 1-CFA would merge all
             calls from the user's script to that helper. This would cause all dataset instances in the user's program to share the exact same internal object fields, leading to massive aliasing and loss of precision for tensor shapes/dtypes in chained operations. By inlining these allocations directly into each
@@ -2645,7 +2999,7 @@
       </class>
       <class name="range" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#range -->
-        <method name="do" descriptor="()LRoot;" numArgs="5" paramNames="start stop step output_type name">
+        <method name="do" descriptor="()LRoot;" numArgs="6" paramNames="self start stop step output_type name">
           <new def="x" class="Ltensorflow/data/Dataset" />
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. Because WALA uses 1-CFA context sensitivity for general methods, if we were to centralize this logic into a single shared helper method (like `read_dataset` or an `init_fields` method), 1-CFA would merge all
             calls from the user's script to that helper. This would cause all dataset instances in the user's program to share the exact same internal object fields, leading to massive aliasing and loss of precision for tensor shapes/dtypes in chained operations. By inlining these allocations directly into each
@@ -2677,7 +3031,7 @@
       </class>
       <class name="random" allocatable="true">
         <!-- https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/data/Dataset#random -->
-        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="seed name">
+        <method name="do" descriptor="()LRoot;" numArgs="3" paramNames="self seed name">
           <new def="x" class="Ltensorflow/data/Dataset" />
           <!-- NOTE: This block of dataset field initializations is duplicated intentionally. Because WALA uses 1-CFA context sensitivity for general methods, if we were to centralize this logic into a single shared helper method (like `read_dataset` or an `init_fields` method), 1-CFA would merge all
             calls from the user's script to that helper. This would cause all dataset instances in the user's program to share the exact same internal object fields, leading to massive aliasing and loss of precision for tensor shapes/dtypes in chained operations. By inlining these allocations directly into each
@@ -2725,6 +3079,9 @@
           <new def="x" class="Ltensorflow/distribute/run/run" />
           <putfield class="LRoot" field="run" fieldType="LRoot" ref="self" value="x" />
           <putfield class="LRoot" field="experimental_run_v2" fieldType="LRoot" ref="self" value="x" />
+          <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function" />
+          <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
+          <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
           <return value="arg0" />
         </method>
       </class>
@@ -2733,6 +3090,9 @@
           <new def="x" class="Ltensorflow/distribute/run/run" />
           <putfield class="LRoot" field="run" fieldType="LRoot" ref="self" value="x" />
           <putfield class="LRoot" field="experimental_run_v2" fieldType="LRoot" ref="self" value="x" />
+          <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function" />
+          <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
+          <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
           <return value="arg0" />
         </method>
       </class>
@@ -2741,6 +3101,9 @@
           <new def="x" class="Ltensorflow/distribute/run/run" />
           <putfield class="LRoot" field="run" fieldType="LRoot" ref="self" value="x" />
           <putfield class="LRoot" field="experimental_run_v2" fieldType="LRoot" ref="self" value="x" />
+          <new def="ddff" class="Ltensorflow/distribute/run/distribute_datasets_from_function" />
+          <putfield class="LRoot" field="distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
+          <putfield class="LRoot" field="experimental_distribute_datasets_from_function" fieldType="LRoot" ref="self" value="ddff" />
           <return value="arg0" />
         </method>
       </class>
@@ -2758,6 +3121,40 @@
           <getfield class="LRoot" field="0" fieldType="LRoot" ref="arg2" def="x" />
           <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="x" numArgs="2" def="v" />
           <return value="v" />
+        </method>
+      </class>
+      <!-- https://www.tensorflow.org/api_docs/python/tf/distribute/Strategy#distribute_datasets_from_function — at runtime `strategy.distribute_datasets_from_function(dataset_fn)` invokes `dataset_fn(input_context)` once per replica and wraps the results in a distributed-dataset object. This synthetic-method
+        body approximates: it allocates a stub `InputContext`, synchronously calls `dataset_fn` with it (single time, single context), and returns the callback's result directly &mdash; no distributed-dataset wrapper. The result is that the callback's body becomes analyzable, which is what wala/ML#113 requires
+        for typing the Datasets that flow out of `dataset_fn`. Modeling a distinct distributed-dataset wrapper type would be additional typing precision on the *return* value (the wrapper's element type tracks the inner dataset's element type); not modeled here because the issue's reported scenario only consumes
+        the wrapper as an opaque object, not as a typed dataset. The deprecated alias `experimental_distribute_datasets_from_function` is wired to the same class on each strategy. -->
+      <class name="distribute_datasets_from_function" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self dataset_fn">
+          <new def="ctx" class="Ltensorflow/distribute/InputContext" />
+          <constant name="num_pipelines" type="int" value="1" />
+          <constant name="pipeline_id" type="int" value="0" />
+          <putfield class="LRoot" field="num_input_pipelines" fieldType="LRoot" ref="ctx" value="num_pipelines" />
+          <putfield class="LRoot" field="input_pipeline_id" fieldType="LRoot" ref="ctx" value="pipeline_id" />
+          <new def="batch_fn" class="Ltensorflow/distribute/InputContext/get_per_replica_batch_size" />
+          <putfield class="LRoot" field="get_per_replica_batch_size" fieldType="LRoot" ref="ctx" value="batch_fn" />
+          <call class="LRoot" name="do" descriptor="()LRoot;" type="virtual" arg0="arg1" arg1="ctx" numArgs="2" def="v" />
+          <return value="v" />
+        </method>
+      </class>
+    </package>
+    <package name="tensorflow/distribute">
+      <class name="InputContext" allocatable="true">
+        <!-- Modeled stub for the `tf.distribute.InputContext` instance passed to the user's `dataset_fn` callback by `distribute_datasets_from_function`. The real class exposes the integer attributes `num_input_pipelines` and `input_pipeline_id` plus the method `get_per_replica_batch_size(global_batch_size)`,
+          which divides the global batch size by the number of replicas. The fields are populated at allocation time in `distribute_datasets_from_function`'s synthetic body: integer constants for the two attributes (placeholders &mdash; the analyzer doesn't track per-replica shard counts statically) and a `get_per_replica_batch_size`
+          callable that returns its `global_batch_size` argument unchanged (an upper-bound approximation; precise per-replica division would require static replica-count modeling). None of these flow into tensor shape or dtype, so the placeholder values don't affect the typing of the Datasets `dataset_fn` produces
+          &mdash; the modeling exists so that reads of `input_context.num_input_pipelines` etc. don't surface as ⊤ at use sites in user code. -->
+      </class>
+    </package>
+    <package name="tensorflow/distribute/InputContext">
+      <class name="get_per_replica_batch_size" allocatable="true">
+        <!-- `input_context.get_per_replica_batch_size(global_batch_size)` returns `global_batch_size / num_replicas` at runtime. This synthetic body returns `global_batch_size` unchanged &mdash; an upper bound, used because we don't track replica counts statically and the caller's typing on the returned
+          int doesn't depend on the precise division (only that it's an int). -->
+        <method name="do" descriptor="()LRoot;" numArgs="2" paramNames="self global_batch_size">
+          <return value="arg1" />
         </method>
       </class>
     </package>
@@ -2980,6 +3377,341 @@
           <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
           <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
           <return value="ret" />
+        </method>
+      </class>
+    </package>
+    <package name="tensorflow/keras/datasets/imdb">
+      <!-- https://www.tensorflow.org/api_docs/python/tf/keras/datasets/imdb/load_data -->
+      <class name="x_train" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/imdb/x_train" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="y_train" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/imdb/y_train" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="x_test" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/imdb/x_test" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="y_test" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/imdb/y_test" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="load_data" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/imdb/x_train" />
+          <call class="Ltensorflow/keras/datasets/imdb/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/imdb/y_train" />
+          <call class="Ltensorflow/keras/datasets/imdb/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
+          <new def="train" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/imdb/x_test" />
+          <call class="Ltensorflow/keras/datasets/imdb/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/imdb/y_test" />
+          <call class="Ltensorflow/keras/datasets/imdb/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
+          <new def="test" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
+          <new def="ret" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
+          <return value="ret" />
+        </method>
+      </class>
+    </package>
+    <package name="tensorflow/keras/datasets/fashion_mnist">
+      <!-- https://www.tensorflow.org/api_docs/python/tf/keras/datasets/fashion_mnist/load_data — same shapes and dtype as `mnist.load_data()`. -->
+      <class name="x_train" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/x_train" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="y_train" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/y_train" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="x_test" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/x_test" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="y_test" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/fashion_mnist/y_test" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="load_data" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/fashion_mnist/x_train" />
+          <call class="Ltensorflow/keras/datasets/fashion_mnist/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/fashion_mnist/y_train" />
+          <call class="Ltensorflow/keras/datasets/fashion_mnist/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
+          <new def="train" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/fashion_mnist/x_test" />
+          <call class="Ltensorflow/keras/datasets/fashion_mnist/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/fashion_mnist/y_test" />
+          <call class="Ltensorflow/keras/datasets/fashion_mnist/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
+          <new def="test" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
+          <new def="ret" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
+          <return value="ret" />
+        </method>
+      </class>
+    </package>
+    <package name="tensorflow/keras/datasets/cifar100">
+      <!-- https://www.tensorflow.org/api_docs/python/tf/keras/datasets/cifar100/load_data — shapes match `cifar10.load_data()` (so the dispatch reuses `Cifar10InputData`); image arrays carry `uint8`. Note: cifar100's label arrays are `int64` at runtime (vs `uint8` for cifar10) — a runtime-dtype divergence
+        the analyzer doesn't yet capture, see wala/ML#487. -->
+      <class name="x_train" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/x_train" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="y_train" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/y_train" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="x_test" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/x_test" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="y_test" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/cifar100/y_test" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="load_data" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/cifar100/x_train" />
+          <call class="Ltensorflow/keras/datasets/cifar100/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/cifar100/y_train" />
+          <call class="Ltensorflow/keras/datasets/cifar100/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
+          <new def="train" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/cifar100/x_test" />
+          <call class="Ltensorflow/keras/datasets/cifar100/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/cifar100/y_test" />
+          <call class="Ltensorflow/keras/datasets/cifar100/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
+          <new def="test" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
+          <new def="ret" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
+          <return value="ret" />
+        </method>
+      </class>
+    </package>
+    <package name="tensorflow/keras/datasets/reuters">
+      <!-- https://www.tensorflow.org/api_docs/python/tf/keras/datasets/reuters/load_data — newswire-classification corpus, variable-length integer-encoded sequences. -->
+      <class name="x_train" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/reuters/x_train" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="y_train" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/reuters/y_train" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="x_test" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/reuters/x_test" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="y_test" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/reuters/y_test" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="load_data" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/reuters/x_train" />
+          <call class="Ltensorflow/keras/datasets/reuters/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/reuters/y_train" />
+          <call class="Ltensorflow/keras/datasets/reuters/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
+          <new def="train" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/reuters/x_test" />
+          <call class="Ltensorflow/keras/datasets/reuters/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/reuters/y_test" />
+          <call class="Ltensorflow/keras/datasets/reuters/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
+          <new def="test" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
+          <new def="ret" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
+          <return value="ret" />
+        </method>
+      </class>
+    </package>
+    <package name="tensorflow/keras/datasets/boston_housing">
+      <!-- https://www.tensorflow.org/api_docs/python/tf/keras/datasets/boston_housing/load_data — small numeric regression dataset, all float64. -->
+      <class name="x_train" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/x_train" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="y_train" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/y_train" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="x_test" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/x_test" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="y_test" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="ret" class="Ltensorflow/keras/datasets/boston_housing/y_test" />
+          <new def="astype_fn" class="Lnumpy/ndarray/astype" />
+          <putfield class="LRoot" field="astype" fieldType="LRoot" ref="ret" value="astype_fn" />
+          <new def="reshape_fn" class="Lnumpy/ndarray/reshape" />
+          <putfield class="LRoot" field="reshape" fieldType="LRoot" ref="ret" value="reshape_fn" />
+          <return value="ret" />
+        </method>
+      </class>
+      <class name="load_data" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="1" paramNames="self">
+          <new def="x_train_fn" class="Ltensorflow/keras/datasets/boston_housing/x_train" />
+          <call class="Ltensorflow/keras/datasets/boston_housing/x_train" name="do" type="virtual" def="x_train" descriptor="()LRoot;" arg0="x_train_fn" numArgs="1" />
+          <new def="y_train_fn" class="Ltensorflow/keras/datasets/boston_housing/y_train" />
+          <call class="Ltensorflow/keras/datasets/boston_housing/y_train" name="do" type="virtual" def="y_train" descriptor="()LRoot;" arg0="y_train_fn" numArgs="1" />
+          <new def="train" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="train" value="x_train" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="train" value="y_train" />
+          <new def="x_test_fn" class="Ltensorflow/keras/datasets/boston_housing/x_test" />
+          <call class="Ltensorflow/keras/datasets/boston_housing/x_test" name="do" type="virtual" def="x_test" descriptor="()LRoot;" arg0="x_test_fn" numArgs="1" />
+          <new def="y_test_fn" class="Ltensorflow/keras/datasets/boston_housing/y_test" />
+          <call class="Ltensorflow/keras/datasets/boston_housing/y_test" name="do" type="virtual" def="y_test" descriptor="()LRoot;" arg0="y_test_fn" numArgs="1" />
+          <new def="test" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="test" value="x_test" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="test" value="y_test" />
+          <new def="ret" class="Ltuple" />
+          <putfield class="LRoot" field="0" fieldType="LRoot" ref="ret" value="train" />
+          <putfield class="LRoot" field="1" fieldType="LRoot" ref="ret" value="test" />
+          <return value="ret" />
+        </method>
+      </class>
+    </package>
+    <package name="tensorflow/strings">
+      <!-- https://www.tensorflow.org/api_docs/python/tf/strings/as_string. Shape passthrough on `input`; output dtype is fixed to `string`. -->
+      <class name="as_string" allocatable="true">
+        <method name="do" descriptor="()LRoot;" numArgs="8" paramNames="self input precision scientific shortest width fill name">
+          <new def="res" class="Ltensorflow/python/framework/ops/Tensor" />
+          <return value="res" />
         </method>
       </class>
     </package>

--- a/edu.cuny.hunter.hybridize.core/turtles.xml
+++ b/edu.cuny.hunter.hybridize.core/turtles.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<!DOCTYPE summary-spec>
+<!-- Pandas model -->
+<summary-spec>
+  <classloader name="PythonLoader">
+    <class name="numpy" allocatable="true">
+      <method name="import" static="true" descriptor="()Lnumpy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+    <class name="sklearn" allocatable="true">
+      <method name="import" static="true" descriptor="()Lsklearn;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+    <class name="pandas" allocatable="true">
+      <method name="import" static="true" descriptor="()Lpandas;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+    <class name="patsy" allocatable="true">
+      <method name="import" static="true" descriptor="()Lpatsy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+    <class name="seaborn" allocatable="true">
+      <method name="import" static="true" descriptor="()Lseaborn;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+    <class name="statsmodels" allocatable="true">
+      <method name="import" static="true" descriptor="()Lstatsmodels;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+    <class name="scipy" allocatable="true">
+      <method name="import" static="true" descriptor="()Lscipy;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+    <class name="matplotlib" allocatable="true">
+      <method name="import" static="true" descriptor="()Lmatplotlib;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+    <class name="IPython" allocatable="true">
+      <method name="import" static="true" descriptor="()LIPython;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+    <class name="mpl_toolkits" allocatable="true">
+      <method name="import" static="true" descriptor="()Lmpl_toolkits;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+    <class name="tensorflow" allocatable="true">
+      <method name="import" static="true" descriptor="()Ltensorflow;">
+        <new def="x" class="Lturtle" />
+        <putfield class="Lturtle" field="any" fieldType="LRoot" ref="x" value="x" />
+        <return value="x" />
+      </method>
+    </class>
+  </classloader>
+</summary-spec>

--- a/edu.cuny.hunter.hybridize.core/turtles.xml
+++ b/edu.cuny.hunter.hybridize.core/turtles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- Pandas model -->
+<!-- General turtle stubs (placeholder summaries spanning multiple libraries). -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">

--- a/edu.cuny.hunter.hybridize.core/turtles.xml
+++ b/edu.cuny.hunter.hybridize.core/turtles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!DOCTYPE summary-spec>
-<!-- General turtle stubs (placeholder summaries spanning multiple libraries). -->
+<!-- Pandas model -->
 <summary-spec>
   <classloader name="PythonLoader">
     <class name="numpy" allocatable="true">

--- a/edu.cuny.hunter.hybridize.core/update_summaries.sh
+++ b/edu.cuny.hunter.hybridize.core/update_summaries.sh
@@ -14,5 +14,7 @@ cp "$ML_PATH/com.ibm.wala.cast.python/data/pandas.xml" .
 cp "$ML_PATH/com.ibm.wala.cast.python/data/pytest.xml" .
 cp "$ML_PATH/com.ibm.wala.cast.python/data/click.xml" .
 cp "$ML_PATH/com.ibm.wala.cast.python/data/abseil.xml" .
+cp "$ML_PATH/com.ibm.wala.cast.python/data/numpy_turtle.xml" .
+cp "$ML_PATH/com.ibm.wala.cast.python/data/turtles.xml" .
 cp "$ML_PATH/com.ibm.wala.cast.python.ml/data/tensorflow.xml" .
 cp "$ML_PATH/com.ibm.wala.cast.python.ml/data/numpy.xml" .

--- a/edu.cuny.hunter.hybridize.feature/feature.xml
+++ b/edu.cuny.hunter.hybridize.feature/feature.xml
@@ -286,7 +286,7 @@ version(s), and exceptions or additional permissions here}.&quot;
     <discovery label="The Eclipse Project repository" url="https://download.eclipse.org/eclipse/updates/4.39" />
     <discovery label="Common Refactoring Framework Update Site" url="https://raw.githubusercontent.com/ponder-lab/Common-Eclipse-Refactoring-Framework/master/edu.cuny.citytech.refactoring.common.updatesite" />
     <discovery label="PyDev Update Site" url="https://raw.githubusercontent.com/ponder-lab/Pydev/pydev_9_3/org.python.pydev.updatesite" />
-    <discovery label="PONDER Lab WALA Update Site" url="https://raw.githubusercontent.com/ponder-lab/WALA/v1.6/com.ibm.wala-repository" />
+    <discovery label="PONDER Lab WALA Update Site" url="https://raw.githubusercontent.com/ponder-lab/WALA/v1.7/com.ibm.wala-repository" />
   </url>
   <includes id="com.ibm.wala.ide_feature" version="0.0.0" />
   <includes id="org.python.pydev.feature" version="0.0.0" />

--- a/edu.cuny.hunter.hybridize.updatesite/category.xml
+++ b/edu.cuny.hunter.hybridize.updatesite/category.xml
@@ -10,5 +10,5 @@
   <repository-reference location="http://download.eclipse.org/eclipse/updates/4.25" enabled="true" />
   <repository-reference location="https://raw.githubusercontent.com/ponder-lab/Common-Eclipse-Refactoring-Framework/master/edu.cuny.citytech.refactoring.common.updatesite" enabled="true" />
   <repository-reference location="https://raw.githubusercontent.com/ponder-lab/Pydev/pydev_9_3/org.python.pydev.updatesite" enabled="true" />
-  <repository-reference location="https://raw.githubusercontent.com/ponder-lab/WALA/v1.6/com.ibm.wala-repository" enabled="true" />
+  <repository-reference location="https://raw.githubusercontent.com/ponder-lab/WALA/v1.7/com.ibm.wala-repository" enabled="true" />
 </site>

--- a/hybridize.target
+++ b/hybridize.target
@@ -27,7 +27,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.42.0</version>
+					<version>0.43.0</version>
 					<type>jar</type>
 				</dependency>
 			</dependencies>

--- a/hybridize.target
+++ b/hybridize.target
@@ -19,8 +19,8 @@
 			<unit id="edu.cuny.citytech.refactoring.common.feature.feature.group" version="5.2.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://raw.githubusercontent.com/ponder-lab/WALA/v1.6/com.ibm.wala-repository"/>
-			<unit id="com.ibm.wala.ide_feature.feature.group" version="1.6.2.202310101608"/>
+			<repository location="https://raw.githubusercontent.com/ponder-lab/WALA/v1.7/com.ibm.wala-repository"/>
+			<unit id="com.ibm.wala.ide_feature.feature.group" version="1.7.1.202605120352"/>
 		</location>
 		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 			<dependencies>


### PR DESCRIPTION
## Summary

Closes #470. Bumps `hybridize.target`'s Ariadne pin from `0.42.0` to `0.43.0`, and (transitively) the `ponder-lab/WALA` p2 update site from `v1.6` to `v1.7` because Ariadne 0.43.0 advanced its WALA dependency from `1.6.12` to `1.7.1`.

The motivating Ariadne change is wala/ML#519's new `TensorType.getDType()` accessor, which lets dtype-aware code drop the round-trip `DType.valueOf(tensorType.getCellType().toUpperCase())`. Other 0.43.0 content (`ClientDriver` argv-shape validation, defensive `NumberFormatException` catches, dead-code removal) is transitively consumed without any Hybridize-side wiring.

## WALA Update Site Bump

Ariadne 0.43.0 is built against WALA 1.7.1, which is binary-incompatible with the `com.ibm.wala.ide` bundle on the existing `ponder-lab/WALA/v1.6` p2 site (manifesting at runtime as `AbstractMethodError: AstTranslator.doFieldWrite`). A new `ponder-lab/WALA/v1.7` p2 branch was published with the matching fat bundle (see https://github.com/ponder-lab/WALA/tree/v1.7); this PR points all four downstream consumers at it:

- `hybridize.target` repository unit
- `edu.cuny.hunter.hybridize.updatesite/category.xml` `repository-reference`
- `edu.cuny.hunter.hybridize.feature/feature.xml` `discovery` URL
- `README.md`, `CONTRIBUTING.md`, `CLAUDE.md` documentation pointers

`CONTRIBUTING.md`'s "Why WALA Comes From..." section explains the structural reason WALA must come from a `ponder-lab/WALA` p2 branch (rather than Maven Central) and links to the wiki procedure for cutting a new branch on future Ariadne bumps that advance WALA.

## Migration of the `DType.valueOf` Call Site

`testInferredTensorTypes` on #463 is the only current call site of the round-trip pattern. That migration is left to fold into #463 once it rebases onto this commit; doing it here would touch #463's still-in-flight file.

## `AVOID_DUMP` API Migration

WALA 1.7.1 changed `CAstCallGraphUtil.AVOID_DUMP` from `public static boolean` to `public static final ThreadLocal<Boolean>`. The single call site in `HybridizeFunctionRefactoringProcessor` is migrated to `AVOID_DUMP.set(...)`.

## Test Plan

- [x] `./mvnw install -DskipTests=true` green locally.
- [x] `./mvnw verify` green locally — 469 tests, 0 errors, 0 failures, 11 skipped (full parity with the pre-bump v1.6 baseline).
- [x] Tycho CI green on this branch.
- [ ] No regression in pre-existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
