### PR TITLE
Extend precision audit to fixture 144 (`tf.data.Dataset.from_tensor_slices`)

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4742,7 +4742,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter144() throws Exception {
-		testHasLikelyTensorParameterHelper(false, true);
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of()));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Extend the precision audit to fixture 144, covering `tf.data.Dataset.from_tensor_slices([1, 2, 3])` iteration.

## Findings

Runtime verification (via `python3.10`): iterating `tf.data.Dataset.from_tensor_slices([1, 2, 3])` yields `EagerTensor` of `INT32, shape=()`—scalar elements.

IDEAL: `INT32, ()` at both Layer 1 and Layer 2. The inferred `TensorSpec(shape=(), dtype=int32)` accurately represents what the function admits.

## Out of Scope

Fixtures 145-158 share the dataset/tuple/list family but each warrants its own batch:

- **145** (multi-context `tf.ones([1, 2])` and `tf.ones([2, 2])`): same pattern as fixture 15—needs explicit Set membership assertion.
- **146** (list passed directly via Phase-3 container detection): `getTensorTypes()` is empty by design; the helper's symmetric assertion doesn't apply.
- **147** (`getHasTensorParameter() == false`): the structural assertion expects no tensor parameter.
- **148-149** (inlined hybrid tests): existing tests are inlined; audit needs inline.
- **150-158** (single-arg tuple parameter with type hints): function signature is `add(t)`, not `add(a, b)`; needs a new helper or inlining.
- **130-133** (`tf.experimental.numpy.ndarray` with two-function structure): deferred from #542.

Each will need careful framing to surface meaningful audit findings rather than rubber-stamp assertions.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests`—492 tests, 0 failures, 11 skipped
- [x] Runtime type verified via `python3.10`
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- #542—batch-13 (`tf.experimental.numpy.ndarray`, parent in the stack).
