### PR TITLE
Extend precision audit to fixture 146

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4765,11 +4765,15 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test lists.
+	 * Test lists. {@code add(list, list)} where {@code list = [tf.ones([1, 2]), tf.ones([2, 2])]}—both parameters bind to a Python list
+	 * literal containing tensors. Phase-3 container detection classifies each parameter as tensor-bearing (so
+	 * {@link Function#getHasTensorParameter()} is {@code true}), but the parameter binds to the list itself, not to a tensor; per-parameter
+	 * {@link Parameter#getTensorTypes()} is empty. Without a concrete per-parameter tensor type, {@code inferSpec} cannot produce a
+	 * {@code TensorSpec}, so the inferred signature drops.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter146() throws Exception {
-		testHasLikelyTensorParameterHelper(false, true);
+		testHasLikelyTensorParameterHelperExpectingDrop(false, true, Set.of(), Set.of());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Extend the precision audit to fixture 146, previously structural-only. The audit-with-drop assertion (`testHasLikelyTensorParameterHelperExpectingDrop`) covers all three layers: hybrid status, per-parameter `getTensorTypes()`, and inferred signature.

## Audit Finding

IDEAL—not a precision gap. The function under test is `add(a, b)` called as `add(list, list)` where `list = [tf.ones([1, 2]), tf.ones([2, 2])]`. At runtime, `a + b` is Python list concatenation, not tensor addition. The analyzer's behavior is correct:

- `getHasTensorParameter() == true` via Phase-3 container detection (the list contains tensors, so the function participates in tensor data flow).
- Per-parameter `getTensorTypes()` is empty—the parameter binds to a list, not a tensor.
- `inferInputSignature()` drops—without a concrete per-parameter tensor type, `inferSpec` cannot produce a `TensorSpec`.

The drop is the right answer: from the runtime's perspective the function isn't a tensor function, so dropping the inferred signature is correct. The Phase-3 classification correctly signals to hybridization that the function participates in tensor data flow.

## Cross-Refs

- #547—established the helper family used by this audit.
- #549—batch-1 fixture sweep (in flight as #552).
- Audit progress memo flagged fixture 146 as deferred pending case-by-case design; this PR resolves that.
