### PR TITLE
Use `assertTrue` for `isTensorContainer()` cache assertion

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8098,7 +8098,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Parameter a = parameters.get(0);
 		assertEquals("a", a.getName());
 
-		assertEquals("Phase 3 classification must populate the `isTensorContainer` cache to TRUE.", Boolean.TRUE, a.isTensorContainer());
+		assertTrue("Phase 3 classification must populate the `isTensorContainer` cache to TRUE.", a.isTensorContainer());
 
 		// Asymmetry pin: `getTensorTypes()` stays empty because Ariadne does not emit a single TensorType for the container itself;
 		// Phase 2's cache-population path runs but finds nothing for this parameter.


### PR DESCRIPTION
## Summary

In `testTensorContainerParameterCache` (added in #499), the cache assertion is:

```java
assertEquals("Phase 3 classification must populate the `isTensorContainer` cache to TRUE.", Boolean.TRUE, a.isTensorContainer());
```

`a.isTensorContainer()` returns `Boolean` (nullable: `null` if Phase 3 did not run), but the test premise is that Phase 3 DID run—so the call is invariant-non-null and `assertTrue(a.isTensorContainer())` auto-unboxes safely.

Same pattern as the `assertEquals(TRUE, p.isTensor())` → `assertTrue(p.isTensor())` migration applied in #500 for classified `isTensor()` calls.

## Cross-Refs

- #499 (introduced `testTensorContainerParameterCache`).
- #500 (introduced the parallel pattern for `isTensor()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)