### PR TITLE
Extend precision audit to fixtures 52-54, 130-133

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -2803,7 +2803,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		// Precision audit. `t = tf.Tensor(c.op, 0, tf.float32)` where `c = tf.matmul(a, b)` and `a`, `b` are FLOAT32 (2, 2) constants.
 		// Runtime: `t` is a FLOAT32 tensor wrapping the matmul output of shape (2, 2).
 		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
-		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, expected, expected);
 	}
 
 	/**
@@ -2813,7 +2813,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter53() throws Exception {
 		// Precision audit. `t = Tensor(c.op, 0, tensorflow.float32)` (raw import) wrapping `c = tensorflow.matmul(a, b)`.
 		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
-		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, expected, expected);
 	}
 
 	/**
@@ -2823,7 +2823,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter54() throws Exception {
 		// Precision audit. `t = Tensor(c.op, 0, tf.float32)` from `tensorflow.python.framework.ops` wrapping `c = tf.matmul(a, b)`.
 		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
-		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, expected, expected);
 	}
 
 	/**
@@ -3054,34 +3054,28 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 	/**
 	 * Precision-audit helper for multi-function fixtures with a single-parameter target function named {@code t}. Loads exactly two
-	 * functions in the test fixture, picks the one with {@code targetFunctionSimpleName}, and asserts the structural shape (single
-	 * parameter named {@code t}), {@link Function#isHybrid()}, {@link Function#getHasTensorParameter()}, per-parameter
-	 * {@link Parameter#getTensorTypes()}, and {@link Function#inferInputSignature()}.
+	 * functions in the test fixture, picks the one with {@code targetFunctionSimpleName} (asserting exactly one match), and asserts the
+	 * structural shape (single parameter named {@code t}), {@link Function#isHybrid()}, that the target has a tensor parameter, the
+	 * per-parameter {@link Parameter#getTensorTypes()}, and {@link Function#inferInputSignature()}. This helper covers the
+	 * tensor-parameter-present case only; if a future fixture needs to assert a signature drop or absent tensor parameter, add a sibling
+	 * helper (analogous to {@link #testHasLikelyTensorParameterHelperExpectingDrop(boolean, boolean, Set, Set)}).
 	 *
 	 * @param targetFunctionSimpleName The simple name of the function under test (one of the two functions in the fixture).
 	 * @param expectingHybridFunction The expected value of {@link Function#isHybrid()} for the target function.
-	 * @param expectingTensorParameter The expected value of {@link Function#getHasTensorParameter()} for the target function.
 	 * @param expectedParameterTensorType The {@link TensorType} expected from Ariadne via {@link Parameter#getTensorTypes()} for the single
 	 *        parameter {@code t}.
 	 * @param expectedSignatureTensorType The {@link TensorType} expected in the inferred input signature.
 	 * @throws Exception If the underlying analysis fails.
 	 */
 	private void testHasLikelyTensorParameterHelperMultiFunction(String targetFunctionSimpleName, boolean expectingHybridFunction,
-			boolean expectingTensorParameter, TensorType expectedParameterTensorType, TensorType expectedSignatureTensorType)
-			throws Exception {
-		assertNotNull("Helper contract: targetFunctionSimpleName must be non-null.", targetFunctionSimpleName);
-		assertNotNull("Helper contract: expectedParameterTensorType must be non-null.", expectedParameterTensorType);
-		assertNotNull("Helper contract: expectedSignatureTensorType must be non-null.", expectedSignatureTensorType);
-
+			TensorType expectedParameterTensorType, TensorType expectedSignatureTensorType) throws Exception {
 		Set<Function> functions = this.getFunctions();
 		assertNotNull(functions);
 		assertEquals(2, functions.size());
 
-		Function target = null;
-		for (Function f : functions)
-			if (Objects.equals(f.getSimpleName(), targetFunctionSimpleName))
-				target = f;
-		assertNotNull("Target function " + targetFunctionSimpleName + " not found in fixture.", target);
+		List<Function> matches = functions.stream().filter(f -> Objects.equals(f.getSimpleName(), targetFunctionSimpleName)).toList();
+		assertEquals("Expected exactly one function named " + targetFunctionSimpleName + " in fixture.", 1, matches.size());
+		Function target = matches.get(0);
 		assertEquals(expectingHybridFunction, target.isHybrid());
 
 		List<Parameter> params = target.getParameters();
@@ -3089,7 +3083,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Parameter t = params.get(0);
 		assertNotNull(t);
 		assertEquals("t", t.getName());
-		assertEquals(expectingTensorParameter, target.getHasTensorParameter());
+		assertTrue(target.getHasTensorParameter());
 		assertEquals(Set.of(expectedParameterTensorType), t.getTensorTypes());
 		assertEquals(Optional.of(List.of(expectedSignatureTensorType)), target.inferInputSignature().map(InputSignature::parameterTypes));
 	}
@@ -3738,7 +3732,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter130() throws Exception {
 		// Precision audit. `t = tf.experimental.numpy.ndarray(c.op, 0, tf.float32)` (fully-qualified) wrapping `c = tf.matmul(a, b)`.
 		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
-		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, expected, expected);
 	}
 
 	/**
@@ -3749,7 +3743,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		// Precision audit. `t = experimental.numpy.ndarray(c.op, 0, tf.float32)` (`from tensorflow import experimental`) wrapping
 		// `c = tf.matmul(a, b)`.
 		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
-		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, expected, expected);
 	}
 
 	/**
@@ -3760,7 +3754,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		// Precision audit. `t = numpy.ndarray(c.op, 0, tf.float32)` (`from tensorflow.experimental import numpy`) wrapping
 		// `c = tf.matmul(a, b)`.
 		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
-		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, expected, expected);
 	}
 
 	/**
@@ -3771,7 +3765,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		// Precision audit. `t = ndarray(c.op, 0, tf.float32)` (`from tensorflow.experimental.numpy import ndarray`) wrapping
 		// `c = tf.matmul(a, b)`.
 		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
-		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, expected, expected);
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -2800,31 +2800,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter52() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertNotNull(functions);
-		assertEquals(2, functions.size());
-
-		Function functionToBeEvaluated = null;
-
-		for (Function func : functions) {
-			if (Objects.equals(func.getSimpleName(), "func2"))
-				functionToBeEvaluated = func;
-		}
-
-		assertNotNull(functionToBeEvaluated);
-
-		List<Parameter> params = functionToBeEvaluated.getParameters();
-
-		// one param.
-		assertEquals(1, params.size());
-
-		Parameter actualParameter = params.get(0);
-		assertNotNull(actualParameter);
-
-		String paramName = actualParameter.getName();
-		assertEquals("t", paramName);
-
-		assertTrue("Expecting function with unlikely tensor parameter.", functionToBeEvaluated.getHasTensorParameter());
+		// Precision audit. `t = tf.Tensor(c.op, 0, tf.float32)` where `c = tf.matmul(a, b)` and `a`, `b` are FLOAT32 (2, 2) constants.
+		// Runtime: `t` is a FLOAT32 tensor wrapping the matmul output of shape (2, 2).
+		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
 	}
 
 	/**
@@ -2832,31 +2811,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter53() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertNotNull(functions);
-		assertEquals(2, functions.size());
-
-		Function functionToBeEvaluated = null;
-
-		for (Function func : functions) {
-			if (Objects.equals(func.getSimpleName(), "func2"))
-				functionToBeEvaluated = func;
-		}
-
-		assertNotNull(functionToBeEvaluated);
-
-		List<Parameter> params = functionToBeEvaluated.getParameters();
-
-		// one param.
-		assertEquals(1, params.size());
-
-		Parameter actualParameter = params.get(0);
-		assertNotNull(actualParameter);
-
-		String paramName = actualParameter.getName();
-		assertEquals("t", paramName);
-
-		assertTrue("Expecting function with unlikely tensor parameter.", functionToBeEvaluated.getHasTensorParameter());
+		// Precision audit. `t = Tensor(c.op, 0, tensorflow.float32)` (raw import) wrapping `c = tensorflow.matmul(a, b)`.
+		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
 	}
 
 	/**
@@ -2864,31 +2821,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter54() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertNotNull(functions);
-		assertEquals(2, functions.size());
-
-		Function functionToBeEvaluated = null;
-
-		for (Function func : functions) {
-			if (Objects.equals(func.getSimpleName(), "func2"))
-				functionToBeEvaluated = func;
-		}
-
-		assertNotNull(functionToBeEvaluated);
-
-		List<Parameter> params = functionToBeEvaluated.getParameters();
-
-		// one param.
-		assertEquals(1, params.size());
-
-		Parameter actualParameter = params.get(0);
-		assertNotNull(actualParameter);
-
-		String paramName = actualParameter.getName();
-		assertEquals("t", paramName);
-
-		assertTrue("Expecting function with unlikely tensor parameter.", functionToBeEvaluated.getHasTensorParameter());
+		// Precision audit. `t = Tensor(c.op, 0, tf.float32)` from `tensorflow.python.framework.ops` wrapping `c = tf.matmul(a, b)`.
+		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
 	}
 
 	/**
@@ -3115,6 +3050,48 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 			TensorType expectedSignatureTensorType) throws Exception {
 		testHasLikelyTensorParameterHelper(false, true, expectedParameterTensorTypes, expectedParameterTensorTypes,
 				List.of(expectedSignatureTensorType, expectedSignatureTensorType));
+	}
+
+	/**
+	 * Precision-audit helper for multi-function fixtures with a single-parameter target function named {@code t}. Loads exactly two
+	 * functions in the test fixture, picks the one with {@code targetFunctionSimpleName}, and asserts the structural shape (single
+	 * parameter named {@code t}), {@link Function#isHybrid()}, {@link Function#getHasTensorParameter()}, per-parameter
+	 * {@link Parameter#getTensorTypes()}, and {@link Function#inferInputSignature()}.
+	 *
+	 * @param targetFunctionSimpleName The simple name of the function under test (one of the two functions in the fixture).
+	 * @param expectingHybridFunction The expected value of {@link Function#isHybrid()} for the target function.
+	 * @param expectingTensorParameter The expected value of {@link Function#getHasTensorParameter()} for the target function.
+	 * @param expectedParameterTensorType The {@link TensorType} expected from Ariadne via {@link Parameter#getTensorTypes()} for the single
+	 *        parameter {@code t}.
+	 * @param expectedSignatureTensorType The {@link TensorType} expected in the inferred input signature.
+	 * @throws Exception If the underlying analysis fails.
+	 */
+	private void testHasLikelyTensorParameterHelperMultiFunction(String targetFunctionSimpleName, boolean expectingHybridFunction,
+			boolean expectingTensorParameter, TensorType expectedParameterTensorType, TensorType expectedSignatureTensorType)
+			throws Exception {
+		assertNotNull("Helper contract: targetFunctionSimpleName must be non-null.", targetFunctionSimpleName);
+		assertNotNull("Helper contract: expectedParameterTensorType must be non-null.", expectedParameterTensorType);
+		assertNotNull("Helper contract: expectedSignatureTensorType must be non-null.", expectedSignatureTensorType);
+
+		Set<Function> functions = this.getFunctions();
+		assertNotNull(functions);
+		assertEquals(2, functions.size());
+
+		Function target = null;
+		for (Function f : functions)
+			if (Objects.equals(f.getSimpleName(), targetFunctionSimpleName))
+				target = f;
+		assertNotNull("Target function " + targetFunctionSimpleName + " not found in fixture.", target);
+		assertEquals(expectingHybridFunction, target.isHybrid());
+
+		List<Parameter> params = target.getParameters();
+		assertEquals(1, params.size());
+		Parameter t = params.get(0);
+		assertNotNull(t);
+		assertEquals("t", t.getName());
+		assertEquals(expectingTensorParameter, target.getHasTensorParameter());
+		assertEquals(Set.of(expectedParameterTensorType), t.getTensorTypes());
+		assertEquals(Optional.of(List.of(expectedSignatureTensorType)), target.inferInputSignature().map(InputSignature::parameterTypes));
 	}
 
 	/**
@@ -3759,31 +3736,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter130() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertNotNull(functions);
-		assertEquals(2, functions.size());
-
-		Function functionToBeEvaluated = null;
-
-		for (Function func : functions) {
-			if (Objects.equals(func.getSimpleName(), "func2"))
-				functionToBeEvaluated = func;
-		}
-
-		assertNotNull(functionToBeEvaluated);
-
-		List<Parameter> params = functionToBeEvaluated.getParameters();
-
-		// one param.
-		assertEquals(1, params.size());
-
-		Parameter actualParameter = params.get(0);
-		assertNotNull(actualParameter);
-
-		String paramName = actualParameter.getName();
-		assertEquals("t", paramName);
-
-		assertTrue("Expecting function with unlikely tensor parameter.", functionToBeEvaluated.getHasTensorParameter());
+		// Precision audit. `t = tf.experimental.numpy.ndarray(c.op, 0, tf.float32)` (fully-qualified) wrapping `c = tf.matmul(a, b)`.
+		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
 	}
 
 	/**
@@ -3791,31 +3746,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter131() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertNotNull(functions);
-		assertEquals(2, functions.size());
-
-		Function functionToBeEvaluated = null;
-
-		for (Function func : functions) {
-			if (Objects.equals(func.getSimpleName(), "func2"))
-				functionToBeEvaluated = func;
-		}
-
-		assertNotNull(functionToBeEvaluated);
-
-		List<Parameter> params = functionToBeEvaluated.getParameters();
-
-		// one param.
-		assertEquals(1, params.size());
-
-		Parameter actualParameter = params.get(0);
-		assertNotNull(actualParameter);
-
-		String paramName = actualParameter.getName();
-		assertEquals("t", paramName);
-
-		assertTrue("Expecting function with unlikely tensor parameter.", functionToBeEvaluated.getHasTensorParameter());
+		// Precision audit. `t = experimental.numpy.ndarray(c.op, 0, tf.float32)` (`from tensorflow import experimental`) wrapping
+		// `c = tf.matmul(a, b)`.
+		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
 	}
 
 	/**
@@ -3823,31 +3757,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter132() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertNotNull(functions);
-		assertEquals(2, functions.size());
-
-		Function functionToBeEvaluated = null;
-
-		for (Function func : functions) {
-			if (Objects.equals(func.getSimpleName(), "func2"))
-				functionToBeEvaluated = func;
-		}
-
-		assertNotNull(functionToBeEvaluated);
-
-		List<Parameter> params = functionToBeEvaluated.getParameters();
-
-		// one param.
-		assertEquals(1, params.size());
-
-		Parameter actualParameter = params.get(0);
-		assertNotNull(actualParameter);
-
-		String paramName = actualParameter.getName();
-		assertEquals("t", paramName);
-
-		assertTrue("Expecting function with unlikely tensor parameter.", functionToBeEvaluated.getHasTensorParameter());
+		// Precision audit. `t = numpy.ndarray(c.op, 0, tf.float32)` (`from tensorflow.experimental import numpy`) wrapping
+		// `c = tf.matmul(a, b)`.
+		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
 	}
 
 	/**
@@ -3855,31 +3768,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter133() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertNotNull(functions);
-		assertEquals(2, functions.size());
-
-		Function functionToBeEvaluated = null;
-
-		for (Function func : functions) {
-			if (Objects.equals(func.getSimpleName(), "func2"))
-				functionToBeEvaluated = func;
-		}
-
-		assertNotNull(functionToBeEvaluated);
-
-		List<Parameter> params = functionToBeEvaluated.getParameters();
-
-		// one param.
-		assertEquals(1, params.size());
-
-		Parameter actualParameter = params.get(0);
-		assertNotNull(actualParameter);
-
-		String paramName = actualParameter.getName();
-		assertEquals("t", paramName);
-
-		assertTrue("Expecting function with unlikely tensor parameter.", functionToBeEvaluated.getHasTensorParameter());
+		// Precision audit. `t = ndarray(c.op, 0, tf.float32)` (`from tensorflow.experimental.numpy import ndarray`) wrapping
+		// `c = tf.matmul(a, b)`.
+		TensorType expected = new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)));
+		testHasLikelyTensorParameterHelperMultiFunction("func2", false, true, expected, expected);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Extend the precision audit to seven multi-function single-arg fixtures: 52-54 and 130-133. All seven previously asserted only the structural shape (one parameter named `t`, `getHasTensorParameter() == true`). Add a new helper `testHasLikelyTensorParameterHelperMultiFunction` that handles this shape and migrate the fixtures.

## The Multi-Function Single-Arg Shape

Each fixture has two functions:

- `func()` (decorated `@tf.function`) constructs tensors via `c = tf.matmul(a, b)` and passes the result through a low-level tensor wrapper into `func2(t)`.
- `func2(t)` is the function under test; `t` is the parameter under audit.

Only the import shape and the constructor name vary across the seven fixtures:

| Fixture | Constructor | Import shape |
|---|---|---|
| 52 | `tf.Tensor(c.op, 0, tf.float32)` | `import tensorflow as tf` |
| 53 | `Tensor(c.op, 0, tensorflow.float32)` | `from tensorflow import Tensor` |
| 54 | `Tensor(c.op, 0, tf.float32)` | `from tensorflow.python.framework.ops import Tensor` |
| 130 | `tf.experimental.numpy.ndarray(c.op, 0, tf.float32)` | fully-qualified |
| 131 | `experimental.numpy.ndarray(...)` | `from tensorflow import experimental` |
| 132 | `numpy.ndarray(...)` | `from tensorflow.experimental import numpy` |
| 133 | `ndarray(...)` | `from tensorflow.experimental.numpy import ndarray` |

## Audit Verdict

IDEAL for all seven. Ariadne tracks the `tf.matmul(a, b)` → `c.op` → tensor-wrapper-constructor → `t` chain correctly, emitting FLOAT32 with shape (2, 2). The inferred input signature carries the same `TensorType` at the single parameter position.

## New Helper

`testHasLikelyTensorParameterHelperMultiFunction(targetFunctionSimpleName, expectingHybridFunction, expectingTensorParameter, expectedParameterTensorType, expectedSignatureTensorType)` — loads exactly two functions, picks the one with the given simple name, asserts the structural shape (single parameter named `t`), and runs the audit.

The helper hardcodes the parameter name `t` because all seven fixtures use it. Future fixtures with different parameter names would extend the helper or add a sibling.

## Cross-Refs

- #547—established the helper family.
- Audit-progress memo flagged 130-133 as deferred pending case-by-case design; this PR resolves them. 52-54 (which weren't flagged but share the same shape) are migrated in the same PR.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests`—492 tests, 0 failures, 11 skipped
- [x] Net −108 lines (67 insertions, 175 deletions)
- [ ] CI green
- [ ] Copilot threads clean
