### PR TITLE
Skip patch-version updates in `maven` and `pip` ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,21 @@
 # record of silently no-op'ing in this repo (broken `if:` guards, missing
 # `pull_request_target` triggers) and reviewing dependabot PRs takes
 # seconds when grouping reduces the volume.
+#
+# Patch-version churn (e.g. `3.5.0 → 3.5.1`) is suppressed via per-block
+# `ignore` rules on `version-update:semver-patch` for ecosystems where
+# the patch cadence outpaces real review value. CVE-driven patches still
+# arrive: dependabot's security-update path bypasses `version-update:*`
+# ignore rules, so a vulnerability disclosed against a pinned patch level
+# still opens a PR under the security-update workflow even though routine
+# version-update patches do not.
 
 version: 2
 updates:
   # Maven build-plugin and library bumps. Grouped so a typical week opens
   # ONE plugin PR instead of one per plugin. Major bumps are excluded from
-  # the group (they need individual review for breaking changes).
+  # the group (they need individual review for breaking changes); patches
+  # are excluded from version-updates entirely (see top-of-file note).
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
@@ -29,16 +38,17 @@ updates:
           - "org.jacoco:*"
         update-types:
           - "minor"
-          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
-  # Python tooling for the test/format requirements. Grouped patch+minor;
-  # majors land as their own PRs. `patterns:` lists the tooling deps
-  # actually present in `/requirements.txt` today; extend it when adding
-  # new tooling. Keeping the list tight (instead of anticipatory globs
-  # like `pytest*`) prevents accidental capture of test-fixture runtime
-  # deps if a future `directories:` expansion ever broadens what the pip
-  # updater sees — `pytest*` would match the `pytest` line in a fixture's
-  # `requirements.txt`, for instance.
+  # Python tooling for the test/format requirements. `patterns:` lists the
+  # tooling deps actually present in `/requirements.txt` today; extend it
+  # when adding new tooling. Keeping the list tight (instead of
+  # anticipatory globs like `pytest*`) prevents accidental capture of
+  # test-fixture runtime deps if a future `directories:` expansion ever
+  # broadens what the pip updater sees — `pytest*` would match the
+  # `pytest` line in a fixture's `requirements.txt`, for instance.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -51,8 +61,9 @@ updates:
           - "black"
         update-types:
           - "minor"
-          - "patch"
     ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
       # TensorFlow is pinned to 2.9.3 by the test fixtures and would force
       # a much larger refactor across the analyzer than dependabot can
       # safely propose. Drop the ignore once the test corpus migrates.


### PR DESCRIPTION
## Summary

Drop routine `semver-patch` version-updates from `maven` and `pip` ecosystems via per-block `ignore` rules. CVE-driven patches continue to arrive through the security-update path (dependabot's security-update workflow bypasses `version-update:*` ignore rules).

## Motivation

The PR churn from routine patches (#527 maven plugins, similar pip patches) was carrying minimal semantic content—mostly transitive dependency bumps and minor bug fixes inside the plugin's own internals. The review-attention-per-bit-of-signal ratio was poor enough to revisit the policy.

What stays:

- **Minor and major** version-updates still arrive (minor grouped per the existing `groups:` config; majors land individually for breaking-change review).
- **Security updates** still arrive on patches because the security-update path explicitly bypasses `version-update:*` ignore rules. The spotless `3.5.0 → 3.5.1` CVE fix (CVE-2025-67030) in #527 is exactly the case the security-update path is designed for—even with this PR landed, that fix would still surface.
- **`github-actions`** block is unchanged: action versions pin to major tags (`@v4`); semver classification doesn't apply the same way.
- **`tensorflow`** ignore in the pip block is preserved.

## Test Plan

- [ ] dependabot.yml parses (CI validation step)
- [ ] No behavior change to existing PRs (#527 already open isn't affected by config landing later)
- [ ] Future routine patch updates: dependabot opens nothing
- [ ] Future patch-level CVE: dependabot opens a security-update PR

## Cross-Refs

- #527—a maven-plugins-group patch bump that prompted the policy discussion. Spotless 3.5.0 → 3.5.1 inside it carries CVE-2025-67030; that one stays inbound through the security-update path.
