### PR TITLE
Replace `DType.valueOf(...)` round-trip with `TensorType.getDType()`

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1919,11 +1919,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertNotNull(inferred);
 		assertEquals("Two tensor types should be inferred (shape divergence, same dtype).", 2, inferred.size());
 
-		// Both dtype and shape must match the expected set. Cell-type strings are mapped to Ariadne's `DType` enum via the inverse of the
-		// canonical `dtype.name().toLowerCase()` Ariadne uses to produce them. Shapes are collapsed to integer lists to avoid depending
-		// on Dimension equality semantics.
+		// Both dtype and shape must match the expected set. Shapes are collapsed to integer lists to avoid depending on Dimension equality
+		// semantics.
 		Set<Map.Entry<DType, List<Integer>>> dtypesAndShapes = inferred.stream()
-				.map(tt -> Map.entry(DType.valueOf(tt.getCellType().toUpperCase()),
+				.map(tt -> Map.entry(tt.getDType(),
 						tt.getDims().stream()
 								.map(d -> d instanceof TensorType.NumericDim ? ((TensorType.NumericDim) d).value() : Integer.valueOf(-1))
 								.collect(Collectors.toList())))


### PR DESCRIPTION
## Summary

Completes the residual acceptance criterion #3 from #470 that #471 explicitly deferred. Replaces the only remaining call site of the cast-and-uppercase round-trip:

```java
DType.valueOf(tt.getCellType().toUpperCase())
```

with the typed accessor that wala/ML#519 added in Ariadne 0.43.0:

```java
tt.getDType()
```

The round-trip pattern paired `DType.name().toLowerCase()` (Ariadne's `cellType` producer) with `DType.valueOf(...)` (Hybridize's consumer); both ends now collapse into one round-trip-free accessor. The accompanying inline comment about "cell-type strings mapped via the inverse of `dtype.name().toLowerCase()`" is dropped since there's no inverse to describe; the clause about collapsing dimensions to integer lists stays (still relevant).

## Context

#471 bumped Ariadne to `0.43.0` (closing #470) but explicitly left this migration unmade — scoped to fold into #463 on rebase. #463 had already merged six days earlier, so the fold-on-rebase plan couldn't run and the migration silently dropped. This PR finishes that deferral.

## Test Plan

- [ ] Tycho CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)