### PR TITLE
Extend precision audit to fixtures 94-99 (`sparse.eye` and `linalg.eye`)

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4170,7 +4170,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
@@ -4178,7 +4180,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
@@ -4186,7 +4190,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
@@ -4194,7 +4200,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter97() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2))));
 	}
 
 	/**
@@ -4202,7 +4208,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter98() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2))));
 	}
 
 	/**
@@ -4210,7 +4216,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter99() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3823,6 +3823,17 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Precision-audit overload for the canonical case where Layer 1 and Layer 2 agree (dense tensors with concrete shape and dtype).
+	 * Delegates to {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)} with {@code expected} for both layers.
+	 *
+	 * @param expected The expected {@link TensorType} reported by Ariadne and produced unchanged by the inference algorithm.
+	 * @throws Exception If the underlying analysis fails.
+	 */
+	private void testHasLikelyTensorParameterHelper(TensorType expected) throws Exception {
+		testHasLikelyTensorParameterHelper(expected, expected);
+	}
+
+	/**
 	 * Test for #2 for TF API `RaggedTensor.from_nested_row_splits`.
 	 */
 	@Test
@@ -4071,7 +4082,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter83() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4079,7 +4090,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter84() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4087,7 +4098,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter85() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4095,7 +4106,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter86() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4103,7 +4114,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter87() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(4))));
 	}
 
 	/**
@@ -4111,7 +4122,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter88() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(4))));
 	}
 
 	/**
@@ -4119,7 +4130,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter89() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(4))));
 	}
 
 	/**
@@ -4127,7 +4138,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter90() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4135,7 +4146,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter91() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(10), new NumericDim(2))));
 	}
 
 	/**
@@ -4143,7 +4154,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter92() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4151,7 +4162,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter93() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3823,8 +3823,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Precision-audit overload for the canonical case where Layer 1 and Layer 2 agree (dense tensors with concrete shape and dtype).
-	 * Delegates to {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)} with {@code expected} for both layers.
+	 * Precision-audit overload for fixtures where Layer 1 and Layer 2 agree numerically. Delegates to
+	 * {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)} with {@code expected} for both layers. Suitable for dense tensors
+	 * with concrete shape and dtype, and also for sparse-tensor fixtures whose numerical assertions match the dense form even though their
+	 * runtime spec emission is semantically distinct (see #533).
 	 *
 	 * @param expected The expected {@link TensorType} reported by Ariadne and produced unchanged by the inference algorithm.
 	 * @throws Exception If the underlying analysis fails.


### PR DESCRIPTION
## Summary

- Extend the two-layer precision audit to fixtures 94-99, covering `tf.sparse.eye` (94-96) and `tf.linalg.eye` (97-99).
- File #533 capturing a runtime-semantics finding on the sparse half: emit `SparseTensorSpec` for sparse-tensor parameters in inferred input signatures (sibling to #524 for ragged).

## Findings

| Fixtures | API | Layer 1 / Layer 2 | Verdict |
|---|---|---|---|
| 94-96 | `sparse.eye(2, 3)` | `FLOAT32, (2, 3)` (both layers) | Numerically IDEAL, runtime-semantically broken |
| 97-99 | `linalg.eye(2)` | `FLOAT32, (2, 2)` (both layers) | IDEAL |

**The sparse finding.** Ariadne emits the exact static shape and dtype for `sparse.eye(2, 3)` (no precision gap—the numbers are right). The inference algorithm passes the `TensorType` through to a `TensorSpec`. But a `tf.function(input_signature=[TensorSpec(shape=(2, 3), dtype=float32)])` rejects a `SparseTensor` argument at runtime—TF distinguishes the two at the API level. The precise emission is `tf.SparseTensorSpec`, which captures the sparseness signal as well as the shape and dtype.

This is structurally distinct from the ragged finding (#524). Ragged-marker `null` is visible at the per-dim level in `TensorType.dims`, so the audit's per-dim assertions surface the imprecision directly. Sparse-vs-dense is invisible at the `TensorType` level—Ariadne emits the same shape and dtype for `sparse.eye(2, 3)` as it would for a dense (2, 3) tensor. Detecting sparseness requires a different signal: the producing tensor generator, or a sparse-aware extension of Ariadne's representation.

Inline TODO comments at fixtures 94-96 reference #533; the numerical assertions pin current behavior unchanged.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests` — 492 tests, 0 failures, 11 skipped
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- #533—`SparseTensorSpec` emission (Layer-2 flip target for sparse parameters).
- #524—`RaggedTensorSpec` emission (sibling case for ragged).
- #532—batch-4 (`random.*` family, all IDEAL).
