### PR TITLE
Cache `isTensorContainer` classification on `Parameter`

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -94,6 +94,12 @@ public final class Parameter {
 	private Set<TensorType> tensorTypes;
 
 	/**
+	 * Cached classification of whether this parameter is a tensor container (e.g., a list/tuple/dict whose elements are tensors). Populated
+	 * by {@link #isTensorTyped} when Phase 3 ({@link #hasTensorContainer}) fires. {@code null} until classification has run.
+	 */
+	private Boolean tensorContainer;
+
+	/**
 	 * Owning {@link Function} back-reference.
 	 */
 	private final Function function;
@@ -172,6 +178,21 @@ public final class Parameter {
 
 	protected void setTensorTypes(Set<TensorType> tensorTypes) {
 		this.tensorTypes = tensorTypes;
+	}
+
+	/**
+	 * Returns the cached classification of whether this parameter is a tensor container (e.g., a list/tuple/dict whose elements are
+	 * tensors). Populated during {@link #isTensorTyped}'s Phase 3. Returns {@code null} if classification has not yet run.
+	 * <p>
+	 * Distinct from {@link #getTensorTypes()}: a tensor container is recognized as tensor-typed by Phase 3's container detection, but
+	 * Ariadne does not emit a single {@link TensorType} for the container itself. Consumers that distinguish "container of tensors" from
+	 * "direct tensor" should use this method.
+	 *
+	 * @return {@code TRUE} if Phase 3 classified this parameter as a tensor container, {@code FALSE} if Phase 3 ran and did not, or
+	 *         {@code null} if classification has not yet run.
+	 */
+	public Boolean isTensorContainer() {
+		return this.tensorContainer;
 	}
 
 	/**
@@ -590,7 +611,9 @@ public final class Parameter {
 				subMonitor.worked(1);
 
 				// Phase 3: check for containers of tensors.
-				if (this.hasTensorContainer(tensorAnalysis, nodes, builder, subMonitor.split(1))) {
+				boolean isContainer = this.hasTensorContainer(tensorAnalysis, nodes, builder, subMonitor.split(1));
+				this.tensorContainer = isContainer;
+				if (isContainer) {
 					LOG.info(this.function + " likely has a tensor-like parameter: " + this.getName() + " due to tensor analysis.");
 					this.function.addInfo(TYPE_INFERENCING,
 							"Used tensor type analysis to infer tensor container type for parameter: " + this.getName() + ".");

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -95,7 +95,10 @@ public final class Parameter {
 
 	/**
 	 * Cached classification of whether this parameter is a tensor container (e.g., a list/tuple/dict whose elements are tensors). Populated
-	 * by {@link #isTensorTyped} when Phase 3 ({@link #hasTensorContainer}) fires. {@code null} until classification has run.
+	 * by {@link #isTensorTyped} only when Phase 3 ({@link #hasTensorContainer}) executes—i.e., when classification falls through Phase 1
+	 * (type hints) and the Phase 2 (Ariadne) cache is empty. Earlier-returning phases (self, type-hint hit, non-empty Phase 2 result, or
+	 * empty call-graph nodes) leave this field at its default. {@code null} therefore means either classification has not run or it ran but
+	 * did not reach Phase 3.
 	 */
 	private Boolean tensorContainer;
 
@@ -182,14 +185,17 @@ public final class Parameter {
 
 	/**
 	 * Returns the cached classification of whether this parameter is a tensor container (e.g., a list/tuple/dict whose elements are
-	 * tensors). Populated during {@link #isTensorTyped}'s Phase 3. Returns {@code null} if classification has not yet run.
+	 * tensors). Populated only when {@link #isTensorTyped}'s Phase 3 ({@link #hasTensorContainer}) executes; earlier-returning phases
+	 * (self, type-hint hit, non-empty Phase 2 result, or empty call-graph nodes) leave it at the default. Returns {@code null} when
+	 * classification has not run or did not reach Phase 3.
 	 * <p>
 	 * Distinct from {@link #getTensorTypes()}: a tensor container is recognized as tensor-typed by Phase 3's container detection, but
 	 * Ariadne does not emit a single {@link TensorType} for the container itself. Consumers that distinguish "container of tensors" from
 	 * "direct tensor" should use this method.
 	 *
-	 * @return {@code TRUE} if Phase 3 classified this parameter as a tensor container, {@code FALSE} if Phase 3 ran and did not, or
-	 *         {@code null} if classification has not yet run.
+	 * @return {@code TRUE} if Phase 3 classified this parameter as a tensor container, {@code FALSE} if Phase 3 ran and did not classify
+	 *         the parameter as a tensor container, or {@code null} if Phase 3 did not run (classification not started, or returned
+	 *         earlier).
 	 */
 	public Boolean isTensorContainer() {
 		return this.tensorContainer;

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testTensorContainerParameterCache/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testTensorContainerParameterCache/in/A.py
@@ -1,0 +1,14 @@
+# Regression fixture for #497. Parameter `a` is reached via a list-of-tensors call site;
+# Ariadne's per-parameter iterator does not emit a single TensorType for the container
+# itself, but `Parameter.isTensorTyped`'s Phase 3 (`hasTensorContainer`) classifies it as
+# tensor-typed. The new `isTensorContainer()` cache exposes Phase 3's verdict; the existing
+# `getTensorTypes()` cache stays empty (the asymmetry this PR documents).
+
+import tensorflow as tf
+
+
+def f(a):
+    pass
+
+
+f([tf.constant([1.0, 2.0])])

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8074,4 +8074,39 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(t.hashCode(), t.hashCode());
 		assertNotNull(t.toString());
 	}
+
+	/**
+	 * Regression test for #497: a tensor-container parameter (reached via a list-of-tensors call site) classifies as tensor-typed via
+	 * {@link Parameter#isTensorTyped}'s Phase 3 but does not populate the per-Parameter {@link Set} of {@link TensorType}s (the container
+	 * itself is not a tensor in Ariadne's analysis). Pins three relationships:
+	 * <ul>
+	 * <li>{@link Function#getHasTensorParameter} reflects the parameter-level Phase 3 result.
+	 * <li>The new {@link Parameter#isTensorContainer} cache returns {@code TRUE} for this parameter.
+	 * <li>{@link Parameter#getTensorTypes} stays empty—the asymmetry between the boolean classifier and the type-set cache that this PR
+	 * documents.
+	 * </ul>
+	 */
+	@Test
+	public void testTensorContainerParameterCache() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		// Parameter-level Phase 3 classification ⇒ function-level reflection.
+		assertTrue("Function with a tensor-container parameter classifies as having a tensor parameter.", function.getHasTensorParameter());
+
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(1, parameters.size());
+		Parameter a = parameters.get(0);
+		assertEquals("a", a.getName());
+
+		// Phase 3 cache (new in #497): explicit container classification.
+		assertEquals("Phase 3 classification must populate the `isTensorContainer` cache to TRUE.", Boolean.TRUE, a.isTensorContainer());
+
+		// Asymmetry pin: `getTensorTypes()` stays empty because Ariadne does not emit a single TensorType for the container itself;
+		// Phase 2's cache-population path runs but finds nothing for this parameter.
+		Set<TensorType> tensorTypes = a.getTensorTypes();
+		assertTrue("Container parameter must not surface a direct TensorType through `getTensorTypes()`.",
+				tensorTypes == null || tensorTypes.isEmpty());
+	}
 }


### PR DESCRIPTION
## Summary

Closes #497.

`Parameter.isTensorTyped`'s three classification phases produced inconsistent cache state. Phase 3 (`hasTensorContainer`) returned true on the boolean classifier without populating any cache, leaving `Parameter.getTensorTypes()` empty for container parameters. `Function.inferInputSignature` (#480) walks `getTensorTypes()` and silently excluded these parameters from the inferred signature.

## Change

Add a `Boolean tensorContainer` field + `public Boolean isTensorContainer()` getter on `Parameter`. Populate during Phase 3 of `isTensorTyped`. The new getter is the explicit query for "is this a tensor container?"—the existing `getTensorTypes()` continues to expose Ariadne's direct-tensor classification only. The asymmetry is now named on the API surface rather than hidden in the cache state.

Backward-compatible. Existing callers of `isTensorTyped`/`getTensorTypes`/`getHasTensorParameter` see no behavior change. New API on `Parameter`.

## Regression Test

`testTensorContainerParameterCache`: fixture passes `[tf.constant([1.0, 2.0])]` (list-of-tensor) to `f`. Asserts three relationships:

- Function-level: `Function.getHasTensorParameter() == TRUE`.
- Parameter cache (new in this PR): `Parameter.isTensorContainer() == TRUE`.
- Asymmetry: `Parameter.getTensorTypes()` is empty.

Verified the test errors on `main` (compile-fail: `isTensorContainer()` undefined) and passes on this branch.

## Verification

`./mvnw verify` green locally: 472 tests, 0 failures, 0 errors, 11 skipped (+1 from baseline for the new regression test).

## Cross-Refs

- #480 (introduced `inferInputSignature` and the no-arg `getTensorTypes()` cache).
- #496 (closed Phase-1 cache hole with `inferTensorTypes` hoist).
- #498 (related design discussion: split classification from query on `Parameter`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)