### PR TITLE
Hoist `inferTensorTypes` to fire unconditionally on `isTensorTyped` entry

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -593,6 +593,13 @@ public final class Parameter {
 			if (this.isSelf())
 				return this.isTensor = FALSE;
 
+			// Populate the tensor-types cache up front whenever Ariadne has anything to say about this parameter, so subsequent reads via
+			// `getTensorTypes()` (no-arg) see a consistent value regardless of which classification phase below fires. In particular, the
+			// type-hint shortcut (Phase 1) `return`s before reaching the Ariadne query; populating here keeps the cache correct for
+			// type-hint parameters that Ariadne also classified from the call site.
+			if (!nodes.isEmpty())
+				this.inferTensorTypes(tensorAnalysis);
+
 			// check a special case where we consider type hints.
 			boolean followTypeHints = this.function.getAlwaysFollowTypeHints() || this.function.getHybridizationParameters() != null
 					// TODO: Actually get the value here (#111).
@@ -613,9 +620,8 @@ public final class Parameter {
 
 			// If this function is in the call graph.
 			if (!nodes.isEmpty()) {
-				// Phase 2: ask the parameter directly whether Ariadne associates any tensor type with it.
-				this.inferTensorTypes(tensorAnalysis);
-
+				// Phase 2: read the tensor-types cache populated above. If Ariadne associated any tensor type with this parameter, treat it
+				// as tensor-typed.
 				if (!this.getTensorTypes().isEmpty()) {
 					LOG.info(this.function + " likely has a tensor parameter: " + this.getName() + " due to tensor analysis.");
 					this.function.addInfo(TYPE_INFERENCING,

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferredTensorTypesUnderFollowTypeHints/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferredTensorTypesUnderFollowTypeHints/in/A.py
@@ -1,0 +1,19 @@
+# Regression fixture for #495. With `experimental_follow_type_hints=True` and a tensor-typed
+# type hint, `Parameter.isTensorTyped`'s Phase 1 returns true before Phase 2 (the Ariadne
+# query) runs. Before #496, that early return left the per-Parameter tensor-types cache
+# unpopulated, so downstream consumers reading `Parameter.getTensorTypes()` (no-arg) saw an
+# empty set even when Ariadne had a concrete `TensorType` for the parameter from the call
+# site. Hoisting `inferTensorTypes` to fire before Phase 1 closes the hole.
+
+import tensorflow as tf
+
+
+@tf.function(experimental_follow_type_hints=True)
+def func(t: tf.Tensor):
+    return t + 1
+
+
+x = tf.constant([1.0, 2.0])
+assert x.dtype == tf.float32
+assert x.shape == (2,)
+func(x)

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -8337,5 +8338,37 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 		assertFalse("Non-tensor type hint (`int`) must NOT classify the parameter as tensor-typed.", x.isTensor());
 		assertFalse("Function with no tensor classification: `getHasTensorParameter()` is FALSE.", function.getHasTensorParameter());
+	}
+
+	/**
+	 * Regression test for #495: under `experimental_follow_type_hints=True` with a `tf.Tensor` type hint, the per-Parameter tensor-types
+	 * cache must be populated even though `Parameter.classifyAsTensor`'s Phase 1 (type hints) returns true before Phase 2 (Ariadne query)
+	 * runs. Without the hoist landed in #496, `param.getTensorTypes()` returned the empty default for type-hint-classified parameters even
+	 * when Ariadne had a concrete `TensorType` from the call site.
+	 */
+	@Test
+	public void testInferredTensorTypesUnderFollowTypeHints() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertNotNull(functions);
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+		assertNotNull(function);
+		assertTrue("Function is decorated with `@tf.function(experimental_follow_type_hints=True)`.", function.isHybrid());
+		assertTrue("The `experimental_follow_type_hints` parameter is supplied on the `tf.function` decorator.",
+				function.getHybridizationParameters().isExperimentalFollowTypeHintsParamExists());
+		assertTrue("The function has a tensor parameter (via the type hint).", function.getHasTensorParameter());
+
+		List<Parameter> parameters = function.getParameters();
+		assertNotNull(parameters);
+		assertEquals(1, parameters.size());
+		Parameter t = parameters.get(0);
+		assertEquals("t", t.getName());
+
+		// The load-bearing assertion: the cache is populated from the call site's `tf.constant([1.0, 2.0])`, even though Phase 1's
+		// type-hint hit causes `classifyAsTensor` to return true before Phase 2 reads the cache. Without the hoist, this assertion fails
+		// (the cache stays at the empty default).
+		TensorType expected = new TensorType(DType.FLOAT32.name().toLowerCase(Locale.ROOT), List.of(new TensorType.NumericDim(2)));
+		assertEquals("Cache must be populated from Ariadne's call-site classification under followTypeHints.", Set.of(expected),
+				t.getTensorTypes());
 	}
 }

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -50,7 +50,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -122,6 +121,7 @@ import org.python.pydev.ui.BundleInfoStub;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.python.pydev.analysis.additionalinfo.AbstractAdditionalDependencyInfo;
 import com.python.pydev.analysis.additionalinfo.AdditionalProjectInterpreterInfo;
 
@@ -8060,10 +8060,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		// Both dtype and shape must match the expected set. Shapes are collapsed to integer lists to avoid depending on Dimension equality
 		// semantics.
 		Set<Map.Entry<DType, List<Integer>>> dtypesAndShapes = inferred.stream()
-				.map(tt -> Map.entry(tt.getDType(),
-						tt.getDims().stream()
-								.map(d -> d instanceof TensorType.NumericDim ? ((TensorType.NumericDim) d).value() : Integer.valueOf(-1))
-								.collect(Collectors.toList())))
+				.map(tt -> Map.entry(tt.getDType(), tt.getDims().stream()
+						.map(d -> d instanceof NumericDim ? ((NumericDim) d).value() : Integer.valueOf(-1)).collect(Collectors.toList())))
 				.collect(toSet());
 
 		Set<Map.Entry<DType, List<Integer>>> expected = Set.of(Map.entry(DType.FLOAT32, Arrays.asList(2, 1)),
@@ -8367,7 +8365,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		// The load-bearing assertion: the cache is populated from the call site's `tf.constant([1.0, 2.0])`, even though Phase 1's
 		// type-hint hit causes `classifyAsTensor` to return true before Phase 2 reads the cache. Without the hoist, this assertion fails
 		// (the cache stays at the empty default).
-		TensorType expected = new TensorType(DType.FLOAT32.name().toLowerCase(Locale.ROOT), List.of(new TensorType.NumericDim(2)));
+		TensorType expected = new TensorType(DType.FLOAT32, List.of(new NumericDim(2)));
 		assertEquals("Cache must be populated from Ariadne's call-site classification under followTypeHints.", Set.of(expected),
 				t.getTensorTypes());
 	}


### PR DESCRIPTION
## Summary

Closes #495 (cache hole).

After #488/#489 moved the type-hint/Ariadne/container classification into `Parameter.isTensorTyped`, the `inferTensorTypes` call that populates the per-Parameter tensor-types cache lived only inside Phase 2 (Ariadne query). Three paths bypassed it:

- Self parameters (early return).
- Type-hint-classified parameters with `followTypeHints` enabled (Phase 1 returns true before Phase 2).
- Functions with empty call-graph nodes (Phase 2 already gated on `!nodes.isEmpty()`).

Consumers reading `Parameter.getTensorTypes()` (no-arg, introduced #480) silently saw an empty set in these cases—dropping type-hint-classified tensor parameters from `Function.inferInputSignature`'s output even when Ariadne had a concrete `TensorType` from the call site. The self and empty-nodes cases are benign (excluded explicitly by `inferInputSignature`); the type-hint case is the load-bearing leak.

## Change

Move the `inferTensorTypes(tensorAnalysis)` call from inside Phase 2 to right after the `isSelf` check, still gated on `!nodes.isEmpty()`. Phase 1 (type hints) and Phase 2 (Ariadne cache read) now both observe a consistent cache state. Phase 2 reads `getTensorTypes()` instead of re-invoking `inferTensorTypes`.

Self parameters remain excluded from the cache (no semantic need; `inferInputSignature` filters them via `isSelf()`).

## Regression Test

`testInferredTensorTypesUnderFollowTypeHints`: `experimental_follow_type_hints=True` on a function with a `tf.Tensor` type hint, called with `tf.constant([1.0, 2.0])`. Asserts the cache contains Ariadne's call-site `TensorType(FLOAT32, [NumericDim(2)])`.

Verified failing on `main` before the hoist:

```
java.lang.AssertionError: Cache must be populated from Ariadne's call-site classification under followTypeHints.
expected:<[{[D:Constant,2] of float32}]> but was:<null>
```

Passes after the hoist.

## Verification

`./mvnw verify` green locally: 472 tests, 0 failures, 0 errors, 11 skipped (+1 from baseline for the new regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)