### PR TITLE
Extend precision audit to fixtures 67-82 (`RaggedTensor.from_*` family)

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3952,7 +3952,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter71() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3960,7 +3961,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter72() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3968,7 +3970,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter73() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3976,7 +3979,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter74() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3984,7 +3988,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter75() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3992,7 +3997,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter76() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4000,7 +4006,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter77() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4008,7 +4015,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter78() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4016,7 +4024,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter79() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4024,7 +4033,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter80() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(4), null)),
+				new TensorType(INT32, List.of(new NumericDim(4), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4032,7 +4042,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter81() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(4), null)),
+				new TensorType(INT32, List.of(new NumericDim(4), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4040,7 +4051,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter82() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(4), null)),
+				new TensorType(INT32, List.of(new NumericDim(4), new SymbolicDim("?"))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -2,6 +2,7 @@ package edu.cuny.hunter.hybridize.tests;
 
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.INT32;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.STRING;
 import static edu.cuny.hunter.hybridize.core.analysis.Function.PLUGIN_ID;
 import static edu.cuny.hunter.hybridize.core.analysis.Information.INPUT_SIGNATURE_INFERENCE;
 import static edu.cuny.hunter.hybridize.core.analysis.Information.SPECULATIVE_ANALYSIS;
@@ -2365,7 +2366,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		// disagreement (|D| != 1).
 		Function dbl = nameToFunctions.get("double").iterator().next();
 		Parameter a = dbl.getParameters().get(0);
-		assertEquals(Set.of(new TensorType(INT32, List.of()), new TensorType(FLOAT32, List.of()), new TensorType(DType.STRING, List.of())),
+		assertEquals(Set.of(new TensorType(INT32, List.of()), new TensorType(FLOAT32, List.of()), new TensorType(STRING, List.of())),
 				a.getTensorTypes());
 		Optional<InputSignature> dblSig = dbl.inferInputSignature();
 		assertFalse("Expected signature drop due to dtype disagreement across call sites.", dblSig.isPresent());
@@ -3834,7 +3835,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		// Precision audit. `tf.RaggedTensor.from_nested_row_splits(values, splits)` — runtime dtype=int32, shape=(3, None, None).
 		// Ariadne emits an INT32 TensorType with three dims: a known constant 3 followed by two raggedness markers (raw null).
 		// TODO(wala/ML#544): flip the `null` entries to `new RaggedDim()` once Ariadne ships the typed sentinel.
-		TensorType ariadne = new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null));
+		TensorType ariadne = new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null));
 		assertEquals(Set.of(ariadne), a.getTensorTypes());
 		assertEquals(Set.of(ariadne), b.getTensorTypes());
 
@@ -3852,7 +3853,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter60() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3861,7 +3862,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter61() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3870,7 +3871,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter62() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3879,7 +3880,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter63() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3888,7 +3889,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter64() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3897,7 +3898,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter65() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3906,7 +3907,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter66() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, java.util.Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3915,7 +3916,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter67() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3923,7 +3925,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter68() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3931,7 +3934,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter69() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3939,7 +3943,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter70() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Extend the two-layer precision audit to fixtures 67-82, covering the full `tf.RaggedTensor.from_*` constructor family (`from_nested_value_rowids`, `from_row_lengths`, `from_row_limits`, `from_row_splits`, `from_row_starts`, `from_value_rowids`).
- Static-import `STRING` and shift to `Arrays.asList` per the project's no-FQN style; sweep applies to previously-inlined fixture-59 / 60-66 anchors as well.

## Findings

**Layer 1 (Ariadne, consumed 0.44.0):**

- `from_nested_value_rowids` over a `tf.keras.Input(shape=[None], dtype=tf.string)` (67-70): `STRING, (NumericDim(4), null, null, null)` — `NumericDim` from `max(rowids[0]) + 1`, two ragged-marker `null` entries, one dynamic-dim `null` from the `keras.Input` shape.
- Single-ragged `from_*` constructors (71-82): `INT32, (NumericDim(nrows), null)` — `nrows = 5` for 71-79 (`from_row_lengths`/`limits`/`splits`/`starts`), `nrows = 4` for 80-82 (`from_value_rowids` over `[0,0,0,0,2,2,2,3]`).

**Layer 2 (Hybridize):** every `null` collapses to `SymbolicDim("?")`. Correct semantics for the dynamic dim (a `TensorSpec` wildcard genuinely matches runtime behavior) but lossy for ragged dims (a `RaggedTensorSpec` is the precise emission—#524).

The TODO anchors at `testHasLikelyTensorParameter59` and at the translation site in `Function#inferInputSignature` continue to carry the flip references for wala/ML#544 (typed `RaggedDim`, fixed on Ariadne master via ponder-lab/ML#320 but not yet in a Hybridize-consumed release) and #524.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests` — 492 tests, 0 failures, 11 skipped
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- wala/ML#544—typed `RaggedDim` sentinel (Layer-1 flip target; fixed on Ariadne master).
- wala/ML#545—typed `DynamicDim` sentinel (Layer-1 flip target for the dynamic-dim positions in 67-70).
- #524—`RaggedTensorSpec` emission (Layer-2 flip target).
- #525—batch-2 (`from_nested_row_splits` fixtures 60-66).
- #522—batch-1 (fixtures 1-58 + 59).
