### PR TITLE
Extend precision audit to fixtures 83-93 (`random.*` family)

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4118,7 +4118,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `random.gamma`.
+	 * Test for #2 for TF API `random.normal`.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter88() throws Exception {
@@ -4126,7 +4126,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `random.gamma`.
+	 * Test for #2 for TF API `random.normal`.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter89() throws Exception {

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3823,6 +3823,17 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Precision-audit overload for the canonical case where Layer 1 and Layer 2 agree (dense tensors with concrete shape and dtype).
+	 * Delegates to {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)} with {@code expected} for both layers.
+	 *
+	 * @param expected The expected {@link TensorType} reported by Ariadne and produced unchanged by the inference algorithm.
+	 * @throws Exception If the underlying analysis fails.
+	 */
+	private void testHasLikelyTensorParameterHelper(TensorType expected) throws Exception {
+		testHasLikelyTensorParameterHelper(expected, expected);
+	}
+
+	/**
 	 * Test for #2 for TF API `RaggedTensor.from_nested_row_splits`.
 	 */
 	@Test
@@ -4071,7 +4082,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter83() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4079,7 +4090,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter84() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4087,7 +4098,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter85() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4095,7 +4106,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter86() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4103,7 +4114,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter87() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(4))));
 	}
 
 	/**
@@ -4111,7 +4122,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter88() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(4))));
 	}
 
 	/**
@@ -4119,7 +4130,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter89() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(4))));
 	}
 
 	/**
@@ -4127,7 +4138,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter90() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4135,7 +4146,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter91() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4143,7 +4154,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter92() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4151,7 +4162,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter93() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2))));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Extend the two-layer precision audit to fixtures 83-93, covering the full `tf.random.*` constructor family (`random.gamma`, `random.normal`, `random.poisson`, `random.truncated_normal`).
- Add the one-arg `testHasLikelyTensorParameterHelper(TensorType expected)` overload back—removed in #525 for being unused, restored here as the first caller is the symmetric-Layer-1==Layer-2 case that this batch represents.

## Findings

All eleven fixtures are **IDEAL**: Layer 1 (Ariadne) and Layer 2 (Hybridize inference) both match the Python runtime ground truth exactly. No TODO anchors, no upstream gaps surfaced.

| Fixtures | API | Predicted shape & dtype |
|---|---|---|
| 83-86 | `random.gamma(shape=[10], alpha=[2 floats])` | `FLOAT32, (10, 2)` (from `shape + broadcast(alpha)`) |
| 87-89 | `random.normal(shape=[4], mean, stddev, tf.float32)` | `FLOAT32, (4,)` |
| 90-91 | `random.poisson(shape=[10], lam=[2 floats])` | `FLOAT32, (10, 2)` |
| 92-93 | `random.truncated_normal(shape=[2])` | `FLOAT32, (2,)` |

Every prediction was first-try-correct against the actual Ariadne output—convergence between the mental model and Ariadne's emission for this family is high.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests` — 492 tests, 0 failures, 11 skipped
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- #530—batch-3 (`RaggedTensor.from_*` family, fixtures 67-82).
