### PR TITLE
Extend precision audit to fixtures 126-129 (`tf.experimental.numpy.ndarray`)

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4405,7 +4405,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter118() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4413,7 +4414,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter119() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4421,7 +4423,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter120() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4429,7 +4432,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter121() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4437,7 +4441,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter122() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4171,8 +4171,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.eye`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
@@ -4183,8 +4184,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.eye`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
@@ -4195,8 +4197,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.eye`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
@@ -4308,8 +4311,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.SparseTensor`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
@@ -4320,8 +4324,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.SparseTensor`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
@@ -4332,8 +4337,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.SparseTensor`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3794,10 +3794,6 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		testHasLikelyTensorParameterHelper(false, true);
 	}
 
-	private void testHasLikelyTensorParameterHelper(boolean expectingHybridFunction) throws Exception {
-		testHasLikelyTensorParameterHelper(expectingHybridFunction, true);
-	}
-
 	/**
 	 * Precision-audit overload: in addition to the structural checks of {@link #testHasLikelyTensorParameterHelper()}, asserts that both
 	 * parameters carry exactly {@code layer1} as their inferred tensor type (Layer 1) and that the inferred input signature is
@@ -3833,6 +3829,26 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	private void testHasLikelyTensorParameterHelper(TensorType expected) throws Exception {
 		testHasLikelyTensorParameterHelper(expected, expected);
+	}
+
+	/**
+	 * Precision-audit overload that also accepts the expected hybrid-function status. Equivalent to
+	 * {@link #testHasLikelyTensorParameterHelper(TensorType)} but parameterized on {@code expectingHybridFunction}; needed for fixtures
+	 * exercising {@code @tf.function}-decorated functions where the structural check expects {@code isHybrid() == true}.
+	 *
+	 * @param expectingHybridFunction The expected value of {@link Function#isHybrid()} for the loaded function.
+	 * @param expected The expected {@link TensorType} reported by Ariadne and produced unchanged by the inference algorithm.
+	 * @throws Exception If the underlying analysis fails.
+	 */
+	private void testHasLikelyTensorParameterHelper(boolean expectingHybridFunction, TensorType expected) throws Exception {
+		Function function = testHasLikelyTensorParameterHelper(expectingHybridFunction, true);
+		Parameter a = function.getParameters().get(0);
+		Parameter b = function.getParameters().get(1);
+		assertEquals(Set.of(expected), a.getTensorTypes());
+		assertEquals(Set.of(expected), b.getTensorTypes());
+		Optional<InputSignature> sig = function.inferInputSignature();
+		assertTrue(sig.isPresent());
+		assertEquals(List.of(expected, expected), sig.get().parameterTypes());
 	}
 
 	/**
@@ -4450,31 +4466,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter123() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertNotNull(functions);
-		assertEquals(1, functions.size());
-		Function function = functions.iterator().next();
-		assertNotNull(function);
-		assertTrue(function.isHybrid());
-
-		List<Parameter> params = function.getParameters();
-
-		// two params.
-		assertEquals(2, params.size());
-
-		Parameter actualParameter = params.get(0);
-		assertNotNull(actualParameter);
-
-		String paramName = actualParameter.getName();
-		assertEquals("a", paramName);
-
-		actualParameter = params.get(1);
-		assertNotNull(actualParameter);
-
-		paramName = actualParameter.getName();
-		assertEquals("b", paramName);
-
-		assertTrue("Expecting function with likely tensor parameter.", function.getHasTensorParameter());
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4659,7 +4651,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter134() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4667,8 +4659,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter135() throws Exception {
-		// Same test as testHasLikelyTensorParameter123 but the tf.function has a parenthesis.
-		testHasLikelyTensorParameterHelper(true);
+		// Same test as testHasLikelyTensorParameter123 but with a tf.function has a parenthesis.
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4677,7 +4669,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter136() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4686,7 +4678,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter137() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4695,7 +4687,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter138() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4704,7 +4696,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter139() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4713,7 +4705,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter140() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4722,7 +4714,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter141() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4731,7 +4723,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter142() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4740,7 +4732,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter143() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4492,15 +4492,15 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter126() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of()));
 	}
 
 	/**
-	 * Test for #2 for TF API `tf.keras.layers.Input`.
+	 * Test for #2 for TF API `tf.experimental.numpy.ndarray`.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter127() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of()));
 	}
 
 	/**
@@ -4508,7 +4508,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter128() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of()));
 	}
 
 	/**
@@ -4516,7 +4516,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter129() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of()));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4659,7 +4659,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter135() throws Exception {
-		// Same test as testHasLikelyTensorParameter123 but with a tf.function has a parenthesis.
+		// Same test as testHasLikelyTensorParameter123 but the tf.function has parentheses.
 		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4173,7 +4173,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4183,7 +4184,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4193,7 +4195,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4304,7 +4307,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
@@ -4314,7 +4318,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
@@ -4324,7 +4329,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4271,7 +4271,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter105() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4279,7 +4279,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter106() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4287,7 +4287,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter107() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4295,7 +4295,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter108() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4474,7 +4474,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter124() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
 	/**
@@ -4482,7 +4483,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter125() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4303,7 +4303,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
@@ -4311,7 +4313,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
@@ -4319,7 +4323,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4742,7 +4742,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter144() throws Exception {
-		testHasLikelyTensorParameterHelper(false, true);
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of()));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4169,34 +4169,37 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 	/**
 	 * Test for #2 for TF API `sparse.eye`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.eye`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.eye`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4303,34 +4306,37 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 	/**
 	 * Test for #2 for TF API `sparse.SparseTensor`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.SparseTensor`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.SparseTensor`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4333,7 +4333,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter112() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4341,7 +4342,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter113() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4349,7 +4351,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter114() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4357,7 +4360,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter115() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4365,7 +4369,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter116() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4373,7 +4378,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter117() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Extend the two-layer precision audit to:

- Fixtures 126-129—`tf.experimental.numpy.ndarray` family with the `value_index(a, b)` access pattern.
- Fixture 144—`tf.data.Dataset.from_tensor_slices` iteration (merged in via the stacked #543 cascade).

Fix one stale Javadoc (fixture 127 was tagged `tf.keras.layers.Input` but its Python actually uses `tf.experimental.numpy.ndarray`).

## Findings

All five fixtures are **IDEAL**.

| Fixtures | API | Layer 1 / Layer 2 |
|---|---|---|
| 126-129 | `tf.experimental.numpy.ndarray(op, 0, tf.float32)` | `FLOAT32, ()` (scalar) at both layers |
| 144 | `tf.data.Dataset.from_tensor_slices([1, 2, 3])` iteration | `INT32, ()` (scalar) at both layers |

**Runtime verification (via `python3.10`):**

- `tf.experimental.numpy.ndarray(op, 0, tf.float32)` returns `tensorflow.python.framework.ops.Tensor`—a regular dense Tensor of shape `()` and FLOAT32 dtype. Same shape pattern as fixture 25 (which uses the `tf.Tensor(op, 0, tf.float32)` low-level constructor).
- `tf.data.Dataset.from_tensor_slices([1, 2, 3]).element_spec` is `TensorSpec(shape=(), dtype=tf.int32)`. Iterated elements have `shape=()` and `dtype=int32`.

The inferred `TensorSpec(shape=(), dtype=...)` accurately admits each function's call sites in both cases.

## Out of Scope

Fixtures 130-133 use the same `tf.experimental.numpy.ndarray` API but with a different surrounding structure (two top-level functions, `@tf.function`-decorated outer, internal `tf.matmul`); deferred to a follow-up.

Fixtures 145-158 each have distinct shapes (multi-context, container, hybrid-inlined, tuple-arg with type hints); each is its own batch.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests`—492 tests, 0 failures, 11 skipped
- [x] Runtime types verified via `python3.10`
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- #541—batch-12 (`tf.keras.layers.Input`).
- #543—batch-14 (`tf.data.Dataset.from_tensor_slices`, merged into this branch via the stacked cascade).
- #535—earlier `tf.keras.Input` audit.
