### PR TITLE
Drop stale #499-PR-references from `testTensorContainerParameterCache` Javadoc

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8081,9 +8081,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * itself is not a tensor in Ariadne's analysis). Pins three relationships:
 	 * <ul>
 	 * <li>{@link Function#getHasTensorParameter} reflects the parameter-level Phase 3 result.
-	 * <li>The new {@link Parameter#isTensorContainer} cache returns {@code TRUE} for this parameter.
-	 * <li>{@link Parameter#getTensorTypes} stays empty—the asymmetry between the boolean classifier and the type-set cache that this PR
-	 * documents.
+	 * <li>The {@link Parameter#isTensorContainer} cache returns {@code TRUE} for this parameter.
+	 * <li>{@link Parameter#getTensorTypes} stays empty—the asymmetry between the boolean classifier and the type-set cache.
 	 * </ul>
 	 */
 	@Test


### PR DESCRIPTION
## Summary

Two stale references to #499 (now merged) in `testTensorContainerParameterCache`'s Javadoc:

- `<li>The new {@link Parameter#isTensorContainer} cache returns {@code TRUE}`—drop "new"; the cache has been on main since #499 merged.
- `the asymmetry between the boolean classifier and the type-set cache that this PR documents.`—drop "that this PR documents"; the documenting PR (#499) is no longer in flight.

Cosmetic Javadoc-only change; behavior unchanged.

Section-label inline comments (`// Parameter-level Phase 3 classification ⇒ ...`, `// Phase 3 cache (new in #497): ...`, `// Asymmetry pin: ...`) are deliberately preserved—symmetric with the section labels in the parallel `testParameterClassifyAsTensorContract` (added in #500).

The `Boolean.TRUE` → `TRUE` (static-import) consolidation is deliberately out of scope here; #502 supersedes that line by switching to `assertTrue`.

## Cross-Refs

- #499 (introduced `testTensorContainerParameterCache`).
- #500 (kept this method untouched apart from the necessary `isTensorTyped` → `classifyAsTensor` rename).
- #502 (independent follow-up for `assertEquals(TRUE, ...)` → `assertTrue(...)` on the cache assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)