### PR TITLE
Filter Spotless hook to file types it actually formats

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,14 @@ repos:
         entry: ./mvnw spotless:apply
         language: system
         pass_filenames: false
-        # Skip when the commit touches only binary files Spotless cannot
-        # format, so we do not pay JVM-startup latency for nothing. The
-        # generic `<format>` block in `pom.xml` uses `<include>**/*</include>`
-        # (trailing-whitespace + EOF-newline rules apply to every text file),
-        # so the right filter is to exclude binary extensions rather than to
-        # whitelist specific text ones. Spotless's repo-wide apply still runs
-        # when invoked, which is why `pass_filenames: false` stays.
-        exclude: '\.(jar|zip|class|exe|dll|png|jpg|jpeg|gif|pdf|so|dylib|ico|woff|woff2|ttf|otf|bin|tar|gz|tgz)$'
+        # Skip when the commit touches only binary files Spotless's `<format>`
+        # block in `pom.xml` already excludes, so we do not pay JVM-startup
+        # latency for nothing. Mirrors the pom's binary excludes exactly:
+        # any extension not in this list will still trigger the hook, and
+        # Spotless will apply (or skip) per its own rules. The generic
+        # `<format>` uses `<include>**/*</include>`, so the right filter is
+        # to exclude only what the pom already excludes -- not a broader set
+        # that would mask CI failures on non-pom-excluded files.
+        # Spotless's repo-wide apply still runs when invoked, which is why
+        # `pass_filenames: false` stays.
+        exclude: '\.(class|dll|exe|gif|jar|jpg|pdf|png|zip)$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,11 @@ repos:
         entry: ./mvnw spotless:apply
         language: system
         pass_filenames: false
+        # Skip when the commit touches only binary files Spotless cannot
+        # format, so we do not pay JVM-startup latency for nothing. The
+        # generic `<format>` block in `pom.xml` uses `<include>**/*</include>`
+        # (trailing-whitespace + EOF-newline rules apply to every text file),
+        # so the right filter is to exclude binary extensions rather than to
+        # whitelist specific text ones. Spotless's repo-wide apply still runs
+        # when invoked, which is why `pass_filenames: false` stays.
+        exclude: '\.(jar|zip|class|exe|dll|png|jpg|jpeg|gif|pdf|so|dylib|ico|woff|woff2|ttf|otf|bin|tar|gz|tgz)$'


### PR DESCRIPTION
## Summary

Follow-up to #477. Adds an `exclude:` filter to the local `spotless-apply` hook so it only fires when the commit touches at least one file Spotless can format.

Mirrors ponder-lab/ML#287's regex.

## Why a Blacklist, Not a Whitelist

The Spotless generic `<format>` block in `pom.xml` uses `<include>**/*</include>` with curated `<excludes>` (binaries, generated dirs). Trailing-whitespace and EOF-newline rules apply to every text file, not just `.md`/`.xml`/`.java`. A whitelist would skip commits touching only `.properties`/`.txt`/`.yml`/etc. and let them later fail `mvn spotless:check` in CI.

The correct shape skips only when the commit touches files Spotless cannot format:

```yaml
exclude: '\.(jar|zip|class|exe|dll|png|jpg|jpeg|gif|pdf|so|dylib|ico|woff|woff2|ttf|otf|bin|tar|gz|tgz)$'
```

The hook skips Spotless only when *every* staged file is a binary; any text file triggers Spotless, matching what `spotless:check` enforces in CI.

## Verification

`pre-commit run --all-files` green locally. The Spotless step runs on this commit (the YAML file is a text file Spotless does process), as expected.

## Cross-Refs

- #477: introduced the pre-commit config that this PR refines.
- ponder-lab/ML#287: sibling fix on the Ariadne side; Copilot reviewer caught the whitelist-shape bug there first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
