### PR TITLE
Extend precision audit to fixtures 60-66 (`RaggedTensor.from_nested_row_splits`)

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3796,21 +3796,6 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Expected Ariadne {@link TensorType} (Layer 1) for fixtures exercising {@code tf.RaggedTensor.from_nested_row_splits} with `values`
-	 * and a single {@code row_splits} list whose outer length yields a leading {@link NumericDim} of 3. Ragged inner dimensions are emitted
-	 * as raw {@code null}—see wala/ML#544 for the typed-sentinel flip target.
-	 */
-	private static final TensorType RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE = new TensorType(INT32,
-			java.util.Arrays.asList(new NumericDim(3), null, null));
-
-	/**
-	 * Expected inferred {@link TensorType} (Layer 2) for the same fixtures: the algorithm collapses ragged markers to {@link SymbolicDim}
-	 * wildcards inside a non-ragged {@code TensorSpec}—see #524 for the {@code RaggedTensorSpec} flip target.
-	 */
-	private static final TensorType RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED = new TensorType(INT32,
-			List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?")));
-
-	/**
 	 * Test for #2 for TF API `RaggedTensor.from_nested_row_splits`.
 	 */
 	@Test
@@ -3852,7 +3837,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter60() throws Exception {
-		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3860,7 +3846,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter61() throws Exception {
-		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3868,7 +3855,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter62() throws Exception {
-		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3876,7 +3864,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter63() throws Exception {
-		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3884,7 +3873,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter64() throws Exception {
-		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3892,7 +3882,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter65() throws Exception {
-		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3900,7 +3891,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter66() throws Exception {
-		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3737,7 +3737,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(List.of(expectedA, expectedB), sig.get().parameterTypes());
 	}
 
-	private void testHasLikelyTensorParameterHelper(boolean expectingHybridFunction, boolean expectingTensorParameter) throws Exception {
+	private Function testHasLikelyTensorParameterHelper(boolean expectingHybridFunction, boolean expectingTensorParameter)
+			throws Exception {
 		Set<Function> functions = this.getFunctions();
 		assertNotNull(functions);
 		assertEquals(1, functions.size());
@@ -3763,6 +3764,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("b", paramName);
 
 		assertEquals(expectingTensorParameter, function.getHasTensorParameter());
+		return function;
 	}
 
 	private void testHasLikelyTensorParameterHelper() throws Exception {
@@ -3783,8 +3785,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * {@link Optional#empty} assertion.
 	 */
 	private void testHasLikelyTensorParameterHelper(TensorType layer1, TensorType layer2) throws Exception {
-		testHasLikelyTensorParameterHelper(false, true);
-		Function function = this.getFunctions().iterator().next();
+		Function function = testHasLikelyTensorParameterHelper(false, true);
 		Parameter a = function.getParameters().get(0);
 		Parameter b = function.getParameters().get(1);
 		assertEquals(Set.of(layer1), a.getTensorTypes());
@@ -3793,6 +3794,21 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertTrue(sig.isPresent());
 		assertEquals(List.of(layer2, layer2), sig.get().parameterTypes());
 	}
+
+	/**
+	 * Expected Ariadne {@link TensorType} (Layer 1) for fixtures exercising {@code tf.RaggedTensor.from_nested_row_splits} with `values`
+	 * and a single {@code row_splits} list whose outer length yields a leading {@link NumericDim} of 3. Ragged inner dimensions are emitted
+	 * as raw {@code null}—see wala/ML#544 for the typed-sentinel flip target.
+	 */
+	private static final TensorType RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE = new TensorType(INT32,
+			java.util.Arrays.asList(new NumericDim(3), null, null));
+
+	/**
+	 * Expected inferred {@link TensorType} (Layer 2) for the same fixtures: the algorithm collapses ragged markers to {@link SymbolicDim}
+	 * wildcards inside a non-ragged {@code TensorSpec}—see #524 for the {@code RaggedTensorSpec} flip target.
+	 */
+	private static final TensorType RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED = new TensorType(INT32,
+			List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?")));
 
 	/**
 	 * Test for #2 for TF API `RaggedTensor.from_nested_row_splits`.
@@ -3836,8 +3852,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter60() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
 	}
 
 	/**
@@ -3845,8 +3860,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter61() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
 	}
 
 	/**
@@ -3854,8 +3868,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter62() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
 	}
 
 	/**
@@ -3863,8 +3876,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter63() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
 	}
 
 	/**
@@ -3872,8 +3884,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter64() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
 	}
 
 	/**
@@ -3881,8 +3892,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter65() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
 	}
 
 	/**
@@ -3890,8 +3900,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter66() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(RAGGED_FROM_NESTED_ROW_SPLITS_ARIADNE, RAGGED_FROM_NESTED_ROW_SPLITS_INFERRED);
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3742,6 +3742,11 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * so callers performing additional assertions (e.g., the precision-audit overload at
 	 * {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)}) can reuse the same instance instead of triggering a second
 	 * {@link #getFunctions()} pass.
+	 *
+	 * @param expectingHybridFunction The expected value of {@link Function#isHybrid()} for the loaded function.
+	 * @param expectingTensorParameter The expected value of {@link Function#getHasTensorParameter()} for the loaded function.
+	 * @return The validated {@link Function}.
+	 * @throws Exception If the underlying analysis fails.
 	 */
 	private Function testHasLikelyTensorParameterHelper(boolean expectingHybridFunction, boolean expectingTensorParameter)
 			throws Exception {
@@ -3789,6 +3794,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * strictly distinct from Layer 1 (e.g., ragged tensors—see {@link #testHasLikelyTensorParameter59()} for the TODO-anchored canonical
 	 * fixture and the upstream/downstream flip targets wala/ML#544 and #524). Signature-drop cases must still inline their own
 	 * {@link Optional#empty} assertion.
+	 *
+	 * @param layer1 The expected per-parameter {@link TensorType} reported by Ariadne via {@link Parameter#getTensorTypes()}.
+	 * @param layer2 The expected per-parameter {@link TensorType} produced by Hybridize via {@link Function#inferInputSignature()}.
+	 * @throws Exception If the underlying analysis fails.
 	 */
 	private void testHasLikelyTensorParameterHelper(TensorType layer1, TensorType layer2) throws Exception {
 		Function function = testHasLikelyTensorParameterHelper(false, true);

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3774,6 +3774,27 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Precision-audit overload: in addition to the structural checks of {@link #testHasLikelyTensorParameterHelper()}, asserts that both
+	 * parameters carry exactly {@code layer1} as their inferred tensor type (Layer 1) and that the inferred input signature is
+	 * {@code [layer2, layer2]} (Layer 2). When Layer 1 and Layer 2 agree (the common case), pass the same {@link TensorType} for both
+	 * arguments. The two-layer form is needed when an upstream representation gap or an algorithm-side collapse produces a Layer-2 type
+	 * strictly distinct from Layer 1 (e.g., ragged tensors—see {@link #testHasLikelyTensorParameter59()} for the TODO-anchored canonical
+	 * fixture and the upstream/downstream flip targets wala/ML#544 and #524). Signature-drop cases must still inline their own
+	 * {@link Optional#empty} assertion.
+	 */
+	private void testHasLikelyTensorParameterHelper(TensorType layer1, TensorType layer2) throws Exception {
+		testHasLikelyTensorParameterHelper(false, true);
+		Function function = this.getFunctions().iterator().next();
+		Parameter a = function.getParameters().get(0);
+		Parameter b = function.getParameters().get(1);
+		assertEquals(Set.of(layer1), a.getTensorTypes());
+		assertEquals(Set.of(layer1), b.getTensorTypes());
+		Optional<InputSignature> sig = function.inferInputSignature();
+		assertTrue(sig.isPresent());
+		assertEquals(List.of(layer2, layer2), sig.get().parameterTypes());
+	}
+
+	/**
 	 * Test for #2 for TF API `RaggedTensor.from_nested_row_splits`.
 	 */
 	@Test
@@ -3815,7 +3836,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter60() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3823,7 +3845,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter61() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3831,7 +3854,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter62() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3839,7 +3863,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter63() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3847,7 +3872,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter64() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3855,7 +3881,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter65() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3863,7 +3890,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter66() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3737,6 +3737,12 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals(List.of(expectedA, expectedB), sig.get().parameterTypes());
 	}
 
+	/**
+	 * Runs the structural assertions for the canonical two-parameter {@code (a, b)} fixture shape. Returns the validated {@link Function}
+	 * so callers performing additional assertions (e.g., the precision-audit overload at
+	 * {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)}) can reuse the same instance instead of triggering a second
+	 * {@link #getFunctions()} pass.
+	 */
 	private Function testHasLikelyTensorParameterHelper(boolean expectingHybridFunction, boolean expectingTensorParameter)
 			throws Exception {
 		Set<Function> functions = this.getFunctions();


### PR DESCRIPTION
## Summary

- Add two-layer helper overload `testHasLikelyTensorParameterHelper(TensorType layer1, TensorType layer2)` for fixtures where the Ariadne (Layer 1) and Hybridize (Layer 2) outputs intentionally diverge—primarily ragged-tensor cases pinned to wala/ML#544 and #524.
- Apply the helper to fixtures 60-66, all exercising `tf.RaggedTensor.from_nested_row_splits` with the same `(NumericDim(3), null, null)` Layer-1 shape as the canonical TODO-anchored fixture `testHasLikelyTensorParameter59`.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests` — 492 tests, 0 failures, 11 skipped
- [x] `./mvnw spotless:check` — clean
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- wala/ML#544—typed `RaggedDim` sentinel (Layer-1 flip target)
- #524—`RaggedTensorSpec` emission (Layer-2 flip target)
- #522—prior precision-audit batch (fixtures 1-58 + 59)
