### PR TITLE
Extend precision audit to fixtures 105-108 (`ragged.constant`)

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4271,7 +4271,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter105() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4279,7 +4279,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter106() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4287,7 +4287,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter107() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4295,7 +4295,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter108() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Extend the two-layer precision audit to fixtures 105-108, covering `tf.ragged.constant(pylist)` with `pylist = [1, 2]` / `[2, 2]` (flat lists, no nested structure).

## Findings

All four fixtures: `INT32, (NumericDim(2))` at both Layer 1 and Layer 2. **IDEAL.**

The ragged-constant Ariadne path (`RaggedConstant.java`) emits no ragged-marker `null` entries for flat-list inputs—the `shape.add(null)` loop runs zero times when `ragged_rank = 0`. Hybridize's inference passes the shape through unchanged.

**Runtime verification:** `python3.10 -c "import tensorflow as tf; print(type(tf.ragged.constant([1, 2])))"` returns `EagerTensor`, not `RaggedTensor`. The flat-list case degenerates to a regular dense tensor at runtime, so the emitted `TensorSpec(shape=(2,), dtype=int32)` accurately represents the runtime contract. No #524-style flip target for these fixtures.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests` — 492 tests, 0 failures, 11 skipped
- [x] Runtime type verified via `python3.10`
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- #535—batch-6 (`keras.Input`, dynamic-batch IDEAL).
