### PR TITLE
Classify `def f(self):` as an instance method

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1654,7 +1654,7 @@ public class Function {
 	 */
 	public boolean isMethod() {
 		List<Parameter> parameters = this.getParameters();
-		return parameters.size() > 1 && parameters.get(0).isSelf();
+		return parameters.size() >= 1 && parameters.get(0).isSelf();
 	}
 
 	protected void setHasPythonSideEffects(Boolean hasPythonSideEffects) {

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSelfOnlyMethod/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSelfOnlyMethod/in/A.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+
+class C:
+
+    @tf.function
+    def f(self):
+        return tf.constant(1)
+
+
+C().f()

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSelfOnlyMethod/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSelfOnlyMethod/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8093,4 +8093,20 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(1, Arrays.stream(f.getStatus().getEntries()).filter(e -> e.getSeverity() == INFO)
 				.filter(e -> e.getCode() == SPECULATIVE_ANALYSIS.getCode()).count());
 	}
+
+	/**
+	 * Regression test for https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/324: a method whose only parameter is
+	 * {@code self} (e.g., {@code def f(self):}) was previously misclassified as not-a-method because {@link Function#isMethod} required
+	 * {@code parameters.size() > 1}. After the fix it requires {@code >= 1}.
+	 */
+	@Test
+	public void testSelfOnlyMethod() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		assertEquals("C.f", function.getIdentifier());
+		assertEquals(1, function.getNumberOfParameters());
+		assertTrue("A method whose only parameter is `self` should be classified as a method.", function.isMethod());
+	}
 }


### PR DESCRIPTION
## Summary

Closes #324. `Function.isMethod()` required `parameters.size() > 1`, so a Python method whose only parameter is `self` (e.g., `def __init__(self):`) was misclassified as not-a-method. The evaluator CSV column cited in #324 (`ConvNet.__init__` shown as `FALSE` for "method") traced back to this exact predicate.

## Change

One-line predicate relaxation in `Function.isMethod()`:

```diff
-return parameters.size() > 1 && parameters.get(0).isSelf();
+return parameters.size() >= 1 && parameters.get(0).isSelf();
```

A function whose first parameter is named `self` is an instance method regardless of arity. Python's `__init__(self):`, `__del__(self):`, and any `def f(self):` previously misclassified are now correctly classified.

## Risk

The change only flips classification for functions where `parameters.size() == 1` and the first parameter is named `self`. In real Python code, top-level functions don't take a `self` parameter, so the false-positive surface is essentially zero.

## Regression Test

Adds `testSelfOnlyMethod` exercising the smallest concrete shape:

```python
class C:
    @tf.function
    def f(self):
        return tf.constant(1)
```

Test asserts `C.f` has 1 parameter and `isMethod() == true`. Fails on the prior behavior; passes after the fix.

## Verification

`./mvnw verify` green locally—471 tests, 0 errors, 0 failures, 11 skipped (was 470 + the new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
