### PR TITLE
Extend precision audit to fixture 145 (multi-context `tf.ones`)

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4405,7 +4405,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter118() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4413,7 +4414,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter119() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4421,7 +4423,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter120() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4429,7 +4432,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter121() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4437,7 +4441,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter122() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4171,8 +4171,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.eye`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
@@ -4183,8 +4184,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.eye`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
@@ -4195,8 +4197,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.eye`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
@@ -4308,8 +4311,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.SparseTensor`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
@@ -4320,8 +4324,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.SparseTensor`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
@@ -4332,8 +4337,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test for #2 for TF API `sparse.SparseTensor`.
 	 * <p>
 	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
-	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
-	 * {@code SparseTensorSpec} emission flip target.
+	 * runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3790,17 +3790,13 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		return function;
 	}
 
-	private void testHasLikelyTensorParameterHelper() throws Exception {
-		testHasLikelyTensorParameterHelper(false, true);
-	}
-
 	/**
-	 * Precision-audit overload: in addition to the structural checks of {@link #testHasLikelyTensorParameterHelper()}, asserts that both
-	 * parameters carry exactly {@code layer1} as their inferred tensor type (Layer 1) and that the inferred input signature is
-	 * {@code [layer2, layer2]} (Layer 2). When Layer 1 and Layer 2 agree (the common case), pass the same {@link TensorType} for both
-	 * arguments. The two-layer form is needed when an upstream representation gap or an algorithm-side collapse produces a Layer-2 type
-	 * strictly distinct from Layer 1 (e.g., ragged tensors—see {@link #testHasLikelyTensorParameter59()} for the TODO-anchored canonical
-	 * fixture and the upstream/downstream flip targets wala/ML#544 and #524). Signature-drop cases must still inline their own
+	 * Precision-audit overload: in addition to the structural checks of {@link #testHasLikelyTensorParameterHelper(boolean, boolean)},
+	 * asserts that both parameters carry exactly {@code layer1} as their inferred tensor type (Layer 1) and that the inferred input
+	 * signature is {@code [layer2, layer2]} (Layer 2). When Layer 1 and Layer 2 agree (the common case), pass the same {@link TensorType}
+	 * for both arguments. The two-layer form is needed when an upstream representation gap or an algorithm-side collapse produces a Layer-2
+	 * type strictly distinct from Layer 1 (e.g., ragged tensors—see {@link #testHasLikelyTensorParameter59()} for the TODO-anchored
+	 * canonical fixture and the upstream/downstream flip targets wala/ML#544 and #524). Signature-drop cases must still inline their own
 	 * {@link Optional#empty} assertion.
 	 *
 	 * @param layer1 The expected per-parameter {@link TensorType} reported by Ariadne via {@link Parameter#getTensorTypes()}.
@@ -4750,7 +4746,19 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter145() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		Function function = testHasLikelyTensorParameterHelper(false, true);
+		Parameter a = function.getParameters().get(0);
+		Parameter b = function.getParameters().get(1);
+		// `add(element, element)` inside `for element in [tf.ones([1, 2]), tf.ones([2, 2])]`—multi-context across loop iterations;
+		// FLOAT32 dtype agrees, rank-2 agrees, but position-0 dim disagrees (1 vs 2) and position-1 agrees (2 vs 2).
+		TensorType context1 = new TensorType(FLOAT32, List.of(new NumericDim(1), new NumericDim(2)));
+		TensorType context2 = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
+		assertEquals(Set.of(context1, context2), a.getTensorTypes());
+		assertEquals(Set.of(context1, context2), b.getTensorTypes());
+		TensorType inferred = new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(2)));
+		Optional<InputSignature> sig = function.inferInputSignature();
+		assertTrue(sig.isPresent());
+		assertEquals(List.of(inferred, inferred), sig.get().parameterTypes());
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3794,10 +3794,6 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		testHasLikelyTensorParameterHelper(false, true);
 	}
 
-	private void testHasLikelyTensorParameterHelper(boolean expectingHybridFunction) throws Exception {
-		testHasLikelyTensorParameterHelper(expectingHybridFunction, true);
-	}
-
 	/**
 	 * Precision-audit overload: in addition to the structural checks of {@link #testHasLikelyTensorParameterHelper()}, asserts that both
 	 * parameters carry exactly {@code layer1} as their inferred tensor type (Layer 1) and that the inferred input signature is
@@ -3833,6 +3829,26 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	private void testHasLikelyTensorParameterHelper(TensorType expected) throws Exception {
 		testHasLikelyTensorParameterHelper(expected, expected);
+	}
+
+	/**
+	 * Precision-audit overload that also accepts the expected hybrid-function status. Equivalent to
+	 * {@link #testHasLikelyTensorParameterHelper(TensorType)} but parameterized on {@code expectingHybridFunction}; needed for fixtures
+	 * exercising {@code @tf.function}-decorated functions where the structural check expects {@code isHybrid() == true}.
+	 *
+	 * @param expectingHybridFunction The expected value of {@link Function#isHybrid()} for the loaded function.
+	 * @param expected The expected {@link TensorType} reported by Ariadne and produced unchanged by the inference algorithm.
+	 * @throws Exception If the underlying analysis fails.
+	 */
+	private void testHasLikelyTensorParameterHelper(boolean expectingHybridFunction, TensorType expected) throws Exception {
+		Function function = testHasLikelyTensorParameterHelper(expectingHybridFunction, true);
+		Parameter a = function.getParameters().get(0);
+		Parameter b = function.getParameters().get(1);
+		assertEquals(Set.of(expected), a.getTensorTypes());
+		assertEquals(Set.of(expected), b.getTensorTypes());
+		Optional<InputSignature> sig = function.inferInputSignature();
+		assertTrue(sig.isPresent());
+		assertEquals(List.of(expected, expected), sig.get().parameterTypes());
 	}
 
 	/**
@@ -4450,31 +4466,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter123() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertNotNull(functions);
-		assertEquals(1, functions.size());
-		Function function = functions.iterator().next();
-		assertNotNull(function);
-		assertTrue(function.isHybrid());
-
-		List<Parameter> params = function.getParameters();
-
-		// two params.
-		assertEquals(2, params.size());
-
-		Parameter actualParameter = params.get(0);
-		assertNotNull(actualParameter);
-
-		String paramName = actualParameter.getName();
-		assertEquals("a", paramName);
-
-		actualParameter = params.get(1);
-		assertNotNull(actualParameter);
-
-		paramName = actualParameter.getName();
-		assertEquals("b", paramName);
-
-		assertTrue("Expecting function with likely tensor parameter.", function.getHasTensorParameter());
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4659,7 +4651,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter134() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4667,8 +4659,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter135() throws Exception {
-		// Same test as testHasLikelyTensorParameter123 but the tf.function has a parenthesis.
-		testHasLikelyTensorParameterHelper(true);
+		// Same test as testHasLikelyTensorParameter123 but with a tf.function has a parenthesis.
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4677,7 +4669,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter136() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4686,7 +4678,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter137() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4695,7 +4687,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter138() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4704,7 +4696,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter139() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4713,7 +4705,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter140() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4722,7 +4714,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter141() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4731,7 +4723,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter142() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**
@@ -4740,7 +4732,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter143() throws Exception {
 		// Same test as testHasLikelyTensorParameter123 but with a tf.function parameter.
-		testHasLikelyTensorParameterHelper(true);
+		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4492,15 +4492,15 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter126() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of()));
 	}
 
 	/**
-	 * Test for #2 for TF API `tf.keras.layers.Input`.
+	 * Test for #2 for TF API `tf.experimental.numpy.ndarray`.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter127() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of()));
 	}
 
 	/**
@@ -4508,7 +4508,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter128() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of()));
 	}
 
 	/**
@@ -4516,7 +4516,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter129() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of()));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4659,7 +4659,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter135() throws Exception {
-		// Same test as testHasLikelyTensorParameter123 but with a tf.function has a parenthesis.
+		// Same test as testHasLikelyTensorParameter123 but the tf.function has parentheses.
 		testHasLikelyTensorParameterHelper(true, new TensorType(INT32, List.of(new NumericDim(5))));
 	}
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4173,7 +4173,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4183,7 +4184,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4193,7 +4195,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4304,7 +4307,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
@@ -4314,7 +4318,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
@@ -4324,7 +4329,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {
 		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
+		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4271,7 +4271,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter105() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4279,7 +4279,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter106() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4287,7 +4287,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter107() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**
@@ -4295,7 +4295,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter108() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(2))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4474,7 +4474,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter124() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
 	/**
@@ -4482,7 +4483,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter125() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4303,7 +4303,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
@@ -4311,7 +4313,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
@@ -4319,7 +4323,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
+		// runtime—see #533 for the `SparseTensorSpec` emission flip target.
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4742,7 +4742,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter144() throws Exception {
-		testHasLikelyTensorParameterHelper(false, true);
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of()));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4169,34 +4169,37 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 	/**
 	 * Test for #2 for TF API `sparse.eye`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.eye`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.eye`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
@@ -4303,34 +4306,37 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 	/**
 	 * Test for #2 for TF API `sparse.SparseTensor`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.SparseTensor`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
 	 * Test for #2 for TF API `sparse.SparseTensor`.
+	 * <p>
+	 * The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects {@code SparseTensor} arguments at
+	 * runtime; see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">#533</a> for the
+	 * {@code SparseTensorSpec} emission flip target.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {
-		// The shape/dtype assertion is numerically correct but the inferred `TensorSpec` rejects `SparseTensor` arguments at
-		// runtime—see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533 for the `SparseTensorSpec` emission flip
-		// target.
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4333,7 +4333,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter112() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4341,7 +4342,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter113() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4349,7 +4351,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter114() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4357,7 +4360,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter115() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4365,7 +4369,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter116() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4373,7 +4378,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter117() throws Exception {
-		testHasLikelyTensorParameterHelper();
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
+				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Extend the precision audit to fixture 145, covering the multi-context `tf.ones` family.
- Drop the void zero-arg `testHasLikelyTensorParameterHelper()` overload (structurally redundant after the earlier `Function`-returning refactor; see below).

## Findings

Fixture 145's Python: `add(element, element)` inside `for element in [tf.ones([1, 2]), tf.ones([2, 2])]`. Each parameter sees two distinct `TensorType` values across loop iterations—`FLOAT32, (1, 2)` and `FLOAT32, (2, 2)`. Dtype agrees, rank agrees, but position-0 dim disagrees (1 vs 2) while position-1 agrees (2 vs 2).

- **Layer 1:** `Set.of(TensorType(FLOAT32, (1, 2)), TensorType(FLOAT32, (2, 2)))` for both `a` and `b`.
- **Layer 2:** `inferInputSignature` produces `TensorType(FLOAT32, (SymbolicDim("?"), NumericDim(2)))`—per-dim consensus narrows to a wildcard where the dims disagree and pins the constant where they agree. Signature is `[inferred, inferred]`.

**IDEAL multi-context case**: the inferred signature accurately admits both observed call sites. `TensorSpec(shape=(?, 2))` accepts both `(1, 2)` and `(2, 2)` inputs at runtime.

## Helper Cleanup

The void `testHasLikelyTensorParameterHelper()` overload was structurally redundant after the earlier refactor that made the two-arg structural helper return `Function` (so audit overloads can reuse the validated instance). The void overload called the now-`Function`-returning form and discarded the result—a structural mismatch that survived only because some fixtures still wanted just the structural check.

This batch's audit conversion of fixture 145 removed the void overload's last caller. Drop it. A future fixture wanting the structural-only convenience can either call `testHasLikelyTensorParameterHelper(false, true)` directly (one extra arg to type) or restore a `Function`-returning 0-arg form at that point. No speculative preservation under `@SuppressWarnings`.

One Javadoc cross-reference in the asymmetric-layer overload updated from `()` to `(boolean, boolean)` accordingly.

## Stacking

Stacked on #543 / #542 (the audit cascade). The diff against the parent branch shows only fixture 145's audit + the helper removal + the Javadoc cross-ref update.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests`—492 tests, 0 failures, 11 skipped
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- #543—batch-14 (`tf.data.Dataset.from_tensor_slices`, ancestor in the stack).
- #542—batch-13 (`tf.experimental.numpy.ndarray`, parent in the stack).
- #522—earlier multi-context audit at fixture 15 (dtype disagreement → signature drop, distinct from this batch's dim-disagreement narrowing).
