### PR TITLE
Strip section-divider inline comments from `testTensorContainerParameterCache`

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8092,7 +8092,6 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(1, functions.size());
 		Function function = functions.iterator().next();
 
-		// Parameter-level Phase 3 classification ⇒ function-level reflection.
 		assertTrue("Function with a tensor-container parameter classifies as having a tensor parameter.", function.getHasTensorParameter());
 
 		List<Parameter> parameters = function.getParameters();
@@ -8100,7 +8099,6 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Parameter a = parameters.get(0);
 		assertEquals("a", a.getName());
 
-		// Phase 3 cache (new in #497): explicit container classification.
 		assertEquals("Phase 3 classification must populate the `isTensorContainer` cache to TRUE.", Boolean.TRUE, a.isTensorContainer());
 
 		// Asymmetry pin: `getTensorTypes()` stays empty because Ariadne does not emit a single TensorType for the container itself;


### PR DESCRIPTION
## Summary

Removes two pure section-divider inline comments from `testTensorContainerParameterCache` (introduced in #499):

- `// Parameter-level Phase 3 classification ⇒ function-level reflection.`
- `// Phase 3 cache (new in #497): explicit container classification.`

These are organizational headers—no WHY content beyond what the immediately following assertion's message string already conveys. Matches the codebase's general "no comments unless the WHY is non-obvious" default.

Substantive WHY comment preserved:

- `// Asymmetry pin: getTensorTypes() stays empty because Ariadne does not emit a single TensorType for the container itself; Phase 2's cache-population path runs but finds nothing for this parameter.`

## Cross-Refs

- #499 (introduced `testTensorContainerParameterCache`).
- #504 (parallel strip for `testParameterClassifyAsTensorContract` on the #500 branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)