### PR TITLE
Clarify `testHasLikelyTensorParameterHelper` Javadocs

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3800,17 +3800,14 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * {@link #testHasLikelyTensorParameterHelper(boolean, boolean)}) where both parameters {@code a} and {@code b} are expected to share
 	 * the same per-parameter type at each of Layer 1 (Ariadne) and Layer 2 (Hybridize). On top of the structural checks, this overload
 	 * asserts {@code a.getTensorTypes().equals(Set.of(layer1))} and the symmetric assertion for {@code b}, then asserts that
-	 * {@link Function#inferInputSignature()} returns {@code [layer2, layer2]}.
-	 * <p>
-	 * The same-type-for-both-parameters assumption matches every fixture in the audit corpus today—call sites pass the same kind of tensor
-	 * for both arguments. For asymmetric per-parameter expectations (e.g., {@link #testHasLikelyTensorParameter11()} where {@code a} is
-	 * shape {@code (1, 2)} and {@code b} is shape {@code (2, 2)}), fixtures inline their own assertions instead of using this helper.
-	 * <p>
-	 * The two-layer form is needed when Ariadne's emitted {@link TensorType} differs from the {@link TensorType} the inference algorithm
-	 * produces—an upstream representation gap or an algorithm-side collapse. The canonical case is ragged tensors; see
-	 * {@link #testHasLikelyTensorParameter59()} for the TODO-anchored fixture and the upstream / downstream flip targets wala/ML#544 and
-	 * #524. Signature-drop cases (where {@link Function#inferInputSignature()} returns {@link Optional#empty}) must still inline their own
-	 * {@link Optional#empty} assertion.
+	 * {@link Function#inferInputSignature()} returns {@code [layer2, layer2]}. The same-type-for-both-parameters assumption matches every
+	 * fixture in the audit corpus today—call sites pass the same kind of tensor for both arguments. For asymmetric per-parameter
+	 * expectations (e.g., {@link #testHasLikelyTensorParameter11()} where {@code a} is shape {@code (1, 2)} and {@code b} is shape
+	 * {@code (2, 2)}), fixtures inline their own assertions instead of using this helper. The two-layer form is needed when Ariadne's
+	 * emitted {@link TensorType} differs from the {@link TensorType} the inference algorithm produces—an upstream representation gap or an
+	 * algorithm-side collapse. The canonical case is ragged tensors; see {@link #testHasLikelyTensorParameter59()} for the TODO-anchored
+	 * fixture and the upstream/downstream flip targets wala/ML#544 and #524. Signature-drop cases (where
+	 * {@link Function#inferInputSignature()} returns {@link Optional#empty}) must still inline their own {@link Optional#empty} assertion.
 	 *
 	 * @param layer1 The per-parameter {@link TensorType} expected from Ariadne via {@link Parameter#getTensorTypes()}; applied identically
 	 *        to {@code a} and {@code b}.
@@ -3834,11 +3831,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * {@link #testHasLikelyTensorParameterHelper(boolean, boolean)}) where Layer 1 (Ariadne) and Layer 2 (Hybridize) agree: both parameters
 	 * {@code a} and {@code b} carry {@code expected} from Ariadne and the inferred input signature is {@code [expected, expected]}.
 	 * Delegates to {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)} with {@code expected} passed for both layer
-	 * arguments.
-	 * <p>
-	 * Suitable for IDEAL fixtures (dense tensors with concrete shape and dtype) and for sparse-tensor fixtures whose numerical assertion
-	 * matches the dense form even though their runtime spec emission is semantically distinct (see #533). For asymmetric layer expectations
-	 * or asymmetric per-parameter expectations, see the helpers / inline patterns referenced in
+	 * arguments. Suitable for IDEAL fixtures (dense tensors with concrete shape and dtype) and for sparse-tensor fixtures whose numerical
+	 * assertion matches the dense form even though their runtime spec emission is semantically distinct (see #533). For asymmetric layer
+	 * expectations or asymmetric per-parameter expectations, see the helpers/inline patterns referenced in
 	 * {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)}.
 	 *
 	 * @param expected The {@link TensorType} expected at Layer 1 (Ariadne's {@link Parameter#getTensorTypes()}) and at Layer 2 (Hybridize's
@@ -4206,10 +4201,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.eye`.
-	 * <p>
-	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.eye`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects
+	 * {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
@@ -4219,10 +4212,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.eye`.
-	 * <p>
-	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.eye`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects
+	 * {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
@@ -4232,10 +4223,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.eye`.
-	 * <p>
-	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.eye`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects
+	 * {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
@@ -4346,10 +4335,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.SparseTensor`.
-	 * <p>
-	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.SparseTensor`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec}
+	 * rejects {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
@@ -4359,10 +4346,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.SparseTensor`.
-	 * <p>
-	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.SparseTensor`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec}
+	 * rejects {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
@@ -4372,10 +4357,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.SparseTensor`.
-	 * <p>
-	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.SparseTensor`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec}
+	 * rejects {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3750,9 +3750,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Runs the structural assertions for the canonical two-parameter {@code (a, b)} fixture shape. Returns the validated {@link Function}
-	 * so callers performing additional assertions (e.g., the precision-audit overload at
-	 * {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)}) can reuse the same instance instead of triggering a second
+	 * Runs the structural assertions for the canonical two-parameter fixture shape: the file under test must contain exactly one function,
+	 * that function must have exactly two parameters named {@code a} and {@code b}, and its {@link Function#isHybrid()} and
+	 * {@link Function#getHasTensorParameter()} must match the supplied expectations. Returns the validated {@link Function} so callers
+	 * performing additional assertions (e.g., the precision-audit overloads) can reuse the same instance instead of triggering a second
 	 * {@link #getFunctions()} pass.
 	 *
 	 * @param expectingHybridFunction The expected value of {@link Function#isHybrid()} for the loaded function.
@@ -3795,16 +3796,26 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Precision-audit overload: in addition to the structural checks of {@link #testHasLikelyTensorParameterHelper()}, asserts that both
-	 * parameters carry exactly {@code layer1} as their inferred tensor type (Layer 1) and that the inferred input signature is
-	 * {@code [layer2, layer2]} (Layer 2). When Layer 1 and Layer 2 agree (the common case), pass the same {@link TensorType} for both
-	 * arguments. The two-layer form is needed when an upstream representation gap or an algorithm-side collapse produces a Layer-2 type
-	 * strictly distinct from Layer 1 (e.g., ragged tensors—see {@link #testHasLikelyTensorParameter59()} for the TODO-anchored canonical
-	 * fixture and the upstream/downstream flip targets wala/ML#544 and #524). Signature-drop cases must still inline their own
+	 * Precision-audit overload for the canonical two-parameter fixture shape (verified by
+	 * {@link #testHasLikelyTensorParameterHelper(boolean, boolean)}) where both parameters {@code a} and {@code b} are expected to share
+	 * the same per-parameter type at each of Layer 1 (Ariadne) and Layer 2 (Hybridize). On top of the structural checks, this overload
+	 * asserts {@code a.getTensorTypes().equals(Set.of(layer1))} and the symmetric assertion for {@code b}, then asserts that
+	 * {@link Function#inferInputSignature()} returns {@code [layer2, layer2]}.
+	 * <p>
+	 * The same-type-for-both-parameters assumption matches every fixture in the audit corpus today—call sites pass the same kind of tensor
+	 * for both arguments. For asymmetric per-parameter expectations (e.g., {@link #testHasLikelyTensorParameter11()} where {@code a} is
+	 * shape {@code (1, 2)} and {@code b} is shape {@code (2, 2)}), fixtures inline their own assertions instead of using this helper.
+	 * <p>
+	 * The two-layer form is needed when Ariadne's emitted {@link TensorType} differs from the {@link TensorType} the inference algorithm
+	 * produces—an upstream representation gap or an algorithm-side collapse. The canonical case is ragged tensors; see
+	 * {@link #testHasLikelyTensorParameter59()} for the TODO-anchored fixture and the upstream / downstream flip targets wala/ML#544 and
+	 * #524. Signature-drop cases (where {@link Function#inferInputSignature()} returns {@link Optional#empty}) must still inline their own
 	 * {@link Optional#empty} assertion.
 	 *
-	 * @param layer1 The expected per-parameter {@link TensorType} reported by Ariadne via {@link Parameter#getTensorTypes()}.
-	 * @param layer2 The expected per-parameter {@link TensorType} produced by Hybridize via {@link Function#inferInputSignature()}.
+	 * @param layer1 The per-parameter {@link TensorType} expected from Ariadne via {@link Parameter#getTensorTypes()}; applied identically
+	 *        to {@code a} and {@code b}.
+	 * @param layer2 The per-parameter {@link TensorType} expected in the inferred input signature via
+	 *        {@link Function#inferInputSignature()}; applied identically to {@code a} and {@code b}.
 	 * @throws Exception If the underlying analysis fails.
 	 */
 	private void testHasLikelyTensorParameterHelper(TensorType layer1, TensorType layer2) throws Exception {
@@ -3819,12 +3830,19 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Precision-audit overload for fixtures where Layer 1 and Layer 2 agree numerically. Delegates to
-	 * {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)} with {@code expected} for both layers. Suitable for dense tensors
-	 * with concrete shape and dtype, and also for sparse-tensor fixtures whose numerical assertions match the dense form even though their
-	 * runtime spec emission is semantically distinct (see #533).
+	 * Precision-audit overload for the canonical two-parameter fixture shape (verified by
+	 * {@link #testHasLikelyTensorParameterHelper(boolean, boolean)}) where Layer 1 (Ariadne) and Layer 2 (Hybridize) agree: both parameters
+	 * {@code a} and {@code b} carry {@code expected} from Ariadne and the inferred input signature is {@code [expected, expected]}.
+	 * Delegates to {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)} with {@code expected} passed for both layer
+	 * arguments.
+	 * <p>
+	 * Suitable for IDEAL fixtures (dense tensors with concrete shape and dtype) and for sparse-tensor fixtures whose numerical assertion
+	 * matches the dense form even though their runtime spec emission is semantically distinct (see #533). For asymmetric layer expectations
+	 * or asymmetric per-parameter expectations, see the helpers / inline patterns referenced in
+	 * {@link #testHasLikelyTensorParameterHelper(TensorType, TensorType)}.
 	 *
-	 * @param expected The expected {@link TensorType} reported by Ariadne and produced unchanged by the inference algorithm.
+	 * @param expected The {@link TensorType} expected at Layer 1 (Ariadne's {@link Parameter#getTensorTypes()}) and at Layer 2 (Hybridize's
+	 *        {@link Function#inferInputSignature()}), applied identically to both parameters {@code a} and {@code b}.
 	 * @throws Exception If the underlying analysis fails.
 	 */
 	private void testHasLikelyTensorParameterHelper(TensorType expected) throws Exception {
@@ -3832,12 +3850,16 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Precision-audit overload that also accepts the expected hybrid-function status. Equivalent to
-	 * {@link #testHasLikelyTensorParameterHelper(TensorType)} but parameterized on {@code expectingHybridFunction}; needed for fixtures
-	 * exercising {@code @tf.function}-decorated functions where the structural check expects {@code isHybrid() == true}.
+	 * Precision-audit overload for the canonical two-parameter fixture shape (verified by
+	 * {@link #testHasLikelyTensorParameterHelper(boolean, boolean)}) where Layer 1 (Ariadne) and Layer 2 (Hybridize) agree and the expected
+	 * hybrid-function status must be supplied. Equivalent to {@link #testHasLikelyTensorParameterHelper(TensorType)} but parameterized on
+	 * {@code expectingHybridFunction}; needed for fixtures exercising {@code @tf.function}-decorated functions where the structural check
+	 * expects {@code isHybrid() == true}. On top of the structural check, asserts {@code a.getTensorTypes().equals(Set.of(expected))} (and
+	 * the symmetric assertion for {@code b}) and that {@link Function#inferInputSignature()} returns {@code [expected, expected]}.
 	 *
 	 * @param expectingHybridFunction The expected value of {@link Function#isHybrid()} for the loaded function.
-	 * @param expected The expected {@link TensorType} reported by Ariadne and produced unchanged by the inference algorithm.
+	 * @param expected The {@link TensorType} expected at Layer 1 (Ariadne's {@link Parameter#getTensorTypes()}) and at Layer 2 (Hybridize's
+	 *        {@link Function#inferInputSignature()}), applied identically to both parameters {@code a} and {@code b}.
 	 * @throws Exception If the underlying analysis fails.
 	 */
 	private void testHasLikelyTensorParameterHelper(boolean expectingHybridFunction, TensorType expected) throws Exception {


### PR DESCRIPTION
## Summary

Documentation-only rewrite of the four `testHasLikelyTensorParameterHelper` overloads' Javadocs to make three previously-implicit constraints explicit on each precision-audit overload. No code changes.

## Background

Review of #542's diff context surfaced three concrete clarity issues with the helper family:

1. *"How do you know that the function will have two parameters?"*—the constraint is inherited from the underlying structural helper but never restated on the precision-audit overloads.
2. *"This comment makes no sense to me."*—`@param expected The expected TensorType reported by Ariadne and produced unchanged by the inference algorithm` mashes Layer 1 and Layer 2 into one opaque sentence.
3. *"Why do both parameters have the same tensor type?"*—the constraint isn't an architectural decision, just a coincidence of the audit corpus; the asymmetric-per-parameter case (like fixture 11) inlines.

Each is a documentation gap, not a semantic problem. This PR fixes the documentation.

## Changes

- **Structural helper** (`testHasLikelyTensorParameterHelper(boolean, boolean)`)—rewrite summary to spell out the canonical shape: exactly one function, exactly two parameters named `a` and `b`.
- **Asymmetric-layer overload** (`(TensorType layer1, TensorType layer2)`)—lead with the canonical-shape reference, then call out the same-type-for-both-parameters assumption explicitly, then explain the two-layer form, then note the inline pattern for asymmetric per-parameter cases (referencing `testHasLikelyTensorParameter11`).
- **Symmetric overload** (`(TensorType expected)`)—replace the "Ariadne and produced unchanged by the inference algorithm" phrasing with explicit Layer 1/Layer 2/applied-to-both-parameters wording.
- **Hybrid-symmetric overload** (`(boolean, TensorType)`)—same Layer 1/Layer 2/applied-to-both wording; explicit `assertEquals` shape called out.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests`—492 tests, 0 failures, 11 skipped
- [x] No code changes; tests pass unchanged
- [ ] CI green
- [ ] Copilot threads clean
