### PR TITLE
Strip pure section-divider inline comments from `Parameter`/`Function` classifier tests

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1411,11 +1411,14 @@ public class Function {
 		subMonitor.setWorkRemaining(params.size());
 
 		for (Parameter param : params) {
-			if (param.isSelf())
+			if (param.isSelf()) {
 				selfParam = true;
+				subMonitor.worked(1);
+				continue; // skip self parameters.
+			}
 
 			param.classifyAsTensor(tensorAnalysis, nodes, builder, subMonitor.split(IProgressMonitor.UNKNOWN));
-			if (Boolean.TRUE.equals(param.isTensor()))
+			if (TRUE.equals(param.isTensor()))
 				this.hasTensorParameter = TRUE;
 
 			subMonitor.worked(1);

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1417,7 +1417,8 @@ public class Function {
 				continue; // skip self parameters.
 			}
 
-			if (param.isTensorTyped(tensorAnalysis, nodes, builder, subMonitor.split(IProgressMonitor.UNKNOWN))) {
+			param.classifyAsTensor(tensorAnalysis, nodes, builder, subMonitor.split(IProgressMonitor.UNKNOWN));
+			if (Boolean.TRUE.equals(param.isTensor())) {
 				this.hasTensorParameter = TRUE;
 				subMonitor.worked(1);
 				continue; // next parameter.

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1418,8 +1418,11 @@ public class Function {
 			}
 
 			param.classifyAsTensor(tensorAnalysis, nodes, builder, subMonitor.split(IProgressMonitor.UNKNOWN));
-			if (TRUE.equals(param.isTensor()))
+			if (TRUE.equals(param.isTensor())) {
 				this.hasTensorParameter = TRUE;
+				subMonitor.worked(1);
+				continue; // next parameter.
+			}
 
 			subMonitor.worked(1);
 		}

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1417,8 +1417,7 @@ public class Function {
 				continue; // skip self parameters.
 			}
 
-			param.classifyAsTensor(tensorAnalysis, nodes, builder, subMonitor.split(IProgressMonitor.UNKNOWN));
-			if (TRUE.equals(param.isTensor())) {
+			if (param.classifyAsTensor(tensorAnalysis, nodes, builder, subMonitor.split(IProgressMonitor.UNKNOWN))) {
 				this.hasTensorParameter = TRUE;
 				subMonitor.worked(1);
 				continue; // next parameter.

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1411,18 +1411,12 @@ public class Function {
 		subMonitor.setWorkRemaining(params.size());
 
 		for (Parameter param : params) {
-			if (param.isSelf()) {
+			if (param.isSelf())
 				selfParam = true;
-				subMonitor.worked(1);
-				continue; // skip self parameters.
-			}
 
 			param.classifyAsTensor(tensorAnalysis, nodes, builder, subMonitor.split(IProgressMonitor.UNKNOWN));
-			if (Boolean.TRUE.equals(param.isTensor())) {
+			if (Boolean.TRUE.equals(param.isTensor()))
 				this.hasTensorParameter = TRUE;
-				subMonitor.worked(1);
-				continue; // next parameter.
-			}
 
 			subMonitor.worked(1);
 		}

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -4,6 +4,8 @@ import static com.ibm.wala.cast.python.util.Util.getAllocationSiteInNode;
 import static edu.cuny.hunter.hybridize.core.analysis.Information.TYPE_INFERENCING;
 import static edu.cuny.hunter.hybridize.core.analysis.Util.getFullyQualifiedName;
 import static edu.cuny.hunter.hybridize.core.analysis.Util.getSelection;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static java.util.Collections.unmodifiableSet;
 import static org.eclipse.core.runtime.Platform.getLog;
 import static org.eclipse.core.runtime.SubMonitor.convert;
@@ -95,12 +97,18 @@ public final class Parameter {
 
 	/**
 	 * Cached classification of whether this parameter is a tensor container (e.g., a list/tuple/dict whose elements are tensors). Populated
-	 * by {@link #isTensorTyped} only when Phase 3 ({@link #hasTensorContainer}) executes—i.e., when classification falls through Phase 1
+	 * by {@link #classifyAsTensor} only when Phase 3 ({@link #hasTensorContainer}) executes—i.e., when classification falls through Phase 1
 	 * (type hints) and the Phase 2 (Ariadne) cache is empty. Earlier-returning phases (self, type-hint hit, non-empty Phase 2 result, or
 	 * empty call-graph nodes) leave this field at its default. {@code null} therefore means either classification has not run or it ran but
 	 * did not reach Phase 3.
 	 */
 	private Boolean tensorContainer;
+
+	/**
+	 * Cached "is this parameter likely tensor-typed?" classification produced by {@link #classifyAsTensor}. {@code null} until the
+	 * classifier has run.
+	 */
+	private Boolean isTensor;
 
 	/**
 	 * Owning {@link Function} back-reference.
@@ -550,38 +558,40 @@ public final class Parameter {
 	}
 
 	/**
-	 * Returns true iff this parameter is likely to be tensor-typed.
+	 * Classifies this parameter as tensor-typed (or not) by combining type-hint detection, Ariadne's tensor-type analysis, and
+	 * tensor-container detection. Populates the {@link #isTensor()} cache; the boolean result is also returned for convenience.
 	 *
 	 * @param tensorAnalysis Ariadne's tensor type analysis for the project.
 	 * @param callGraph The call graph for the project.
 	 * @param builder The propagation-call-graph builder for the project.
 	 * @param monitor Progress monitor for the sub-work.
-	 * @return True iff this parameter is likely to be tensor-typed based on a combination of type hints and Ariadne's analysis.
 	 * @throws Exception If the underlying analysis or AST traversal fails.
 	 */
-	public boolean isTensorTyped(TensorTypeAnalysis tensorAnalysis, CallGraph callGraph, PythonSSAPropagationCallGraphBuilder builder,
+	public void classifyAsTensor(TensorTypeAnalysis tensorAnalysis, CallGraph callGraph, PythonSSAPropagationCallGraphBuilder builder,
 			IProgressMonitor monitor) throws Exception {
-		return this.isTensorTyped(tensorAnalysis, this.function.getNodes(callGraph), builder, monitor);
+		this.classifyAsTensor(tensorAnalysis, this.function.getNodes(callGraph), builder, monitor);
 	}
 
 	/**
-	 * Returns true iff this parameter is likely to be tensor-typed.
+	 * Classifies this parameter as tensor-typed (or not) by combining type-hint detection, Ariadne's tensor-type analysis, and
+	 * tensor-container detection. Populates the {@link #isTensor()} cache.
 	 *
 	 * @param tensorAnalysis Ariadne's tensor type analysis for the project.
 	 * @param nodes The call graph nodes corresponding to the owning function.
 	 * @param builder The propagation-call-graph builder for the project.
 	 * @param monitor Progress monitor for the sub-work.
-	 * @return True iff this parameter is likely to be tensor-typed based on a combination of type hints and Ariadne's analysis.
 	 * @throws Exception If the underlying analysis or AST traversal fails.
 	 */
-	boolean isTensorTyped(TensorTypeAnalysis tensorAnalysis, Set<CGNode> nodes, PythonSSAPropagationCallGraphBuilder builder,
+	void classifyAsTensor(TensorTypeAnalysis tensorAnalysis, Set<CGNode> nodes, PythonSSAPropagationCallGraphBuilder builder,
 			IProgressMonitor monitor) throws Exception {
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Checking if parameter: " + this + " is tensor-typed...", 3);
 
 		try {
 			// don't consider `self` as a tensor.
-			if (this.isSelf())
-				return false;
+			if (this.isSelf()) {
+				this.isTensor = FALSE;
+				return;
+			}
 
 			// check a special case where we consider type hints.
 			boolean followTypeHints = this.function.getAlwaysFollowTypeHints() || this.function.getHybridizationParameters() != null
@@ -596,7 +606,8 @@ public final class Parameter {
 					LOG.info(this.function + " likely has a tensor parameter: " + this.getName() + " due to a type hint.");
 					this.function.addInfo(TYPE_INFERENCING, "Used a type hint to infer tensor type for parameter: " + this.getName() + ".");
 					subMonitor.worked(2);
-					return true;
+					this.isTensor = TRUE;
+					return;
 				}
 			} else
 				subMonitor.worked(1);
@@ -611,7 +622,8 @@ public final class Parameter {
 					this.function.addInfo(TYPE_INFERENCING,
 							"Used tensor type analysis to infer tensor type for parameter: " + this.getName() + ".");
 					subMonitor.worked(2);
-					return true;
+					this.isTensor = TRUE;
+					return;
 				}
 
 				subMonitor.worked(1);
@@ -623,15 +635,26 @@ public final class Parameter {
 					LOG.info(this.function + " likely has a tensor-like parameter: " + this.getName() + " due to tensor analysis.");
 					this.function.addInfo(TYPE_INFERENCING,
 							"Used tensor type analysis to infer tensor container type for parameter: " + this.getName() + ".");
-					return true;
+					this.isTensor = TRUE;
+					return;
 				}
 			} else
 				subMonitor.worked(2);
 
-			return false;
+			this.isTensor = FALSE;
 		} finally {
 			subMonitor.done();
 		}
+	}
+
+	/**
+	 * Returns the cached "is this parameter likely tensor-typed?" classification produced by {@link #classifyAsTensor}. Returns
+	 * {@code null} if the classifier has not yet run.
+	 *
+	 * @return {@code TRUE} if tensor-typed, {@code FALSE} if not, or {@code null} if classification has not yet run.
+	 */
+	public Boolean isTensor() {
+		return this.isTensor;
 	}
 
 	@Override

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -559,7 +559,7 @@ public final class Parameter {
 
 	/**
 	 * Classifies this parameter as tensor-typed (or not) by combining type-hint detection, Ariadne's tensor-type analysis, and
-	 * tensor-container detection. Populates the {@link #isTensor()} cache; the boolean result is also returned for convenience.
+	 * tensor-container detection. Populates the {@link #isTensor()} cache. Read the result via {@link #isTensor()} after this call returns.
 	 *
 	 * @param tensorAnalysis Ariadne's tensor type analysis for the project.
 	 * @param callGraph The call graph for the project.

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -565,7 +565,7 @@ public final class Parameter {
 	 * @param callGraph The call graph for the project.
 	 * @param builder The propagation-call-graph builder for the project.
 	 * @param monitor Progress monitor for the sub-work.
-	 * @return {@code true} if this parameter is classified as tensor-typed; {@code false} otherwise.
+	 * @return true if this parameter is classified as tensor-typed; false otherwise.
 	 * @throws Exception If the underlying analysis or AST traversal fails.
 	 */
 	public boolean classifyAsTensor(TensorTypeAnalysis tensorAnalysis, CallGraph callGraph, PythonSSAPropagationCallGraphBuilder builder,
@@ -581,7 +581,7 @@ public final class Parameter {
 	 * @param nodes The call graph nodes corresponding to the owning function.
 	 * @param builder The propagation-call-graph builder for the project.
 	 * @param monitor Progress monitor for the sub-work.
-	 * @return {@code true} if this parameter is classified as tensor-typed; {@code false} otherwise.
+	 * @return true if this parameter is classified as tensor-typed; false otherwise.
 	 * @throws Exception If the underlying analysis or AST traversal fails.
 	 */
 	boolean classifyAsTensor(TensorTypeAnalysis tensorAnalysis, Set<CGNode> nodes, PythonSSAPropagationCallGraphBuilder builder,

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -565,7 +565,7 @@ public final class Parameter {
 	 * @param callGraph The call graph for the project.
 	 * @param builder The propagation-call-graph builder for the project.
 	 * @param monitor Progress monitor for the sub-work.
-	 * @return true if this parameter is classified as tensor-typed; false otherwise.
+	 * @return True iff this parameter is classified as tensor-typed.
 	 * @throws Exception If the underlying analysis or AST traversal fails.
 	 */
 	public boolean classifyAsTensor(TensorTypeAnalysis tensorAnalysis, CallGraph callGraph, PythonSSAPropagationCallGraphBuilder builder,
@@ -581,7 +581,7 @@ public final class Parameter {
 	 * @param nodes The call graph nodes corresponding to the owning function.
 	 * @param builder The propagation-call-graph builder for the project.
 	 * @param monitor Progress monitor for the sub-work.
-	 * @return true if this parameter is classified as tensor-typed; false otherwise.
+	 * @return True iff this parameter is classified as tensor-typed.
 	 * @throws Exception If the underlying analysis or AST traversal fails.
 	 */
 	boolean classifyAsTensor(TensorTypeAnalysis tensorAnalysis, Set<CGNode> nodes, PythonSSAPropagationCallGraphBuilder builder,
@@ -590,10 +590,8 @@ public final class Parameter {
 
 		try {
 			// don't consider `self` as a tensor.
-			if (this.isSelf()) {
-				this.isTensor = FALSE;
-				return false;
-			}
+			if (this.isSelf())
+				return this.isTensor = FALSE;
 
 			// check a special case where we consider type hints.
 			boolean followTypeHints = this.function.getAlwaysFollowTypeHints() || this.function.getHybridizationParameters() != null
@@ -608,8 +606,7 @@ public final class Parameter {
 					LOG.info(this.function + " likely has a tensor parameter: " + this.getName() + " due to a type hint.");
 					this.function.addInfo(TYPE_INFERENCING, "Used a type hint to infer tensor type for parameter: " + this.getName() + ".");
 					subMonitor.worked(2);
-					this.isTensor = TRUE;
-					return true;
+					return this.isTensor = TRUE;
 				}
 			} else
 				subMonitor.worked(1);
@@ -624,8 +621,7 @@ public final class Parameter {
 					this.function.addInfo(TYPE_INFERENCING,
 							"Used tensor type analysis to infer tensor type for parameter: " + this.getName() + ".");
 					subMonitor.worked(2);
-					this.isTensor = TRUE;
-					return true;
+					return this.isTensor = TRUE;
 				}
 
 				subMonitor.worked(1);
@@ -637,14 +633,12 @@ public final class Parameter {
 					LOG.info(this.function + " likely has a tensor-like parameter: " + this.getName() + " due to tensor analysis.");
 					this.function.addInfo(TYPE_INFERENCING,
 							"Used tensor type analysis to infer tensor container type for parameter: " + this.getName() + ".");
-					this.isTensor = TRUE;
-					return true;
+					return this.isTensor = TRUE;
 				}
 			} else
 				subMonitor.worked(2);
 
-			this.isTensor = FALSE;
-			return false;
+			return this.isTensor = FALSE;
 		} finally {
 			subMonitor.done();
 		}

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -193,7 +193,7 @@ public final class Parameter {
 
 	/**
 	 * Returns the cached classification of whether this parameter is a tensor container (e.g., a list/tuple/dict whose elements are
-	 * tensors). Populated only when {@link #isTensorTyped}'s Phase 3 ({@link #hasTensorContainer}) executes; earlier-returning phases
+	 * tensors). Populated only when {@link #classifyAsTensor}'s Phase 3 ({@link #hasTensorContainer}) executes; earlier-returning phases
 	 * (self, type-hint hit, non-empty Phase 2 result, or empty call-graph nodes) leave it at the default. Returns {@code null} when
 	 * classification has not run or did not reach Phase 3.
 	 * <p>

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -559,30 +559,32 @@ public final class Parameter {
 
 	/**
 	 * Classifies this parameter as tensor-typed (or not) by combining type-hint detection, Ariadne's tensor-type analysis, and
-	 * tensor-container detection. Populates the {@link #isTensor()} cache. Read the result via {@link #isTensor()} after this call returns.
+	 * tensor-container detection. Populates the {@link #isTensor()} cache and returns the same verdict for caller convenience.
 	 *
 	 * @param tensorAnalysis Ariadne's tensor type analysis for the project.
 	 * @param callGraph The call graph for the project.
 	 * @param builder The propagation-call-graph builder for the project.
 	 * @param monitor Progress monitor for the sub-work.
+	 * @return {@code true} if this parameter is classified as tensor-typed; {@code false} otherwise.
 	 * @throws Exception If the underlying analysis or AST traversal fails.
 	 */
-	public void classifyAsTensor(TensorTypeAnalysis tensorAnalysis, CallGraph callGraph, PythonSSAPropagationCallGraphBuilder builder,
+	public boolean classifyAsTensor(TensorTypeAnalysis tensorAnalysis, CallGraph callGraph, PythonSSAPropagationCallGraphBuilder builder,
 			IProgressMonitor monitor) throws Exception {
-		this.classifyAsTensor(tensorAnalysis, this.function.getNodes(callGraph), builder, monitor);
+		return this.classifyAsTensor(tensorAnalysis, this.function.getNodes(callGraph), builder, monitor);
 	}
 
 	/**
 	 * Classifies this parameter as tensor-typed (or not) by combining type-hint detection, Ariadne's tensor-type analysis, and
-	 * tensor-container detection. Populates the {@link #isTensor()} cache.
+	 * tensor-container detection. Populates the {@link #isTensor()} cache and returns the same verdict for caller convenience.
 	 *
 	 * @param tensorAnalysis Ariadne's tensor type analysis for the project.
 	 * @param nodes The call graph nodes corresponding to the owning function.
 	 * @param builder The propagation-call-graph builder for the project.
 	 * @param monitor Progress monitor for the sub-work.
+	 * @return {@code true} if this parameter is classified as tensor-typed; {@code false} otherwise.
 	 * @throws Exception If the underlying analysis or AST traversal fails.
 	 */
-	void classifyAsTensor(TensorTypeAnalysis tensorAnalysis, Set<CGNode> nodes, PythonSSAPropagationCallGraphBuilder builder,
+	boolean classifyAsTensor(TensorTypeAnalysis tensorAnalysis, Set<CGNode> nodes, PythonSSAPropagationCallGraphBuilder builder,
 			IProgressMonitor monitor) throws Exception {
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Checking if parameter: " + this + " is tensor-typed...", 3);
 
@@ -590,7 +592,7 @@ public final class Parameter {
 			// don't consider `self` as a tensor.
 			if (this.isSelf()) {
 				this.isTensor = FALSE;
-				return;
+				return false;
 			}
 
 			// check a special case where we consider type hints.
@@ -607,7 +609,7 @@ public final class Parameter {
 					this.function.addInfo(TYPE_INFERENCING, "Used a type hint to infer tensor type for parameter: " + this.getName() + ".");
 					subMonitor.worked(2);
 					this.isTensor = TRUE;
-					return;
+					return true;
 				}
 			} else
 				subMonitor.worked(1);
@@ -623,7 +625,7 @@ public final class Parameter {
 							"Used tensor type analysis to infer tensor type for parameter: " + this.getName() + ".");
 					subMonitor.worked(2);
 					this.isTensor = TRUE;
-					return;
+					return true;
 				}
 
 				subMonitor.worked(1);
@@ -636,12 +638,13 @@ public final class Parameter {
 					this.function.addInfo(TYPE_INFERENCING,
 							"Used tensor type analysis to infer tensor container type for parameter: " + this.getName() + ".");
 					this.isTensor = TRUE;
-					return;
+					return true;
 				}
 			} else
 				subMonitor.worked(2);
 
 			this.isTensor = FALSE;
+			return false;
 		} finally {
 			subMonitor.done();
 		}

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testMethodWithSelfAndTensorParameter/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testMethodWithSelfAndTensorParameter/in/A.py
@@ -1,0 +1,14 @@
+# Regression fixture for #498. A method `m` with `self` and a tensor parameter `t`. After
+# `Parameter.classifyAsTensor` runs on each, `self.isTensor() == FALSE` (self-check), and
+# `t.isTensor() == TRUE` (Ariadne classifies from the tensor call site). Pins that
+# classification is per-parameter and works correctly across method-style call patterns.
+
+import tensorflow as tf
+
+
+class C:
+    def m(self, t):
+        return t
+
+
+C().m(tf.constant([1.0, 2.0]))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testMultipleTensorParameters/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testMultipleTensorParameters/in/A.py
@@ -1,0 +1,17 @@
+# Regression fixture for #498. The function `f` has two tensor parameters (`a`, `b`).
+# After `Parameter.classifyAsTensor` runs, both have `isTensor() == TRUE`, and
+# `Function.getHasTensorParameter() == TRUE`. Pins that ALL non-self tensor parameters
+# classify independently—the classification is per-parameter, not first-match-wins.
+
+import tensorflow as tf
+
+
+def f(a, b):
+    return a + b
+
+
+x = tf.constant([1.0, 2.0])
+y = tf.constant([3.0, 4.0])
+assert x.shape == (2,)
+assert y.shape == (2,)
+f(x, y)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testNonTensorTypeHintNotClassified/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testNonTensorTypeHintNotClassified/in/A.py
@@ -1,0 +1,15 @@
+# Regression fixture for #498. The function has an `int` type hint on its parameter. Even
+# under the test harness's global `ALWAYS_FOLLOW_TYPE_HINTS=true`, Phase 1's
+# `hasTensorTypeHint` check is specific to TF tensor types—an `int` hint does not match,
+# so Phase 1 doesn't classify. The call site supplies a non-tensor, so Phase 2 doesn't fire
+# either. Pins that Phase 1 is specifically TF-tensor-typed, not arbitrary-type-hinted.
+
+import tensorflow as tf
+
+
+@tf.function
+def func(x: int):
+    pass
+
+
+func(5)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testParameterClassifyAsTensorContract/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testParameterClassifyAsTensorContract/in/A.py
@@ -1,0 +1,17 @@
+# Regression fixture for #498. The function `f` has two parameters: `t` is a tensor (passed
+# from the call site as `tf.constant([1.0, 2.0])`) and `n` is a non-tensor (an int literal).
+# After `Parameter.classifyAsTensor` runs (transitively via `Function.inferTensorParameters`),
+# `t.isTensor()` returns TRUE and `n.isTensor()` returns FALSE. Pins the classifier→query
+# contract: the cached `isTensor()` value reflects the classifier's verdict.
+
+import tensorflow as tf
+
+
+def f(t, n):
+    return t + n
+
+
+x = tf.constant([1.0, 2.0])
+assert x.dtype == tf.float32
+assert x.shape == (2,)
+f(x, 5)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testParameterClassifyAsTensorContractReverse/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testParameterClassifyAsTensorContractReverse/in/A.py
@@ -1,0 +1,13 @@
+# Regression fixture for #498 (reverse direction). The function `f` takes two non-tensor
+# parameters (ints from a non-tensor call site). After `Parameter.classifyAsTensor` runs,
+# both parameters have `isTensor() == FALSE` and `Function.getHasTensorParameter() == FALSE`.
+# The function name `f` does not match the speculative-context regex, so the speculative
+# override doesn't fire. Pins the reverse direction of the classifier→reflection contract:
+# Function.getHasTensorParameter() == FALSE ⇒ no non-self parameter has isTensor() == TRUE.
+
+
+def f(a, b):
+    return a + b
+
+
+f(1, 2)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSelfParameterClassification/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSelfParameterClassification/in/A.py
@@ -1,0 +1,13 @@
+# Regression fixture for #498. A method `f` with only `self` as parameter. After
+# `Parameter.classifyAsTensor` runs, `self.isSelf() == TRUE` and `self.isTensor() == FALSE`
+# (the early-return in classifyAsTensor for self params). The owning function has only one
+# parameter (self), so `Function.getHasTensorParameter() == FALSE` (the speculative-context
+# branch is gated on `!onlySelfParam`).
+
+
+class C:
+    def f(self):
+        pass
+
+
+C().f()

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSpeculativeContextOverridesParameterEvidence/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSpeculativeContextOverridesParameterEvidence/in/A.py
@@ -1,0 +1,18 @@
+# Regression fixture for #498. The `__call__` method on a `tf.keras.Model` subclass is
+# called with a non-tensor (`5`). No parameter classifies as tensor-typed on its own (no
+# type hint, no Ariadne call-site classification, no container). But the function name
+# matches the speculative-context regex (`call|__call__|...`) AND the owning class
+# inherits from `tf.keras.Model`, so `Function.inferTensorParameters`' speculative-context
+# branch fires and sets `hasTensorParameter = TRUE` without any parameter having
+# `isTensor() == TRUE`. Pins the asymmetry: `getHasTensorParameter() == TRUE` does NOT
+# imply `∃ non-self param p : p.isTensor() == TRUE`.
+
+import tensorflow as tf
+
+
+class M(tf.keras.Model):
+    def __call__(self, x):
+        return x
+
+
+M()(5)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testTensorTypeHintHonoredViaGlobalFlag/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testTensorTypeHintHonoredViaGlobalFlag/in/A.py
@@ -1,0 +1,15 @@
+# Regression fixture for #498. The function has a `tf.Tensor` type hint on its parameter
+# but `experimental_follow_type_hints` is NOT supplied on the `@tf.function` decorator.
+# Under the test harness's global `ALWAYS_FOLLOW_TYPE_HINTS=true`, the `followTypeHints`
+# predicate inside `Parameter.classifyAsTensor` is the OR of (global flag, per-decorator
+# flag), so the type hint still classifies. Pins that either flag alone suffices.
+
+import tensorflow as tf
+
+
+@tf.function
+def func(x: tf.Tensor):
+    pass
+
+
+func(5)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testZeroParameterFunctionHasNoTensorParameter/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testZeroParameterFunctionHasNoTensorParameter/in/A.py
@@ -1,0 +1,10 @@
+# Regression fixture for #498. A function with no parameters trivially has no tensor
+# parameter. `Function.getHasTensorParameter() == FALSE` (the classification loop has
+# nothing to iterate over).
+
+
+def f():
+    pass
+
+
+f()

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8156,8 +8156,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Regression test for #498: a `self` parameter classifies as non-tensor unconditionally (early-return in
-	 * {@link Parameter#classifyAsTensor}). The owning function has only `self`, so `Function.getHasTensorParameter() == FALSE`: the
+	 * Regression test for #498: a `self` parameter is skipped by `Function.inferTensorParameters` (the classifier never runs on it), so its
+	 * cached `isTensor()` stays {@code null}. The owning function has only `self`, so `Function.getHasTensorParameter() == FALSE`: the
 	 * speculative-context fallback is gated on `!onlySelfParam`, and the function name `f` doesn't match the regex anyway.
 	 */
 	@Test
@@ -8174,7 +8174,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("self", self.getName());
 
 		assertTrue("Parameter `self` must classify as self.", self.isSelf());
-		assertEquals("Self parameter must classify as non-tensor unconditionally.", Boolean.FALSE, self.isTensor());
+		assertNotEquals("Self parameter is not classified as tensor-typed by `Function.inferTensorParameters` (skipped).", TRUE,
+				self.isTensor());
 	}
 
 	/**
@@ -8202,9 +8203,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("self", self.getName());
 		assertEquals("x", x.getName());
 
-		assertEquals(Boolean.FALSE, self.isTensor());
-		assertEquals("Asymmetry: function-level TRUE does not imply parameter-level TRUE under speculative-context override.",
-				Boolean.FALSE, x.isTensor());
+		assertNotEquals("Self parameter is skipped by classifier; not classified as tensor.", TRUE, self.isTensor());
+		assertFalse("Asymmetry: function-level TRUE does not imply parameter-level TRUE under speculative-context override.", x.isTensor());
 	}
 
 	/**
@@ -8238,8 +8238,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("a", a.getName());
 		assertEquals("b", b.getName());
 
-		assertEquals("First tensor parameter classifies as tensor-typed.", Boolean.TRUE, a.isTensor());
-		assertEquals("Second tensor parameter classifies as tensor-typed independently of the first.", Boolean.TRUE, b.isTensor());
+		assertTrue("First tensor parameter classifies as tensor-typed.", a.isTensor());
+		assertTrue("Second tensor parameter classifies as tensor-typed independently of the first.", b.isTensor());
 		assertTrue("Function with multiple tensor parameters has `getHasTensorParameter() == TRUE`.", function.getHasTensorParameter());
 	}
 
@@ -8263,14 +8263,14 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Parameter x = parameters.get(0);
 		assertEquals("x", x.getName());
 
-		assertEquals("Type hint honored via the test harness's global `ALWAYS_FOLLOW_TYPE_HINTS=true`.", Boolean.TRUE, x.isTensor());
+		assertTrue("Type hint honored via the test harness's global `ALWAYS_FOLLOW_TYPE_HINTS=true`.", x.isTensor());
 		assertTrue("Type-hint-classified parameter ⇒ `getHasTensorParameter()` is TRUE.", function.getHasTensorParameter());
 	}
 
 	/**
-	 * Regression test for #498: pins classification across a method-style call (self + tensor parameter in the same function). Both
-	 * parameters classify per-parameter: `self.isTensor() == FALSE` (self-check), `t.isTensor() == TRUE` (Ariadne classifies from the
-	 * tensor call site). The function reflects the parameter-level tensor signal.
+	 * Regression test for #498: pins classification across a method-style call (self + tensor parameter in the same function). Self is
+	 * skipped by `Function.inferTensorParameters` (cache stays at default); `t` is classified by Ariadne from the tensor call site. The
+	 * function reflects the parameter-level tensor signal.
 	 */
 	@Test
 	public void testMethodWithSelfAndTensorParameter() throws Exception {
@@ -8286,8 +8286,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("t", t.getName());
 
 		assertTrue("Parameter `self` classifies as self.", self.isSelf());
-		assertEquals("Self parameter classifies as non-tensor.", Boolean.FALSE, self.isTensor());
-		assertEquals("Tensor parameter `t` classifies as tensor-typed.", Boolean.TRUE, t.isTensor());
+		assertNotEquals("Self parameter is skipped by classifier; not classified as tensor.", TRUE, self.isTensor());
+		assertTrue("Tensor parameter `t` classifies as tensor-typed.", t.isTensor());
 		assertTrue("Method with a tensor parameter ⇒ `getHasTensorParameter() == TRUE`.", function.getHasTensorParameter());
 	}
 
@@ -8306,7 +8306,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Parameter x = parameters.get(0);
 		assertEquals("x", x.getName());
 
-		assertEquals("Non-tensor type hint (`int`) must NOT classify the parameter as tensor-typed.", Boolean.FALSE, x.isTensor());
+		assertFalse("Non-tensor type hint (`int`) must NOT classify the parameter as tensor-typed.", x.isTensor());
 		assertFalse("Function with no tensor classification: `getHasTensorParameter()` is FALSE.", function.getHasTensorParameter());
 	}
 }

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8266,4 +8266,47 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("Type hint honored via the test harness's global `ALWAYS_FOLLOW_TYPE_HINTS=true`.", Boolean.TRUE, x.isTensor());
 		assertTrue("Type-hint-classified parameter ⇒ `getHasTensorParameter()` is TRUE.", function.getHasTensorParameter());
 	}
+
+	/**
+	 * Regression test for #498: pins classification across a method-style call (self + tensor parameter in the same function). Both
+	 * parameters classify per-parameter: `self.isTensor() == FALSE` (self-check), `t.isTensor() == TRUE` (Ariadne classifies from the
+	 * tensor call site). The function reflects the parameter-level tensor signal.
+	 */
+	@Test
+	public void testMethodWithSelfAndTensorParameter() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(2, parameters.size());
+		Parameter self = parameters.get(0);
+		Parameter t = parameters.get(1);
+		assertEquals("self", self.getName());
+		assertEquals("t", t.getName());
+
+		assertTrue("Parameter `self` classifies as self.", self.isSelf());
+		assertEquals("Self parameter classifies as non-tensor.", Boolean.FALSE, self.isTensor());
+		assertEquals("Tensor parameter `t` classifies as tensor-typed.", Boolean.TRUE, t.isTensor());
+		assertTrue("Method with a tensor parameter ⇒ `getHasTensorParameter() == TRUE`.", function.getHasTensorParameter());
+	}
+
+	/**
+	 * Regression test for #498: pins that Phase 1's `hasTensorTypeHint` is specific to TF tensor types. An `int` type hint does NOT
+	 * classify the parameter as tensor-typed, even under the test harness's global `ALWAYS_FOLLOW_TYPE_HINTS=true`.
+	 */
+	@Test
+	public void testNonTensorTypeHintNotClassified() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(1, parameters.size());
+		Parameter x = parameters.get(0);
+		assertEquals("x", x.getName());
+
+		assertEquals("Non-tensor type hint (`int`) must NOT classify the parameter as tensor-typed.", Boolean.FALSE, x.isTensor());
+		assertFalse("Function with no tensor classification: `getHasTensorParameter()` is FALSE.", function.getHasTensorParameter());
+	}
 }

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8092,6 +8092,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(1, functions.size());
 		Function function = functions.iterator().next();
 
+		// Parameter-level Phase 3 classification ⇒ function-level reflection.
 		assertTrue("Function with a tensor-container parameter classifies as having a tensor parameter.", function.getHasTensorParameter());
 
 		List<Parameter> parameters = function.getParameters();
@@ -8099,6 +8100,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Parameter a = parameters.get(0);
 		assertEquals("a", a.getName());
 
+		// Phase 3 cache (new in #497): explicit container classification.
 		assertEquals("Phase 3 classification must populate the `isTensorContainer` cache to TRUE.", Boolean.TRUE, a.isTensorContainer());
 
 		// Asymmetry pin: `getTensorTypes()` stays empty because Ariadne does not emit a single TensorType for the container itself;

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8129,6 +8129,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertFalse("Parameter `n` (non-tensor call site) classifies as non-tensor.", n.isTensor());
 
 		assertTrue("Function has at least one tensor parameter ⇒ `getHasTensorParameter()` is TRUE.", function.getHasTensorParameter());
+
+		// Tighter cache→classifier invariant: non-empty `getTensorTypes()` ⇒ `isTensor() == TRUE`.
+		assertFalse("Tensor parameter must have a non-empty `getTensorTypes()` cache (Phase 2 fired).", t.getTensorTypes().isEmpty());
 	}
 
 	/**
@@ -8150,5 +8153,57 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		for (Parameter param : parameters)
 			if (!param.isSelf())
 				assertFalse("`getHasTensorParameter()` is FALSE ⇒ no non-self parameter classifies as tensor-typed.", param.isTensor());
+	}
+
+	/**
+	 * Regression test for #498: a `self` parameter classifies as non-tensor unconditionally (early-return in
+	 * {@link Parameter#classifyAsTensor}). The owning function has only `self`, so `Function.getHasTensorParameter() == FALSE`: the
+	 * speculative-context fallback is gated on `!onlySelfParam`, and the function name `f` doesn't match the regex anyway.
+	 */
+	@Test
+	public void testSelfParameterClassification() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		assertFalse("Self-only method has no tensor parameter.", function.getHasTensorParameter());
+
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(1, parameters.size());
+		Parameter self = parameters.get(0);
+		assertEquals("self", self.getName());
+
+		assertTrue("Parameter `self` must classify as self.", self.isSelf());
+		assertEquals("Self parameter must classify as non-tensor unconditionally.", Boolean.FALSE, self.isTensor());
+	}
+
+	/**
+	 * Regression test for #498: pins the asymmetry that {@link Function#getHasTensorParameter} {@code == TRUE} does NOT imply
+	 * {@code ∃ non-self param p : p.isTensor() == TRUE}. The speculative-context fallback (in {@link Function#inferTensorParameters}) can
+	 * set `hasTensorParameter = TRUE` based on function name + class lineage, with zero parameter-level tensor evidence.
+	 */
+	@Test
+	public void testSpeculativeContextOverridesParameterEvidence() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		assertEquals("__call__", function.getSimpleName());
+
+		// Function-level signal: speculative-context fired.
+		assertTrue("Speculative-context override sets `getHasTensorParameter()` to TRUE.", function.getHasTensorParameter());
+
+		// Parameter-level signal: no individual parameter classifies as tensor-typed (no type hint, no Ariadne call-site classification,
+		// no container).
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(2, parameters.size());
+		Parameter self = parameters.get(0);
+		Parameter x = parameters.get(1);
+		assertEquals("self", self.getName());
+		assertEquals("x", x.getName());
+
+		assertEquals(Boolean.FALSE, self.isTensor());
+		assertEquals("Asymmetry: function-level TRUE does not imply parameter-level TRUE under speculative-context override.",
+				Boolean.FALSE, x.isTensor());
 	}
 }

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8081,8 +8081,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * container itself is not a tensor in Ariadne's analysis). Pins three relationships:
 	 * <ul>
 	 * <li>{@link Function#getHasTensorParameter} reflects the parameter-level Phase 3 result.
-	 * <li>The {@link Parameter#isTensorContainer} cache returns {@code TRUE} for this parameter.
-	 * <li>{@link Parameter#getTensorTypes} stays empty—the asymmetry between the boolean classifier and the type-set cache.
+	 * <li>The new {@link Parameter#isTensorContainer} cache returns {@code TRUE} for this parameter.
+	 * <li>{@link Parameter#getTensorTypes} stays empty—the asymmetry between the boolean classifier and the type-set cache that this PR
+	 * documents.
 	 * </ul>
 	 */
 	@Test
@@ -8091,6 +8092,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(1, functions.size());
 		Function function = functions.iterator().next();
 
+		// Parameter-level Phase 3 classification ⇒ function-level reflection.
 		assertTrue("Function with a tensor-container parameter classifies as having a tensor parameter.", function.getHasTensorParameter());
 
 		List<Parameter> parameters = function.getParameters();
@@ -8098,8 +8100,11 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Parameter a = parameters.get(0);
 		assertEquals("a", a.getName());
 
-		assertEquals("Phase 3 classification must populate the `isTensorContainer` cache to TRUE.", TRUE, a.isTensorContainer());
+		// Phase 3 cache (new in #497): explicit container classification.
+		assertEquals("Phase 3 classification must populate the `isTensorContainer` cache to TRUE.", Boolean.TRUE, a.isTensorContainer());
 
+		// Asymmetry pin: `getTensorTypes()` stays empty because Ariadne does not emit a single TensorType for the container itself;
+		// Phase 2's cache-population path runs but finds nothing for this parameter.
 		Set<TensorType> tensorTypes = a.getTensorTypes();
 		assertTrue("Container parameter must not surface a direct TensorType through `getTensorTypes()`.",
 				tensorTypes == null || tensorTypes.isEmpty());

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8206,4 +8206,64 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("Asymmetry: function-level TRUE does not imply parameter-level TRUE under speculative-context override.",
 				Boolean.FALSE, x.isTensor());
 	}
+
+	/**
+	 * Regression test for #498: a function with no parameters trivially has no tensor parameter. Pins the empty-param-list edge case:
+	 * {@code Function.getHasTensorParameter() == FALSE} (the classification loop iterates over an empty list).
+	 */
+	@Test
+	public void testZeroParameterFunctionHasNoTensorParameter() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		assertEquals(0, function.getParameters().size());
+		assertFalse("Zero-parameter function has no tensor parameter.", function.getHasTensorParameter());
+	}
+
+	/**
+	 * Regression test for #498: pins that ALL non-self tensor parameters classify independently. Two-tensor-parameter fixture; both
+	 * parameters individually classify as tensor-typed, and the function reflects the OR.
+	 */
+	@Test
+	public void testMultipleTensorParameters() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(2, parameters.size());
+		Parameter a = parameters.get(0);
+		Parameter b = parameters.get(1);
+		assertEquals("a", a.getName());
+		assertEquals("b", b.getName());
+
+		assertEquals("First tensor parameter classifies as tensor-typed.", Boolean.TRUE, a.isTensor());
+		assertEquals("Second tensor parameter classifies as tensor-typed independently of the first.", Boolean.TRUE, b.isTensor());
+		assertTrue("Function with multiple tensor parameters has `getHasTensorParameter() == TRUE`.", function.getHasTensorParameter());
+	}
+
+	/**
+	 * Regression test for #498: under the test harness's global `ALWAYS_FOLLOW_TYPE_HINTS=true`, a tensor-typed type hint classifies the
+	 * parameter even when the per-decorator `experimental_follow_type_hints` flag is absent. Pins that the `followTypeHints` predicate is
+	 * the OR of (global flag, per-decorator flag) and that either alone suffices.
+	 */
+	@Test
+	public void testTensorTypeHintHonoredViaGlobalFlag() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		assertTrue("Function is decorated with `@tf.function`.", function.isHybrid());
+		assertFalse("`experimental_follow_type_hints` is NOT supplied on the decorator.",
+				function.getHybridizationParameters().isExperimentalFollowTypeHintsParamExists());
+
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(1, parameters.size());
+		Parameter x = parameters.get(0);
+		assertEquals("x", x.getName());
+
+		assertEquals("Type hint honored via the test harness's global `ALWAYS_FOLLOW_TYPE_HINTS=true`.", Boolean.TRUE, x.isTensor());
+		assertTrue("Type-hint-classified parameter ⇒ `getHasTensorParameter()` is TRUE.", function.getHasTensorParameter());
+	}
 }

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8092,7 +8092,6 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(1, functions.size());
 		Function function = functions.iterator().next();
 
-		// Parameter-level Phase 3 classification ⇒ function-level reflection.
 		assertTrue("Function with a tensor-container parameter classifies as having a tensor parameter.", function.getHasTensorParameter());
 
 		List<Parameter> parameters = function.getParameters();
@@ -8100,7 +8099,6 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Parameter a = parameters.get(0);
 		assertEquals("a", a.getName());
 
-		// Phase 3 cache (new in #497): explicit container classification.
 		assertEquals("Phase 3 classification must populate the `isTensorContainer` cache to TRUE.", Boolean.TRUE, a.isTensorContainer());
 
 		// Asymmetry pin: `getTensorTypes()` stays empty because Ariadne does not emit a single TensorType for the container itself;
@@ -8130,11 +8128,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("t", t.getName());
 		assertEquals("n", n.getName());
 
-		// Classifier→query contract.
 		assertTrue("Parameter `t` (tensor call site) classifies as tensor-typed.", t.isTensor());
 		assertFalse("Parameter `n` (non-tensor call site) classifies as non-tensor.", n.isTensor());
 
-		// Parameter-level → function-level reflection.
 		assertTrue("Function has at least one tensor parameter ⇒ `getHasTensorParameter()` is TRUE.", function.getHasTensorParameter());
 
 		// Tighter cache→classifier invariant: non-empty `getTensorTypes()` ⇒ `isTensor() == TRUE`.

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8132,6 +8132,19 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 		// Tighter cache→classifier invariant: non-empty `getTensorTypes()` ⇒ `isTensor() == TRUE`.
 		assertFalse("Tensor parameter must have a non-empty `getTensorTypes()` cache (Phase 2 fired).", t.getTensorTypes().isEmpty());
+
+		// The call site is `tf.constant([1.0, 2.0])`: shape (2,), dtype float32.
+		Set<Map.Entry<DType, List<Integer>>> tShapesDtypes = t.getTensorTypes().stream()
+				.map(tt -> Map.entry(tt.getDType(),
+						tt.getDims().stream()
+								.map(d -> d instanceof TensorType.NumericDim ? ((TensorType.NumericDim) d).value() : Integer.valueOf(-1))
+								.collect(Collectors.toList())))
+				.collect(toSet());
+		assertEquals("Tensor parameter `t` from `tf.constant([1.0, 2.0])` has dtype FLOAT32 and shape (2,).",
+				Set.of(Map.entry(DType.FLOAT32, Collections.singletonList(2))), tShapesDtypes);
+
+		// Non-tensor parameter must not surface a TensorType.
+		assertTrue("Non-tensor parameter `n` must have an empty `getTensorTypes()` cache.", n.getTensorTypes().isEmpty());
 	}
 
 	/**
@@ -8289,6 +8302,16 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertNotEquals("Self parameter is skipped by classifier; not classified as tensor.", TRUE, self.isTensor());
 		assertTrue("Tensor parameter `t` classifies as tensor-typed.", t.isTensor());
 		assertTrue("Method with a tensor parameter ⇒ `getHasTensorParameter() == TRUE`.", function.getHasTensorParameter());
+
+		// The call site is `C().m(tf.constant([1.0, 2.0]))`: shape (2,), dtype float32.
+		Set<Map.Entry<DType, List<Integer>>> tShapesDtypes = t.getTensorTypes().stream()
+				.map(tt -> Map.entry(tt.getDType(),
+						tt.getDims().stream()
+								.map(d -> d instanceof TensorType.NumericDim ? ((TensorType.NumericDim) d).value() : Integer.valueOf(-1))
+								.collect(Collectors.toList())))
+				.collect(toSet());
+		assertEquals("Tensor parameter `t` from `tf.constant([1.0, 2.0])` has dtype FLOAT32 and shape (2,).",
+				Set.of(Map.entry(DType.FLOAT32, Collections.singletonList(2))), tShapesDtypes);
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8077,13 +8077,12 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 	/**
 	 * Regression test for #497: a tensor-container parameter (reached via a list-of-tensors call site) classifies as tensor-typed via
-	 * {@link Parameter#isTensorTyped}'s Phase 3 but does not populate the per-Parameter {@link Set} of {@link TensorType}s (the container
-	 * itself is not a tensor in Ariadne's analysis). Pins three relationships:
+	 * {@link Parameter#classifyAsTensor}'s Phase 3 but does not populate the per-Parameter {@link Set} of {@link TensorType}s (the
+	 * container itself is not a tensor in Ariadne's analysis). Pins three relationships:
 	 * <ul>
 	 * <li>{@link Function#getHasTensorParameter} reflects the parameter-level Phase 3 result.
-	 * <li>The new {@link Parameter#isTensorContainer} cache returns {@code TRUE} for this parameter.
-	 * <li>{@link Parameter#getTensorTypes} stays empty—the asymmetry between the boolean classifier and the type-set cache that this PR
-	 * documents.
+	 * <li>The {@link Parameter#isTensorContainer} cache returns {@code TRUE} for this parameter.
+	 * <li>{@link Parameter#getTensorTypes} stays empty—the asymmetry between the boolean classifier and the type-set cache.
 	 * </ul>
 	 */
 	@Test
@@ -8092,7 +8091,6 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(1, functions.size());
 		Function function = functions.iterator().next();
 
-		// Parameter-level Phase 3 classification ⇒ function-level reflection.
 		assertTrue("Function with a tensor-container parameter classifies as having a tensor parameter.", function.getHasTensorParameter());
 
 		List<Parameter> parameters = function.getParameters();
@@ -8100,13 +8098,57 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Parameter a = parameters.get(0);
 		assertEquals("a", a.getName());
 
-		// Phase 3 cache (new in #497): explicit container classification.
-		assertEquals("Phase 3 classification must populate the `isTensorContainer` cache to TRUE.", Boolean.TRUE, a.isTensorContainer());
+		assertEquals("Phase 3 classification must populate the `isTensorContainer` cache to TRUE.", TRUE, a.isTensorContainer());
 
-		// Asymmetry pin: `getTensorTypes()` stays empty because Ariadne does not emit a single TensorType for the container itself;
-		// Phase 2's cache-population path runs but finds nothing for this parameter.
 		Set<TensorType> tensorTypes = a.getTensorTypes();
 		assertTrue("Container parameter must not surface a direct TensorType through `getTensorTypes()`.",
 				tensorTypes == null || tensorTypes.isEmpty());
+	}
+
+	/**
+	 * Regression test for #498: pins the classifier→query contract on `Parameter`. After {@link Parameter#classifyAsTensor} runs
+	 * (transitively via {@link Function#inferTensorParameters}), {@link Parameter#isTensor} returns the cached classification: {@code TRUE}
+	 * for a tensor parameter, {@code FALSE} for a non-tensor parameter. Also pins the function-level reflection:
+	 * {@link Function#getHasTensorParameter} is {@code TRUE} iff at least one non-{@code self} parameter has
+	 * {@code Parameter.isTensor() == TRUE} (modulo the speculative-context override, which this fixture doesn't trigger).
+	 */
+	@Test
+	public void testParameterClassifyAsTensorContract() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(2, parameters.size());
+		Parameter t = parameters.get(0);
+		Parameter n = parameters.get(1);
+		assertEquals("t", t.getName());
+		assertEquals("n", n.getName());
+
+		assertTrue("Parameter `t` (tensor call site) classifies as tensor-typed.", t.isTensor());
+		assertFalse("Parameter `n` (non-tensor call site) classifies as non-tensor.", n.isTensor());
+
+		assertTrue("Function has at least one tensor parameter ⇒ `getHasTensorParameter()` is TRUE.", function.getHasTensorParameter());
+	}
+
+	/**
+	 * Regression test for #498 (reverse direction): if {@link Function#getHasTensorParameter} is {@code FALSE}, then no non-{@code self}
+	 * parameter has {@code Parameter.isTensor() == TRUE}. The fixture uses a function named `f` (outside the speculative-context regex)
+	 * with two non-tensor int arguments, so the speculative-context fallback does not fire.
+	 */
+	@Test
+	public void testParameterClassifyAsTensorContractReverse() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		assertFalse("Function with no tensor parameters and no speculative-context match: `getHasTensorParameter()` is FALSE.",
+				function.getHasTensorParameter());
+
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(2, parameters.size());
+		for (Parameter param : parameters)
+			if (!param.isSelf())
+				assertFalse("`getHasTensorParameter()` is FALSE ⇒ no non-self parameter classifies as tensor-typed.", param.isTensor());
 	}
 }

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8125,9 +8125,11 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("t", t.getName());
 		assertEquals("n", n.getName());
 
+		// Classifier→query contract.
 		assertTrue("Parameter `t` (tensor call site) classifies as tensor-typed.", t.isTensor());
 		assertFalse("Parameter `n` (non-tensor call site) classifies as non-tensor.", n.isTensor());
 
+		// Parameter-level → function-level reflection.
 		assertTrue("Function has at least one tensor parameter ⇒ `getHasTensorParameter()` is TRUE.", function.getHasTensorParameter());
 
 		// Tighter cache→classifier invariant: non-empty `getTensorTypes()` ⇒ `isTensor() == TRUE`.


### PR DESCRIPTION
## Summary

Removes two pure section-divider inline comments from `testParameterClassifyAsTensorContract` (introduced in #500):

- `// Classifier→query contract.`
- `// Parameter-level → function-level reflection.`

These are organizational headers—no WHY content beyond what the immediately following assertion's message string already conveys (e.g., `"Parameter `t` (tensor call site) classifies as tensor-typed."`). Matches the codebase's general "no comments unless the WHY is non-obvious" default.

Substantive WHY comments are preserved:

- `// Tighter cache→classifier invariant: non-empty getTensorTypes() ⇒ isTensor() == TRUE.`
- `// The call site is tf.constant([1.0, 2.0]): shape (2,), dtype float32.`
- `// Non-tensor parameter must not surface a TensorType.`

## Cross-Refs

- #500 (introduces `testParameterClassifyAsTensorContract`; keeps the section labels there to minimize scope).
- #505 (parallel strip for `testTensorContainerParameterCache` on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)