### PR TITLE
Extend precision audit to fixture 157

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3011,32 +3011,6 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Structural-only helper parameterized on the boolean expectations. No precision-audit assertions.
-	 *
-	 * @param expectingHybridFunction The expected value of {@link Function#isHybrid()} for the loaded function.
-	 * @param expectingTensorParameter The expected value of {@link Function#getHasTensorParameter()} for the loaded function.
-	 * @throws Exception If the underlying analysis fails.
-	 */
-	private void testHasLikelyTensorParameterHelper(boolean expectingHybridFunction, boolean expectingTensorParameter) throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertNotNull(functions);
-		assertEquals(1, functions.size());
-		Function function = functions.iterator().next();
-		assertNotNull(function);
-		assertEquals(expectingHybridFunction, function.isHybrid());
-
-		List<Parameter> params = function.getParameters();
-		assertEquals(2, params.size());
-		Parameter a = params.get(0);
-		Parameter b = params.get(1);
-		assertNotNull(a);
-		assertNotNull(b);
-		assertEquals("a", a.getName());
-		assertEquals("b", b.getName());
-		assertEquals(expectingTensorParameter, function.getHasTensorParameter());
-	}
-
-	/**
 	 * Precision-audit overload for the canonical two-parameter fixture shape where both parameters {@code a} and {@code b} are expected to
 	 * share the same per-parameter type at each of Layer 1 (Ariadne) and Layer 2 (Hybridize). The two-layer form is needed when Ariadne's
 	 * emitted {@link TensorType} differs from the {@link TensorType} the inference algorithm produces—an upstream representation gap or an
@@ -4175,11 +4149,18 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/265.
+	 * Test for https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/265. Dataset iteration with {@code .batch(2)}: source
+	 * is {@code [1, 2, 3]} (length 3), so batching by 2 produces one full batch of shape (2,) and a residual batch of shape (1,). Both
+	 * batches are INT32. Ariadne tracks both shapes as a multi-context per-parameter Set; the inference algorithm narrows the disagreeing
+	 * dim-0 to a wildcard via per-dim consensus, yielding INT32 (?,) in the signature.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter157() throws Exception {
-		testHasLikelyTensorParameterHelper(false, true);
+		TensorType expectedParameterTensorTypeBatch2 = new TensorType(INT32, List.of(new NumericDim(2)));
+		TensorType expectedParameterTensorTypeBatch1 = new TensorType(INT32, List.of(new NumericDim(1)));
+		TensorType expectedSignatureTensorType = new TensorType(INT32, List.of(new SymbolicDim("?")));
+		testHasLikelyTensorParameterHelperMultiContext(Set.of(expectedParameterTensorTypeBatch2, expectedParameterTensorTypeBatch1),
+				expectedSignatureTensorType);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Extend the precision audit to fixture 157, the only audit-eligible fixture in the 150-158 cluster. The other eight fixtures (150-156, 158) are refactoring-pipeline regression tests for #283—same out-of-scope category as 148-149's #294 tests.

## Audit Finding

IDEAL—multi-context narrowing works correctly. Runtime: `tf.data.Dataset.from_tensor_slices([1, 2, 3]).shuffle(3).batch(2)` batches a length-3 source by 2, producing one full batch of shape (2,) and a residual batch of shape (1,). Both are INT32. The function under test calls `add(element, element)` per iteration, so both parameters bind to the batched tensor.

- Ariadne tracks both batch shapes as a multi-context per-parameter Set `{TensorType(INT32, [1]), TensorType(INT32, [2])}`.
- The inference algorithm narrows the disagreeing dim-0 to a wildcard via per-dim consensus, yielding `TensorType(INT32, [SymbolicDim("?")])` in the signature.

Same multi-context pattern as fixture 145, applied to dataset iteration.

## Helper Cleanup

Drop the structural-only `(boolean, boolean)` helper overload. It had zero remaining callers after this migration and after #553's migration of fixture 146 to `ExpectingDrop`. The strict-compile flag `-err:+unused` requires removal.

## Cross-Refs

- #547—established the helper family.
- #553—migrated fixture 146 to `ExpectingDrop`, the other migration that drained the structural-only helper's callers.
- Audit-progress memo flagged 150-158 as deferred pending case-by-case design; this PR resolves them (157 audited, 150-156 and 158 declared out-of-scope as refactoring-pipeline tests).

## Out of Scope

Fixtures 150-156 and 158 use `getFunction("add")` and assert refactoring-pipeline outcomes (`getPassingPrecondition()`, `getTransformations()`, `getStatus().hasError()`, `getEntryMatchingFailure(...)`). They test #283-specific behavior, not per-parameter tensor-type precision. Same shape as 148-149.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests`—492 tests, 0 failures, 11 skipped
- [x] Net −19 lines (9 insertions, 28 deletions)
- [ ] CI green
- [ ] Copilot threads clean
