### PR TITLE
Strip section-divider inline comments from `testParameterClassifyAsTensorContract`

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8129,11 +8129,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("t", t.getName());
 		assertEquals("n", n.getName());
 
-		// Classifier→query contract.
 		assertTrue("Parameter `t` (tensor call site) classifies as tensor-typed.", t.isTensor());
 		assertFalse("Parameter `n` (non-tensor call site) classifies as non-tensor.", n.isTensor());
 
-		// Parameter-level → function-level reflection.
 		assertTrue("Function has at least one tensor parameter ⇒ `getHasTensorParameter()` is TRUE.", function.getHasTensorParameter());
 
 		// Tighter cache→classifier invariant: non-empty `getTensorTypes()` ⇒ `isTensor() == TRUE`.


### PR DESCRIPTION
## Summary

Removes two pure section-divider inline comments from `testParameterClassifyAsTensorContract` (introduced in #500):

- `// Classifier→query contract.`
- `// Parameter-level → function-level reflection.`

These are organizational headers—no WHY content beyond what the immediately following assertion's message string already conveys (e.g., `"Parameter `t` (tensor call site) classifies as tensor-typed."`). Matches the codebase's general "no comments unless the WHY is non-obvious" default.

Substantive WHY comments preserved:

- `// Tighter cache→classifier invariant: non-empty getTensorTypes() ⇒ isTensor() == TRUE.`
- `// The call site is tf.constant([1.0, 2.0]): shape (2,), dtype float32.`
- `// Non-tensor parameter must not surface a TensorType.`

## Cross-Refs

- #500 (introduced `testParameterClassifyAsTensorContract`).
- #505 (parallel strip for `testTensorContainerParameterCache`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)