### PR TITLE
Extend precision audit to fixtures 118-122 (`RaggedTensor.from_nested_row_lengths`)

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4405,7 +4405,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter118() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4413,7 +4414,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter119() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4421,7 +4423,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter120() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4429,7 +4432,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter121() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4437,7 +4441,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter122() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4171,8 +4171,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.eye`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
@@ -4183,8 +4184,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.eye`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
@@ -4195,8 +4197,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.eye`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
@@ -4308,8 +4311,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.SparseTensor`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
@@ -4320,8 +4324,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.SparseTensor`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
@@ -4332,8 +4337,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.SparseTensor`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4173,7 +4173,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4183,7 +4184,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4193,7 +4195,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4304,7 +4307,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
@@ -4314,7 +4318,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
@@ -4324,7 +4329,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4271,7 +4271,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter105() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4279,7 +4279,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter106() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4287,7 +4287,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter107() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4295,7 +4295,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter108() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4303,7 +4303,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
@@ -4311,7 +4313,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
@@ -4319,7 +4323,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4169,34 +4169,37 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 	/**
 	 * Test for #2 for TF API `sparse.eye`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.eye`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.eye`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4303,34 +4306,37 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 	/**
 	 * Test for #2 for TF API `sparse.SparseTensor`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.SparseTensor`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.SparseTensor`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4333,7 +4333,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter112() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4341,7 +4342,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter113() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4349,7 +4351,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter114() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4357,7 +4360,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter115() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4365,7 +4369,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter116() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4373,7 +4378,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter117() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Extend the two-layer precision audit to fixtures 118-122, covering `tf.RaggedTensor.from_nested_row_lengths(values, nested_row_lengths)`.

## Findings

All five fixtures exercise the same call shape: `x = tf.keras.Input(shape=[None], dtype=tf.string)` paired with `nested_row_lengths = [[2, 1, 0, 2], [2, 0, 3, 1, 1]]`. Outer count `4` comes from `len(nested_row_lengths[0]) = 4`; two ragged dims (K=2) plus the dynamic-batch dim from `keras.Input` give a rank-4 STRING tensor.

- **Layer 1 (Ariadne):** `STRING, (NumericDim(4), null, null, null)`—outer constant, two ragged-marker nulls, one dynamic-dim null.
- **Layer 2 (Hybridize):** `STRING, (NumericDim(4), SymbolicDim("?"), SymbolicDim("?"), SymbolicDim("?"))`.

Same shape pattern as fixtures 67-70 (`from_nested_value_rowids`). The Layer-2 collapse is correct for the dynamic-dim position (admits any batch size in a `TensorSpec`) but lossy for the two ragged-marker positions (need `RaggedTensorSpec`); the TODO anchoring at `testHasLikelyTensorParameter59` and the translation site carries the flip targets.

Ariadne could in principle compute per-row lengths from the static `nested_row_lengths` values (`[2, 1, 0, 2]` and `[2, 0, 3, 1, 1]`) and emit concrete `NumericDim` instead of ragged-marker null at positions 1 and 2. That narrower precision gap is covered by wala/ML#546.

## Stacking

Stacked on #538 (batch-9 `ragged.range`). The diff against `main` currently includes both batches; will clean up automatically once #538 merges.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests`—492 tests, 0 failures, 11 skipped
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- #524—`RaggedTensorSpec` emission (Layer-2 flip target for the ragged positions).
- wala/ML#544—typed `RaggedDim` sentinel (Layer-1 representation, fixed on master).
- wala/ML#545—typed `DynamicDim` sentinel (Layer-1 representation for the dynamic-batch position).
- wala/ML#546—static-args-to-`NumericDim` precision gap across the ragged-tensor family.
- #538—batch-9 (`ragged.range`, parent in the stack).
