### PR TITLE
Extend precision audit to fixtures 100-104 (`keras.Input`)

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4226,7 +4226,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter100() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
 	/**
@@ -4234,7 +4235,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter101() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
 	/**
@@ -4242,7 +4244,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter102() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
 	/**
@@ -4250,7 +4253,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter103() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
 	/**
@@ -4258,7 +4262,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter104() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Extend the two-layer precision audit to fixtures 100-104, covering `tf.keras.Input(shape=(32,))` — the bare `keras.Input` case, distinct from 67-70 where `keras.Input` fed into ragged generators.

## Findings

All five fixtures share the same Layer 1 / Layer 2 shape:

- **Layer 1 (Ariadne):** `FLOAT32, (null, NumericDim(32))` — raw `null` for the dynamic batch dim per wala/ML#545's representation-hygiene tracking.
- **Layer 2 (Hybridize):** `FLOAT32, (SymbolicDim("?"), NumericDim(32))` — the inference algorithm collapses the `null` to a `SymbolicDim("?")` wildcard.

**Crucially, Layer 2's collapse is correct here, unlike the ragged case.** A `TensorSpec(shape=(?, 32), dtype=float32)` accurately represents the runtime contract: a `keras.Input` parameter genuinely admits any batch size at call time, and `SymbolicDim("?")` is the right encoding for "any value." No #524-style flip target on the Layer 2 side—the only TODO is on Layer 1, against wala/ML#545 (typed `DynamicDim` sentinel).

## Verdict

This is the first batch where the Layer 1 / Layer 2 asymmetry is **not** an audit finding. Ragged tensors (#524) have a runtime-incorrect Layer 2 (need `RaggedTensorSpec`). Sparse tensors (#533) have a numerically-correct-but-runtime-incorrect Layer 2 (need `SparseTensorSpec`). Dynamic-batch dims via `keras.Input` just need `SymbolicDim("?")`, which is exactly what Hybridize already emits.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests` — 492 tests, 0 failures, 11 skipped
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- wala/ML#545—typed `DynamicDim` sentinel (Layer-1 flip target).
- #534—batch-5 (`sparse.eye` / `linalg.eye`).
- #532—batch-4 (`random.*`).
