### PR TITLE
Bump `Formatting` submodule and clean up accumulated Javadoc violations

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1466,12 +1466,10 @@ public class Function {
 
 	/**
 	 * Infers the input signature of this function: an ordered tuple of {@link TensorType}s, one per non-{@code self} parameter the
-	 * tensor-type analysis associated with at least one tensor type.
-	 * <p>
-	 * Mirrors the no-argument pattern of {@link #getHasTensorParameter}: the values are computed during {@link #inferTensorParameters}
-	 * (which caches per-parameter tensor types on each {@link Parameter}), and this method reads those cached values.
-	 * <p>
-	 * For each non-{@code self} parameter, this method dispatches on {@link Parameter#isTensor()} into three categories:
+	 * tensor-type analysis associated with at least one tensor type. Mirrors the no-argument pattern of {@link #getHasTensorParameter}: the
+	 * values are computed during {@link #inferTensorParameters} (which caches per-parameter tensor types on each {@link Parameter}), and
+	 * this method reads those cached values. For each non-{@code self} parameter, this method dispatches on {@link Parameter#isTensor()}
+	 * into three categories:
 	 * <ul>
 	 * <li>Truly non-tensor ({@code isTensor() != TRUE}): drop the signature and emit a per-parameter INFO suggesting the source-side
 	 * recovery (annotate as {@code tf.Tensor} and wrap call sites with {@code tf.constant(...)}). The tool does not synthesize a
@@ -1483,7 +1481,6 @@ public class Function {
 	 * <li>Phase-2 hit ({@code isTensor() == TRUE && !getTensorTypes().isEmpty()}): reduce the cached set via {@link #inferSpec} and add the
 	 * reduced spec to the signature.
 	 * </ul>
-	 * <p>
 	 * Current scope: a single tensor type per parameter, with concrete dtype and concrete shape. Multi-context (#507) and other
 	 * non-concrete cases (#494) return {@link Optional#empty} pending future PRs that extend {@link #inferSpec}.
 	 *
@@ -1547,9 +1544,7 @@ public class Function {
 	}
 
 	/**
-	 * Reduces the multi-context set of {@link TensorType}s seen for a single parameter to a single {@link TensorType}.
-	 * <p>
-	 * Three steps:
+	 * Reduces the multi-context set of {@link TensorType}s seen for a single parameter to a single {@link TensorType}. Three steps:
 	 * <ol>
 	 * <li><b>Dtype consensus.</b> If the per-context dtypes don't agree on a single value, return {@link Optional#empty} (the
 	 * {@code |D| ≠ 1 ⇒ ⊥} branch). If the agreed dtype is {@code UNKNOWN} (dtype-⊤), also drop—pending #494, since {@code tf.UNKNOWN} isn't

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1547,7 +1547,9 @@ public class Function {
 	}
 
 	/**
-	 * Reduces the multi-context set of {@link TensorType}s seen for a single parameter to a single {@link TensorType} via three steps:
+	 * Reduces the multi-context set of {@link TensorType}s seen for a single parameter to a single {@link TensorType}.
+	 * <p>
+	 * Three steps:
 	 * <ol>
 	 * <li><b>Dtype consensus.</b> If the per-context dtypes don't agree on a single value, return {@link Optional#empty} (the
 	 * {@code |D| ≠ 1 ⇒ ⊥} branch). If the agreed dtype is {@code UNKNOWN} (dtype-⊤), also drop—pending #494, since {@code tf.UNKNOWN} isn't

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
@@ -6,12 +6,11 @@ import com.ibm.wala.cast.python.ml.types.TensorType;
 
 /**
  * The inferred input signature of a hybridizable function: an ordered tuple of {@link TensorType}s in declaration order, one per
- * non-{@code self} parameter. Produced by {@link Function#inferInputSignature}.
- * <p>
- * `InputSignature` is total over the function's non-{@code self} parameters: every non-{@code self} parameter contributes a
- * {@link TensorType}, or {@link Function#inferInputSignature} returns {@link java.util.Optional#empty} instead of producing a partial
- * signature. The per-parameter dispatch (tensor-classified-with-evidence vs tensor-classified-without-evidence vs truly non-tensor) and its
- * diagnostics live in {@link Function#inferInputSignature}; see that method's Javadoc and #508 for the rules.
+ * non-{@code self} parameter. Produced by {@link Function#inferInputSignature}. `InputSignature` is total over the function's
+ * non-{@code self} parameters: every non-{@code self} parameter contributes a {@link TensorType}, or {@link Function#inferInputSignature}
+ * returns {@link java.util.Optional#empty} instead of producing a partial signature. The per-parameter dispatch
+ * (tensor-classified-with-evidence vs tensor-classified-without-evidence vs truly non-tensor) and its diagnostics live in
+ * {@link Function#inferInputSignature}; see that method's Javadoc and #508 for the rules.
  */
 public record InputSignature(List<TensorType> parameterTypes) {
 }

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -195,11 +195,9 @@ public final class Parameter {
 	 * Returns the cached classification of whether this parameter is a tensor container (e.g., a list/tuple/dict whose elements are
 	 * tensors). Populated only when {@link #classifyAsTensor}'s Phase 3 ({@link #hasTensorContainer}) executes; earlier-returning phases
 	 * (self, type-hint hit, non-empty Phase 2 result, or empty call-graph nodes) leave it at the default. Returns {@code null} when
-	 * classification has not run or did not reach Phase 3.
-	 * <p>
-	 * Distinct from {@link #getTensorTypes()}: a tensor container is recognized as tensor-typed by Phase 3's container detection, but
-	 * Ariadne does not emit a single {@link TensorType} for the container itself. Consumers that distinguish "container of tensors" from
-	 * "direct tensor" should use this method.
+	 * classification has not run or did not reach Phase 3. Distinct from {@link #getTensorTypes()}: a tensor container is recognized as
+	 * tensor-typed by Phase 3's container detection, but Ariadne does not emit a single {@link TensorType} for the container itself.
+	 * Consumers that distinguish "container of tensors" from "direct tensor" should use this method.
 	 *
 	 * @return {@code TRUE} if Phase 3 classified this parameter as a tensor container, {@code FALSE} if Phase 3 ran and did not classify
 	 *         the parameter as a tensor container, or {@code null} if Phase 3 did not run (classification not started, or returned
@@ -210,10 +208,9 @@ public final class Parameter {
 	}
 
 	/**
-	 * Returns the fully-qualified name of this parameter's declared type hint, or {@code null} if no type hint is declared.
-	 * <p>
-	 * Only supports simple type hints that are directly {@link Attribute} expressions; more complex hints (e.g. subscripted generics) are
-	 * not supported and may trigger an exception.
+	 * Returns the fully-qualified name of this parameter's declared type hint, or {@code null} if no type hint is declared. Only supports
+	 * simple type hints that are directly {@link Attribute} expressions; more complex hints (e.g. subscripted generics) are not supported
+	 * and may trigger an exception.
 	 *
 	 * @return The fully-qualified name of the declared type hint, or {@code null} if no type hint is present.
 	 * @throws IllegalStateException If a type hint is declared but its AST node is not an {@link Attribute} (e.g., a subscripted generic
@@ -485,22 +482,18 @@ public final class Parameter {
 	}
 
 	/**
-	 * Infers the {@link TensorType}s the given {@link TensorTypeAnalysis} associates with this parameter.
-	 * <p>
-	 * The lattice contract (see {@code Tensor Type Generators} in {@code com.ibm.wala.cast.python.ml/CONTRIBUTING.md}) lives at the
-	 * <em>per-shape and per-dtype</em> level <em>inside</em> each {@link TensorType}: {@link TensorType#getDims()} {@code == null} is
-	 * shape-⊤, {@link TensorType#getDType()} {@code == DType.UNKNOWN} is dtype-⊤; the two axes are orthogonal. Empty-set outputs from a
-	 * generator's {@code getDefaultShapes} or {@code getDefaultDTypes} mean ⊥ at that generator's call site (per the contract tables).
-	 * <p>
-	 * {@code TensorVariable.state} (the accumulated {@code Set<TensorType>} the iterator surfaces) is <em>not</em> itself a lattice point.
-	 * Generators that classify a variable as a tensor but cannot determine shape/dtype emit a placeholder {@code TensorType(UNKNOWN, null)}
-	 * per the orthogonality rule, so a non-empty state means "Ariadne has at least one tensor classification (possibly ⊤ on either axis)"
-	 * and an empty state means "no generator emitted a TensorType for this variable" (effectively ⊥ at the variable level, under
-	 * contract-compliant generators). {@link TensorTypeAnalysis#iterator} filters its output to {@code state != null && !state.isEmpty()},
-	 * which collapses the iterator-side "variable not analyzed" case with the "Ariadne classified as not-a-tensor" case—both surface as no
-	 * entry.
-	 * <p>
-	 * What this method exposes to callers:
+	 * Infers the {@link TensorType}s the given {@link TensorTypeAnalysis} associates with this parameter. The lattice contract (see
+	 * {@code Tensor Type Generators} in {@code com.ibm.wala.cast.python.ml/CONTRIBUTING.md}) lives at the <em>per-shape and per-dtype</em>
+	 * level <em>inside</em> each {@link TensorType}: {@link TensorType#getDims()} {@code == null} is shape-⊤, {@link TensorType#getDType()}
+	 * {@code == DType.UNKNOWN} is dtype-⊤; the two axes are orthogonal. Empty-set outputs from a generator's {@code getDefaultShapes} or
+	 * {@code getDefaultDTypes} mean ⊥ at that generator's call site (per the contract tables). {@code TensorVariable.state} (the
+	 * accumulated {@code Set<TensorType>} the iterator surfaces) is <em>not</em> itself a lattice point. Generators that classify a
+	 * variable as a tensor but cannot determine shape/dtype emit a placeholder {@code TensorType(UNKNOWN, null)} per the orthogonality
+	 * rule, so a non-empty state means "Ariadne has at least one tensor classification (possibly ⊤ on either axis)" and an empty state
+	 * means "no generator emitted a TensorType for this variable" (effectively ⊥ at the variable level, under contract-compliant
+	 * generators). {@link TensorTypeAnalysis#iterator} filters its output to {@code state != null && !state.isEmpty()}, which collapses the
+	 * iterator-side "variable not analyzed" case with the "Ariadne classified as not-a-tensor" case—both surface as no entry. What this
+	 * method exposes to callers:
 	 * <ul>
 	 * <li>Empty {@code Set<TensorType>}: no iterator entry for this parameter. Equivalent to "Hybridize has no information"—either Ariadne
 	 * didn't analyze the variable or it classified the variable as not-a-tensor. Both behave identically for downstream consumers (e.g.,

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Util.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Util.java
@@ -239,10 +239,11 @@ public class Util {
 	}
 
 	/**
-	 * Returns the {@link exprType} associated with the given {@link decoratorsType}'s "function."
+	 * Returns the {@link exprType} associated with the given {@link decoratorsType}'s {@code function} attribute.
 	 *
-	 * @param decorator The {@link decoratorsType} for which to retrieve the associated {@link exprType} from its "function."
-	 * @return The {@link exprType} associated with the given {@link decoratorsType}'s "function."
+	 * @param decorator The {@link decoratorsType} for which to retrieve the associated {@link exprType} from its {@code function}
+	 *        attribute.
+	 * @return The {@link exprType} associated with the given {@link decoratorsType}'s {@code function} attribute.
 	 */
 	public static exprType getExpressionFromFunction(decoratorsType decorator) {
 		exprType func = decorator.func;

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8515,7 +8515,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 								.collect(Collectors.toList())))
 				.collect(toSet());
 		assertEquals("Tensor parameter `t` from `tf.constant([1.0, 2.0])` has dtype FLOAT32 and shape (2,).",
-				Set.of(Map.entry(FLOAT32, Collections.singletonList(2))), tensorShapesDtypes);
+				Set.of(Map.entry(FLOAT32, List.of(2))), tensorShapesDtypes);
 
 		// Non-tensor parameter must not surface a TensorType.
 		assertTrue("Non-tensor parameter `n` must have an empty `getTensorTypes()` cache.", n.getTensorTypes().isEmpty());
@@ -8685,7 +8685,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 								.collect(Collectors.toList())))
 				.collect(toSet());
 		assertEquals("Tensor parameter `t` from `tf.constant([1.0, 2.0])` has dtype FLOAT32 and shape (2,).",
-				Set.of(Map.entry(FLOAT32, Collections.singletonList(2))), tensorShapesDtypes);
+				Set.of(Map.entry(FLOAT32, List.of(2))), tensorShapesDtypes);
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -531,6 +531,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Returns whether the input test Python file should be executed under {@code python3.10} before analysis.
+	 *
 	 * @return True iff the input test Python file should be executed.
 	 */
 	public boolean getRunInputTestFile() {
@@ -538,6 +540,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Returns whether the output test Python file should be compared against the expected output after analysis.
+	 *
 	 * @return True iff the output test Python file should be compared.
 	 */
 	public boolean getCompareOutputTestFile() {
@@ -6744,7 +6748,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function#retracing,
+	 * Test https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function#retracing.
 	 */
 	@Test
 	public void testRetracing() throws Exception {
@@ -6759,7 +6763,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function#retracing,
+	 * Test https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function#retracing.
 	 */
 	@Test
 	public void testRetracing2() throws Exception {
@@ -6776,7 +6780,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function#retracing,
+	 * Test https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function#retracing.
 	 */
 	@Test
 	public void testRetracing3() throws Exception {
@@ -6797,7 +6801,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function#retracing,
+	 * Test https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function#retracing.
 	 */
 	@Test
 	public void testRetracing4() throws Exception {
@@ -6817,7 +6821,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function#retracing,
+	 * Test https://www.tensorflow.org/versions/r2.9/api_docs/python/tf/function#retracing.
 	 */
 	@Test
 	public void testRetracing5() throws Exception {
@@ -8332,7 +8336,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("xs", xs.getName());
 
 		assertTrue("Parameter `xs` should be classified as tensor-typed via Phase 3 (container).", xs.isTensor());
-		assertEquals("Phase 3 must populate the `isTensorContainer` cache to TRUE.", Boolean.TRUE, xs.isTensorContainer());
+		assertEquals("Phase 3 must populate the `isTensorContainer` cache to TRUE.", TRUE, xs.isTensorContainer());
 		assertTrue("Parameter `xs` must have an empty `getTensorTypes()` cache (no Phase 2 evidence for the container itself).",
 				xs.getTensorTypes().isEmpty());
 
@@ -8504,14 +8508,14 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertFalse("Tensor parameter must have a non-empty `getTensorTypes()` cache (Phase 2 fired).", t.getTensorTypes().isEmpty());
 
 		// The call site is `tf.constant([1.0, 2.0])`: shape (2,), dtype float32.
-		Set<Map.Entry<DType, List<Integer>>> tShapesDtypes = t.getTensorTypes().stream()
+		Set<Map.Entry<DType, List<Integer>>> tensorShapesDtypes = t.getTensorTypes().stream()
 				.map(tt -> Map.entry(tt.getDType(),
 						tt.getDims().stream()
 								.map(d -> d instanceof TensorType.NumericDim ? ((TensorType.NumericDim) d).value() : Integer.valueOf(-1))
 								.collect(Collectors.toList())))
 				.collect(toSet());
 		assertEquals("Tensor parameter `t` from `tf.constant([1.0, 2.0])` has dtype FLOAT32 and shape (2,).",
-				Set.of(Map.entry(FLOAT32, Collections.singletonList(2))), tShapesDtypes);
+				Set.of(Map.entry(FLOAT32, Collections.singletonList(2))), tensorShapesDtypes);
 
 		// Non-tensor parameter must not surface a TensorType.
 		assertTrue("Non-tensor parameter `n` must have an empty `getTensorTypes()` cache.", n.getTensorTypes().isEmpty());
@@ -8674,14 +8678,14 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertTrue("Method with a tensor parameter ⇒ `getHasTensorParameter() == TRUE`.", function.getHasTensorParameter());
 
 		// The call site is `C().m(tf.constant([1.0, 2.0]))`: shape (2,), dtype float32.
-		Set<Map.Entry<DType, List<Integer>>> tShapesDtypes = t.getTensorTypes().stream()
+		Set<Map.Entry<DType, List<Integer>>> tensorShapesDtypes = t.getTensorTypes().stream()
 				.map(tt -> Map.entry(tt.getDType(),
 						tt.getDims().stream()
 								.map(d -> d instanceof TensorType.NumericDim ? ((TensorType.NumericDim) d).value() : Integer.valueOf(-1))
 								.collect(Collectors.toList())))
 				.collect(toSet());
 		assertEquals("Tensor parameter `t` from `tf.constant([1.0, 2.0])` has dtype FLOAT32 and shape (2,).",
-				Set.of(Map.entry(FLOAT32, Collections.singletonList(2))), tShapesDtypes);
+				Set.of(Map.entry(FLOAT32, Collections.singletonList(2))), tensorShapesDtypes);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Bump the `Formatting` submodule from `28d5cc4` (long-stale pin) to current master `f5f1907`. Consumes ponder-lab/Formatting#2 (require `@param` / `@return` on documented methods) plus other rule additions that have accumulated independently.
- Fix the violations the bump surfaces (11 in core, 10 in the test file). None are semantic—all are pre-existing Javadoc prose that the older `Formatting` pin had not yet flagged.

## Categories Fixed

- **`JavadocParagraph`** (`<p>` tag needs a preceding blank Javadoc line): 5 in `Parameter.java`, 3 in `Function.java`, 1 in `InputSignature.java`.
- **`SummaryJavadoc`** (first sentence needs ending period): 2 in core (`Util#getFunction` rewrite from `"function."` to `{@code function} attribute.`; reduce-multi-context Javadoc split into summary sentence + `<p>Three steps:` continuation), 5 in test file (trailing-comma URLs in `testRetracing` Javadoc), 2 "summary javadoc missing" (Javadoc starting with `@return` instead of a summary sentence).
- **`RegexpSinglelineJava`** (no `Boolean.TRUE` / `Boolean.FALSE`): 1 in the test file → static-imported `TRUE`.
- **`LocalVariableName`** (camelCase regex): 4 occurrences of `tShapesDtypes` (violates `^[a-z]([a-z0-9][a-zA-Z0-9]*)?$` because the second character is uppercase `S`) renamed to `tensorShapesDtypes`.

## Test Plan

- [x] `./mvnw checkstyle:check` — 0 violations
- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests` — 492 tests, 0 failures, 11 skipped
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- ponder-lab/Formatting#2—the change that prompted the bump.
- #526—the earlier Javadoc tag improvements that landed the `@param`/`@return` cleanups; this PR finishes the prose-level cleanups the same bump would also have surfaced.
