### PR TITLE
Replace JavaBean-style `is*ParamExists` accessors with `has*Param`

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -172,42 +172,42 @@ public class Function {
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter autograph.
 		 */
-		private boolean autoGraphParamExists;
+		private boolean hasAutoGraphParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter experimental_follow_type_hints.
 		 */
-		private boolean experimentaFollowTypeHintsParamExists;
+		private boolean hasExperimentalFollowTypeHintsParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter experimental_autograph_options.
 		 */
-		private boolean experimentalAutographOptionsParamExists;
+		private boolean hasExperimentalAutographOptionsParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter experimental_implements.
 		 */
-		private boolean experimentalImplementsParamExists;
+		private boolean hasExperimentalImplementsParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter func.
 		 */
-		private boolean funcParamExists;
+		private boolean hasFuncParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter input_signature.
 		 */
-		private boolean inputSignatureParamExists;
+		private boolean hasInputSignatureParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter jit_compile.
 		 */
-		private boolean jitCompileParamExists;
+		private boolean hasJitCompileParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter reduce_retracing.
 		 */
-		private boolean reduceRetracingParamExists;
+		private boolean hasReduceRetracingParam;
 
 		private void computeParameterExistance() {
 			// Use the hybrid decorator cached by `computeHybridization` (#118). That method already iterated every
@@ -247,27 +247,27 @@ public class Function {
 		}
 
 		/**
-		 * Set the appropriate {@code *ParamExists} field for the given {@code tf.function} parameter name. Recognizes both current names
-		 * and the deprecated aliases ({@code experimental_compile} → {@code jit_compile}, {@code experimental_relax_shapes} →
+		 * Set the appropriate {@code has*Param} field for the given {@code tf.function} parameter name. Recognizes both current names and
+		 * the deprecated aliases ({@code experimental_compile} → {@code jit_compile}, {@code experimental_relax_shapes} →
 		 * {@code reduce_retracing}). Unknown names are silently ignored; they may belong to a future TF version we don't model yet.
 		 */
 		private void markParamExists(String paramName) {
 			if (paramName.equals(FUNC))
-				this.funcParamExists = true;
+				this.hasFuncParam = true;
 			else if (paramName.equals(INPUT_SIGNATURE))
-				this.inputSignatureParamExists = true;
+				this.hasInputSignatureParam = true;
 			else if (paramName.equals(AUTOGRAPH))
-				this.autoGraphParamExists = true;
+				this.hasAutoGraphParam = true;
 			else if (paramName.equals(JIT_COMPILE) || paramName.equals(EXPERIMENTAL_COMPILE))
-				this.jitCompileParamExists = true;
+				this.hasJitCompileParam = true;
 			else if (paramName.equals(REDUCE_RETRACING) || paramName.equals(EXPERIMENTAL_RELAX_SHAPES))
-				this.reduceRetracingParamExists = true;
+				this.hasReduceRetracingParam = true;
 			else if (paramName.equals(EXPERIMENTAL_IMPLEMENTS))
-				this.experimentalImplementsParamExists = true;
+				this.hasExperimentalImplementsParam = true;
 			else if (paramName.equals(EXPERIMENTAL_AUTOGRAPH_OPTIONS))
-				this.experimentalAutographOptionsParamExists = true;
+				this.hasExperimentalAutographOptionsParam = true;
 			else if (paramName.equals(EXPERIMENTAL_FOLLOW_TYPE_HINTS))
-				this.experimentaFollowTypeHintsParamExists = true;
+				this.hasExperimentalFollowTypeHintsParam = true;
 		}
 
 		/**
@@ -275,8 +275,8 @@ public class Function {
 		 *
 		 * @return True iff this {@link decoratorsType} has parameter autograph.
 		 */
-		public boolean isAutoGraphParamExists() {
-			return this.autoGraphParamExists;
+		public boolean hasAutoGraphParam() {
+			return this.hasAutoGraphParam;
 		}
 
 		/**
@@ -284,8 +284,8 @@ public class Function {
 		 *
 		 * @return True iff this {@link decoratorsType} has parameter experimental_autograph_options.
 		 */
-		public boolean isExperimentalAutographOptParamExists() {
-			return this.experimentalAutographOptionsParamExists;
+		public boolean hasExperimentalAutographOptionsParam() {
+			return this.hasExperimentalAutographOptionsParam;
 		}
 
 		/**
@@ -293,8 +293,8 @@ public class Function {
 		 *
 		 * @return True iff this {@link decoratorsType} has parameter experimental_follow_type_hints.
 		 */
-		public boolean isExperimentalFollowTypeHintsParamExists() {
-			return this.experimentaFollowTypeHintsParamExists;
+		public boolean hasExperimentalFollowTypeHintsParam() {
+			return this.hasExperimentalFollowTypeHintsParam;
 		}
 
 		/**
@@ -302,17 +302,17 @@ public class Function {
 		 *
 		 * @return True iff this {@link decoratorsType} has parameter experimental_implements.
 		 */
-		public boolean isExperimentalImplementsParamExists() {
-			return this.experimentalImplementsParamExists;
+		public boolean hasExperimentalImplementsParam() {
+			return this.hasExperimentalImplementsParam;
 		}
 
 		/**
-		 * True iff this {@link Function}'s {@link decoratorsType} has parameter has parameter func.
+		 * True iff this {@link Function}'s {@link decoratorsType} has parameter func.
 		 *
 		 * @return True iff this {@link decoratorsType} has parameter func.
 		 */
-		public boolean isFuncParamExists() {
-			return this.funcParamExists;
+		public boolean hasFuncParam() {
+			return this.hasFuncParam;
 		}
 
 		/**
@@ -320,8 +320,8 @@ public class Function {
 		 *
 		 * @return True iff this {@link decoratorsType} has parameter input_signature.
 		 */
-		public boolean isInputSignatureParamExists() {
-			return this.inputSignatureParamExists;
+		public boolean hasInputSignatureParam() {
+			return this.hasInputSignatureParam;
 		}
 
 		/**
@@ -329,8 +329,8 @@ public class Function {
 		 *
 		 * @return True iff this {@link decoratorsType} has parameter jit_compile.
 		 */
-		public boolean isJitCompileParamExists() {
-			return this.jitCompileParamExists;
+		public boolean hasJitCompileParam() {
+			return this.hasJitCompileParam;
 		}
 
 		/**
@@ -338,8 +338,8 @@ public class Function {
 		 *
 		 * @return True iff this {@link Function} has parameter reduce_retracing.
 		 */
-		public boolean isReduceRetracingParamExists() {
-			return this.reduceRetracingParamExists;
+		public boolean hasReduceRetracingParam() {
+			return this.hasReduceRetracingParam;
 		}
 	}
 

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -172,42 +172,42 @@ public class Function {
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter autograph.
 		 */
-		private boolean hasAutoGraphParam;
+		private boolean autoGraphParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter experimental_follow_type_hints.
 		 */
-		private boolean hasExperimentalFollowTypeHintsParam;
+		private boolean experimentalFollowTypeHintsParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter experimental_autograph_options.
 		 */
-		private boolean hasExperimentalAutographOptionsParam;
+		private boolean experimentalAutographOptionsParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter experimental_implements.
 		 */
-		private boolean hasExperimentalImplementsParam;
+		private boolean experimentalImplementsParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter func.
 		 */
-		private boolean hasFuncParam;
+		private boolean funcParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter input_signature.
 		 */
-		private boolean hasInputSignatureParam;
+		private boolean inputSignatureParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter jit_compile.
 		 */
-		private boolean hasJitCompileParam;
+		private boolean jitCompileParam;
 
 		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter reduce_retracing.
 		 */
-		private boolean hasReduceRetracingParam;
+		private boolean reduceRetracingParam;
 
 		private void computeParameterExistance() {
 			// Use the hybrid decorator cached by `computeHybridization` (#118). That method already iterated every
@@ -247,27 +247,27 @@ public class Function {
 		}
 
 		/**
-		 * Set the appropriate {@code has*Param} field for the given {@code tf.function} parameter name. Recognizes both current names and
-		 * the deprecated aliases ({@code experimental_compile} → {@code jit_compile}, {@code experimental_relax_shapes} →
+		 * Set the appropriate {@code *Param} field for the given {@code tf.function} parameter name. Recognizes both current names and the
+		 * deprecated aliases ({@code experimental_compile} → {@code jit_compile}, {@code experimental_relax_shapes} →
 		 * {@code reduce_retracing}). Unknown names are silently ignored; they may belong to a future TF version we don't model yet.
 		 */
 		private void markParamExists(String paramName) {
 			if (paramName.equals(FUNC))
-				this.hasFuncParam = true;
+				this.funcParam = true;
 			else if (paramName.equals(INPUT_SIGNATURE))
-				this.hasInputSignatureParam = true;
+				this.inputSignatureParam = true;
 			else if (paramName.equals(AUTOGRAPH))
-				this.hasAutoGraphParam = true;
+				this.autoGraphParam = true;
 			else if (paramName.equals(JIT_COMPILE) || paramName.equals(EXPERIMENTAL_COMPILE))
-				this.hasJitCompileParam = true;
+				this.jitCompileParam = true;
 			else if (paramName.equals(REDUCE_RETRACING) || paramName.equals(EXPERIMENTAL_RELAX_SHAPES))
-				this.hasReduceRetracingParam = true;
+				this.reduceRetracingParam = true;
 			else if (paramName.equals(EXPERIMENTAL_IMPLEMENTS))
-				this.hasExperimentalImplementsParam = true;
+				this.experimentalImplementsParam = true;
 			else if (paramName.equals(EXPERIMENTAL_AUTOGRAPH_OPTIONS))
-				this.hasExperimentalAutographOptionsParam = true;
+				this.experimentalAutographOptionsParam = true;
 			else if (paramName.equals(EXPERIMENTAL_FOLLOW_TYPE_HINTS))
-				this.hasExperimentalFollowTypeHintsParam = true;
+				this.experimentalFollowTypeHintsParam = true;
 		}
 
 		/**
@@ -276,7 +276,7 @@ public class Function {
 		 * @return True iff this {@link decoratorsType} has parameter autograph.
 		 */
 		public boolean hasAutoGraphParam() {
-			return this.hasAutoGraphParam;
+			return this.autoGraphParam;
 		}
 
 		/**
@@ -285,7 +285,7 @@ public class Function {
 		 * @return True iff this {@link decoratorsType} has parameter experimental_autograph_options.
 		 */
 		public boolean hasExperimentalAutographOptionsParam() {
-			return this.hasExperimentalAutographOptionsParam;
+			return this.experimentalAutographOptionsParam;
 		}
 
 		/**
@@ -294,7 +294,7 @@ public class Function {
 		 * @return True iff this {@link decoratorsType} has parameter experimental_follow_type_hints.
 		 */
 		public boolean hasExperimentalFollowTypeHintsParam() {
-			return this.hasExperimentalFollowTypeHintsParam;
+			return this.experimentalFollowTypeHintsParam;
 		}
 
 		/**
@@ -303,7 +303,7 @@ public class Function {
 		 * @return True iff this {@link decoratorsType} has parameter experimental_implements.
 		 */
 		public boolean hasExperimentalImplementsParam() {
-			return this.hasExperimentalImplementsParam;
+			return this.experimentalImplementsParam;
 		}
 
 		/**
@@ -312,7 +312,7 @@ public class Function {
 		 * @return True iff this {@link decoratorsType} has parameter func.
 		 */
 		public boolean hasFuncParam() {
-			return this.hasFuncParam;
+			return this.funcParam;
 		}
 
 		/**
@@ -321,7 +321,7 @@ public class Function {
 		 * @return True iff this {@link decoratorsType} has parameter input_signature.
 		 */
 		public boolean hasInputSignatureParam() {
-			return this.hasInputSignatureParam;
+			return this.inputSignatureParam;
 		}
 
 		/**
@@ -330,7 +330,7 @@ public class Function {
 		 * @return True iff this {@link decoratorsType} has parameter jit_compile.
 		 */
 		public boolean hasJitCompileParam() {
-			return this.hasJitCompileParam;
+			return this.jitCompileParam;
 		}
 
 		/**
@@ -339,7 +339,7 @@ public class Function {
 		 * @return True iff this {@link Function} has parameter reduce_retracing.
 		 */
 		public boolean hasReduceRetracingParam() {
-			return this.hasReduceRetracingParam;
+			return this.reduceRetracingParam;
 		}
 	}
 

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -623,7 +623,7 @@ public final class Parameter {
 			// check a special case where we consider type hints.
 			boolean followTypeHints = this.function.getAlwaysFollowTypeHints() || this.function.getHybridizationParameters() != null
 					// TODO: Actually get the value here (#111).
-					&& this.function.getHybridizationParameters().isExperimentalFollowTypeHintsParamExists();
+					&& this.function.getHybridizationParameters().hasExperimentalFollowTypeHintsParam();
 
 			// Phase 1: type hints.
 			if (followTypeHints) {

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -491,14 +491,14 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 		HybridizationParameters hybridizationParameters = function.getHybridizationParameters();
 
-		printer.print(hybridizationParameters == null ? null : hybridizationParameters.isAutoGraphParamExists());
-		printer.print(hybridizationParameters == null ? null : hybridizationParameters.isExperimentalAutographOptParamExists());
-		printer.print(hybridizationParameters == null ? null : hybridizationParameters.isExperimentalFollowTypeHintsParamExists());
-		printer.print(hybridizationParameters == null ? null : hybridizationParameters.isExperimentalImplementsParamExists());
-		printer.print(hybridizationParameters == null ? null : hybridizationParameters.isFuncParamExists());
-		printer.print(hybridizationParameters == null ? null : hybridizationParameters.isInputSignatureParamExists());
-		printer.print(hybridizationParameters == null ? null : hybridizationParameters.isJitCompileParamExists());
-		printer.print(hybridizationParameters == null ? null : hybridizationParameters.isReduceRetracingParamExists());
+		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasAutoGraphParam());
+		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasExperimentalAutographOptionsParam());
+		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasExperimentalFollowTypeHintsParam());
+		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasExperimentalImplementsParam());
+		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasFuncParam());
+		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasInputSignatureParam());
+		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasJitCompileParam());
+		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasReduceRetracingParam());
 
 		printer.print(function.getRefactoring());
 		printer.print(function.getPassingPrecondition());

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -811,15 +811,15 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
-				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
-				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(!args.hasFuncParam() && args.hasInputSignatureParam() && !args.hasAutoGraphParam() && !args.hasJitCompileParam()
+				&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
 	 * Test for #108. Positional `input_signature` argument: `@tf.function(None, (tf.TensorSpec(...),))` passes `func=None` and
-	 * `input_signature=(...)` positionally. We expect both `funcParamExists` and `inputSignatureParamExists` to be true (the position-0
-	 * `func` slot is occupied even though its value is `None`; presence of the positional slot is what's detected, not its value).
+	 * `input_signature=(...)` positionally. We expect both `hasFuncParam` and `hasInputSignatureParam` to be true (the position-0 `func`
+	 * slot is occupied even though its value is `None`; presence of the positional slot is what's detected, not its value).
 	 */
 	@Test
 	public void testPositionalParameterInputSignature() throws Exception {
@@ -834,16 +834,16 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(args.isFuncParamExists());
-		assertTrue(args.isInputSignatureParamExists());
-		assertTrue(!args.isAutoGraphParamExists() && !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists()
-				&& !args.isExperimentalImplementsParamExists() && !args.isExperimentalAutographOptParamExists()
-				&& !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(args.hasFuncParam());
+		assertTrue(args.hasInputSignatureParam());
+		assertTrue(!args.hasAutoGraphParam() && !args.hasJitCompileParam() && !args.hasReduceRetracingParam()
+				&& !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
-	 * Test for #108. Positional `autograph` argument at position 2: `@tf.function(None, None, False)`. We expect `funcParamExists`,
-	 * `inputSignatureParamExists`, and `autoGraphParamExists` to all be true.
+	 * Test for #108. Positional `autograph` argument at position 2: `@tf.function(None, None, False)`. We expect `hasFuncParam`,
+	 * `hasInputSignatureParam`, and `hasAutoGraphParam` to all be true.
 	 */
 	@Test
 	public void testPositionalParameterAutograph() throws Exception {
@@ -858,17 +858,17 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(args.isFuncParamExists());
-		assertTrue(args.isInputSignatureParamExists());
-		assertTrue(args.isAutoGraphParamExists());
-		assertTrue(!args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
-				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(args.hasFuncParam());
+		assertTrue(args.hasInputSignatureParam());
+		assertTrue(args.hasAutoGraphParam());
+		assertTrue(!args.hasJitCompileParam() && !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam()
+				&& !args.hasExperimentalAutographOptionsParam() && !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
 	 * Test for #108. Mixed positional + keyword in the same decorator: `@tf.function(None, autograph=False)`. The position-0 `func` slot is
-	 * occupied positionally; `autograph` is bound by keyword. We expect both `funcParamExists` and `autoGraphParamExists` true, and notably
-	 * `inputSignatureParamExists` false (no slot occupied at position 1, no `input_signature` keyword).
+	 * occupied positionally; `autograph` is bound by keyword. We expect both `hasFuncParam` and `hasAutoGraphParam` true, and notably
+	 * `hasInputSignatureParam` false (no slot occupied at position 1, no `input_signature` keyword).
 	 */
 	@Test
 	public void testMixedPositionalAndKeyword() throws Exception {
@@ -883,11 +883,11 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(args.isFuncParamExists());
-		assertTrue(args.isAutoGraphParamExists());
-		assertTrue(!args.isInputSignatureParamExists() && !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists()
-				&& !args.isExperimentalImplementsParamExists() && !args.isExperimentalAutographOptParamExists()
-				&& !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(args.hasFuncParam());
+		assertTrue(args.hasAutoGraphParam());
+		assertTrue(!args.hasInputSignatureParam() && !args.hasJitCompileParam() && !args.hasReduceRetracingParam()
+				&& !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
@@ -907,9 +907,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
-				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
-				&& args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && !args.hasAutoGraphParam() && !args.hasJitCompileParam()
+				&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
@@ -928,9 +928,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
-				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
-				&& !args.isExperimentalAutographOptParamExists() && args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && !args.hasAutoGraphParam() && !args.hasJitCompileParam()
+				&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
@@ -949,9 +949,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
-				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && args.isExperimentalImplementsParamExists()
-				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && !args.hasAutoGraphParam() && !args.hasJitCompileParam()
+				&& !args.hasReduceRetracingParam() && args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
@@ -970,9 +970,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
-				&& args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
-				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && !args.hasAutoGraphParam() && args.hasJitCompileParam()
+				&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
@@ -989,9 +989,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
-				&& !args.isJitCompileParamExists() && args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
-				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && !args.hasAutoGraphParam() && !args.hasJitCompileParam()
+				&& args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
@@ -1010,9 +1010,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && args.isAutoGraphParamExists()
-				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
-				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && args.hasAutoGraphParam() && !args.hasJitCompileParam()
+				&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
@@ -1031,9 +1031,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
-				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
-				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && !args.hasAutoGraphParam() && !args.hasJitCompileParam()
+				&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
@@ -1052,9 +1052,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && args.isInputSignatureParamExists() && args.isAutoGraphParamExists()
-				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
-				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(!args.hasFuncParam() && args.hasInputSignatureParam() && args.hasAutoGraphParam() && !args.hasJitCompileParam()
+				&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
@@ -1100,9 +1100,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		// like `tf.function`. But it also has a tf.function decorator, therefore args should not be Null.
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && args.isAutoGraphParamExists()
-				&& !args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
-				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && args.hasAutoGraphParam() && !args.hasJitCompileParam()
+				&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 
 		checkSideEffectStatus(function);
 	}
@@ -1132,9 +1132,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function.HybridizationParameters args = function.getHybridizationParameters();
 		assertNotNull(args);
 
-		assertTrue(!args.isFuncParamExists() && !args.isInputSignatureParamExists() && !args.isAutoGraphParamExists()
-				&& args.isJitCompileParamExists() && !args.isReduceRetracingParamExists() && !args.isExperimentalImplementsParamExists()
-				&& !args.isExperimentalAutographOptParamExists() && !args.isExperimentalFollowTypeHintsParamExists());
+		assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && !args.hasAutoGraphParam() && args.hasJitCompileParam()
+				&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
 	}
 
 	/**
@@ -1965,7 +1965,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertTrue(function.isHybrid());
 
 		// TODO: Need to check the value (#111).
-		assertTrue(function.getHybridizationParameters().isExperimentalFollowTypeHintsParamExists());
+		assertTrue(function.getHybridizationParameters().hasExperimentalFollowTypeHintsParam());
 
 		List<Parameter> params = function.getParameters();
 
@@ -1987,7 +1987,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function function = functions.iterator().next();
 		assertNotNull(function);
 		assertTrue(function.isHybrid());
-		assertTrue(function.getHybridizationParameters().isExperimentalFollowTypeHintsParamExists());
+		assertTrue(function.getHybridizationParameters().hasExperimentalFollowTypeHintsParam());
 		// TODO: And the value is true (#111).
 
 		List<Parameter> params = function.getParameters();
@@ -2023,7 +2023,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function function = functions.iterator().next();
 		assertNotNull(function);
 		assertTrue(function.isHybrid());
-		assertFalse(function.getHybridizationParameters().isExperimentalFollowTypeHintsParamExists());
+		assertFalse(function.getHybridizationParameters().hasExperimentalFollowTypeHintsParam());
 
 		List<Parameter> params = function.getParameters();
 
@@ -2059,7 +2059,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertTrue(function.isHybrid());
 
 		// TODO: Need to check the value (#111).
-		assertTrue(function.getHybridizationParameters().isExperimentalFollowTypeHintsParamExists());
+		assertTrue(function.getHybridizationParameters().hasExperimentalFollowTypeHintsParam());
 
 		List<Parameter> params = function.getParameters();
 
@@ -2094,7 +2094,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertTrue(function.isHybrid());
 
 		// The flag is there.
-		assertTrue(function.getHybridizationParameters().isExperimentalFollowTypeHintsParamExists());
+		assertTrue(function.getHybridizationParameters().hasExperimentalFollowTypeHintsParam());
 
 		// But, it's set to False.
 		// TODO: assert that the experimental type hints param is set to false (#111).
@@ -8511,7 +8511,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 		assertTrue("Function is decorated with `@tf.function`.", function.isHybrid());
 		assertFalse("`experimental_follow_type_hints` is NOT supplied on the decorator.",
-				function.getHybridizationParameters().isExperimentalFollowTypeHintsParamExists());
+				function.getHybridizationParameters().hasExperimentalFollowTypeHintsParam());
 
 		List<Parameter> parameters = function.getParameters();
 		assertEquals(1, parameters.size());
@@ -8656,7 +8656,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertNotNull(function);
 		assertTrue("Function is decorated with `@tf.function(experimental_follow_type_hints=True)`.", function.isHybrid());
 		assertTrue("The `experimental_follow_type_hints` parameter is supplied on the `tf.function` decorator.",
-				function.getHybridizationParameters().isExperimentalFollowTypeHintsParamExists());
+				function.getHybridizationParameters().hasExperimentalFollowTypeHintsParam());
 		assertTrue("The function has a tensor parameter (via the type hint).", function.getHasTensorParameter());
 
 		List<Parameter> parameters = function.getParameters();


### PR DESCRIPTION
## Summary

- Renames eight `*ParamExists` boolean fields + `is*ParamExists()` accessors on `Function.HybridizationParameters`. Following the `tensor`/`isTensor()` pattern established in #513: field is noun-form, accessor is predicate-form, the two names are distinct so no shadowing
- Drops the unjustified `is*` JavaBean prefix from accessors—`Function` is not exposed via JavaBean introspection, DI, or property serialization, so the convention provides no value and the doubled-predicate reading is the only side effect
- Fixes a pre-existing typo (`experimenta` → `experimental`) and normalizes the abbreviated `OptParam` accessor to `OptionsParam` (matching the field's full word)
- `getHasTensorParameter()` is intentionally untouched; it returns `Boolean` (tri-state), and the JavaBean `is*` rule applies only to primitive `boolean`. Filing a separate cleanup if desired

Closes #512

## Renames

| Field (was) | Field (now) | Accessor (was) | Accessor (now) |
|---|---|---|---|
| `autoGraphParamExists` | `autoGraphParam` | `isAutoGraphParamExists()` | `hasAutoGraphParam()` |
| `experimentaFollowTypeHintsParamExists` | `experimentalFollowTypeHintsParam` | `isExperimentalFollowTypeHintsParamExists()` | `hasExperimentalFollowTypeHintsParam()` |
| `experimentalAutographOptionsParamExists` | `experimentalAutographOptionsParam` | `isExperimentalAutographOptParamExists()` | `hasExperimentalAutographOptionsParam()` |
| `experimentalImplementsParamExists` | `experimentalImplementsParam` | `isExperimentalImplementsParamExists()` | `hasExperimentalImplementsParam()` |
| `funcParamExists` | `funcParam` | `isFuncParamExists()` | `hasFuncParam()` |
| `inputSignatureParamExists` | `inputSignatureParam` | `isInputSignatureParamExists()` | `hasInputSignatureParam()` |
| `jitCompileParamExists` | `jitCompileParam` | `isJitCompileParamExists()` | `hasJitCompileParam()` |
| `reduceRetracingParamExists` | `reduceRetracingParam` | `isReduceRetracingParamExists()` | `hasReduceRetracingParam()` |

## Test Plan

- [x] `./mvnw verify`: 492 tests, 0 failures, 0 errors, 11 skipped
- [x] Spotless passes (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)