### PR TITLE
Extend precision audit to fixture 147 (no-tensor-parameter case)

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3869,6 +3869,27 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Precision-audit overload for the canonical two-parameter fixture shape (verified by
+	 * {@link #testHasLikelyTensorParameterHelper(boolean, boolean)} with {@code expectingTensorParameter = false}) where neither parameter
+	 * is classified as a tensor. On top of the structural check, asserts that both {@code a.getTensorTypes()} and
+	 * {@code b.getTensorTypes()} are empty and that {@link Function#inferInputSignature()} returns {@link Optional#empty}—the signature
+	 * drops at the per-parameter classification step before reaching {@code inferSpec}, distinct from in-{@code inferSpec} drops (e.g.,
+	 * dtype disagreement) where the per-parameter classification succeeded.
+	 *
+	 * @param expectingHybridFunction The expected value of {@link Function#isHybrid()} for the loaded function.
+	 * @throws Exception If the underlying analysis fails.
+	 */
+	private void testHasLikelyTensorParameterHelperNoTensor(boolean expectingHybridFunction) throws Exception {
+		Function function = testHasLikelyTensorParameterHelper(expectingHybridFunction, false);
+		Parameter a = function.getParameters().get(0);
+		Parameter b = function.getParameters().get(1);
+		assertTrue(a.getTensorTypes().isEmpty());
+		assertTrue(b.getTensorTypes().isEmpty());
+		Optional<InputSignature> sig = function.inferInputSignature();
+		assertFalse("No tensor parameter ⇒ signature drops.", sig.isPresent());
+	}
+
+	/**
 	 * Test for #2 for TF API `RaggedTensor.from_nested_row_splits`.
 	 */
 	@Test
@@ -4767,20 +4788,14 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/265.
+	 * Test for https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/265. {@code add(element, element)} inside
+	 * {@code for element in list} where {@code list = list()} then {@code .append(tf.ones(...))}—the dynamic-list construction prevents
+	 * Ariadne from tracking the appended tensors into {@code element}, so neither parameter is classified as a tensor and the inferred
+	 * signature drops at the per-parameter classification step.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter147() throws Exception {
-		Function function = testHasLikelyTensorParameterHelper(false, false);
-		Parameter a = function.getParameters().get(0);
-		Parameter b = function.getParameters().get(1);
-		// `add(element, element)` inside `for element in list` where `list = list()` then `.append(tf.ones(...))`—the dynamic-list
-		// construction prevents Ariadne from tracking the appended tensors into `element`, so neither parameter is classified as a
-		// tensor (`getHasTensorParameter() == false` from the structural helper above).
-		assertTrue(a.getTensorTypes().isEmpty());
-		assertTrue(b.getTensorTypes().isEmpty());
-		Optional<InputSignature> sig = function.inferInputSignature();
-		assertFalse("No tensor parameter ⇒ signature drops.", sig.isPresent());
+		testHasLikelyTensorParameterHelperNoTensor(false);
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4771,7 +4771,16 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter147() throws Exception {
-		testHasLikelyTensorParameterHelper(false, false);
+		Function function = testHasLikelyTensorParameterHelper(false, false);
+		Parameter a = function.getParameters().get(0);
+		Parameter b = function.getParameters().get(1);
+		// `add(element, element)` inside `for element in list` where `list = list()` then `.append(tf.ones(...))`—the dynamic-list
+		// construction prevents Ariadne from tracking the appended tensors into `element`, so neither parameter is classified as a
+		// tensor (`getHasTensorParameter() == false` from the structural helper above).
+		assertTrue(a.getTensorTypes().isEmpty());
+		assertTrue(b.getTensorTypes().isEmpty());
+		Optional<InputSignature> sig = function.inferInputSignature();
+		assertFalse("No tensor parameter ⇒ signature drops.", sig.isPresent());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Extend the precision audit to fixture 147, the first audited fixture where the inferred input signature legitimately doesn't exist (no tensor parameter to infer for).

## Findings

Fixture 147's Python uses `list = list()` followed by `.append(tf.ones(...))` calls, then iterates with `for element in list: add(element, element)`. The dynamic-list construction (builtin `list()` plus `.append`, not a list literal) prevents Ariadne from tracking the appended tensors through to `element`, so neither parameter of `add` is classified as a tensor.

The existing structural helper already expects `getHasTensorParameter() == false` here (`testHasLikelyTensorParameterHelper(false, false)`). The audit-driver addition:

- **Layer 1:** both `a.getTensorTypes()` and `b.getTensorTypes()` are empty `Set`s. No `TensorType` evidence at all.
- **Layer 2:** `inferInputSignature()` returns `Optional.empty()`. The signature drops at the per-parameter classification step before reaching `inferSpec`—distinct from fixture 15's `Optional.empty()` which arose from dtype disagreement across call sites with classified-tensor parameters.

This is **LEGITIMATE-DROP at the classification layer**, a different category from prior LEGITIMATE-DROP cases (which arose from per-dim or per-dtype consensus failure inside `inferSpec`).

## Out of Scope

The Ariadne-side question (could a smarter analyzer track tensors through dynamic-list `list().append(tensor)` construction?) is a known precision-gap area but out of scope for the per-fixture audit pinning—the runtime behavior of this fixture is documented as-emitted.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests`—492 tests, 0 failures, 11 skipped
- [ ] CI green
- [ ] Copilot threads clean

## Cross-Refs

- #545—batch-15 (`tf.ones` multi-context, parent batch).
- #522—earlier multi-context audit at fixture 15 (distinct LEGITIMATE-DROP cause: dtype disagreement, not classification failure).
