### PR TITLE
Align `Parameter.isTensor()` accessor Javadoc with field Javadoc

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -678,10 +678,9 @@ public final class Parameter {
 	}
 
 	/**
-	 * Returns the cached "is this parameter likely tensor-typed?" classification produced by {@link #classifyAsTensor}. Returns
-	 * {@code null} if the classifier has not yet run.
+	 * Returns the cached tensor-typed classification produced by {@link #classifyAsTensor}.
 	 *
-	 * @return {@code TRUE} if tensor-typed, {@code FALSE} if not, or {@code null} if classification has not yet run.
+	 * @return {@code TRUE} if tensor-typed, {@code FALSE} if not, or {@code null} if {@link #classifyAsTensor} has not yet run.
 	 */
 	public Boolean isTensor() {
 		return this.tensor;


### PR DESCRIPTION
## Summary

- Follow-up to #513: the field Javadoc was tightened to the form *"Cached classification of whether this parameter is tensor-typed. `null` until `classifyAsTensor` has run; otherwise `TRUE` or `FALSE`."*, but the accessor Javadoc retained the older quoted-question phrasing (*"is this parameter likely tensor-typed?"*) and a redundant trailing "Returns null if the classifier has not yet run." sentence
- Aligns the two Javadocs so the same tri-state contract reads the same way on both surfaces

## Test Plan

- [x] `./mvnw install -pl edu.cuny.hunter.hybridize.core -am -DskipTests=true`: compile passes (Javadoc validation is part of Tycho's strict compiler)
- [x] Spotless passes (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)