### PR TITLE
Log a `WARNING` when an unknown `@tf.function` decorator argument is encountered

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -265,8 +265,7 @@ public class Function {
 			case EXPERIMENTAL_IMPLEMENTS -> this.experimentalImplementsParam = true;
 			case EXPERIMENTAL_AUTOGRAPH_OPTIONS -> this.experimentalAutographOptionsParam = true;
 			case EXPERIMENTAL_FOLLOW_TYPE_HINTS -> this.experimentalFollowTypeHintsParam = true;
-			default -> LOG.warn("Unknown `@tf.function` decorator argument `" + paramName + "` on " + Function.this
-					+ "; ignoring. The argument may belong to a future TF version we don't model yet.");
+			default -> LOG.warn("Unknown @tf.function argument: " + paramName + " on " + Function.this);
 			}
 		}
 

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -249,7 +249,9 @@ public class Function {
 		/**
 		 * Set the appropriate {@code *Param} field for the given {@code tf.function} parameter name. Recognizes both current names and the
 		 * deprecated aliases ({@code experimental_compile} → {@code jit_compile}, {@code experimental_relax_shapes} →
-		 * {@code reduce_retracing}). Unknown names are silently ignored; they may belong to a future TF version we don't model yet.
+		 * {@code reduce_retracing}). Unknown names are logged at {@code WARNING} level but otherwise ignored; they may belong to a future
+		 * TF version we don't model yet. Intermediate step toward the original ask in #204 (custom exception + test); the log surfaces the
+		 * signal without sacrificing forward-compatibility.
 		 *
 		 * @param paramName The parameter name passed to {@code @tf.function(...)}, exactly as it appears in the call.
 		 */
@@ -263,6 +265,8 @@ public class Function {
 			case EXPERIMENTAL_IMPLEMENTS -> this.experimentalImplementsParam = true;
 			case EXPERIMENTAL_AUTOGRAPH_OPTIONS -> this.experimentalAutographOptionsParam = true;
 			case EXPERIMENTAL_FOLLOW_TYPE_HINTS -> this.experimentalFollowTypeHintsParam = true;
+			default -> LOG.warn("Unknown `@tf.function` decorator argument `" + paramName + "` on " + Function.this
+					+ "; ignoring. The argument may belong to a future TF version we don't model yet.");
 			}
 		}
 

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -265,7 +265,7 @@ public class Function {
 			case EXPERIMENTAL_IMPLEMENTS -> this.experimentalImplementsParam = true;
 			case EXPERIMENTAL_AUTOGRAPH_OPTIONS -> this.experimentalAutographOptionsParam = true;
 			case EXPERIMENTAL_FOLLOW_TYPE_HINTS -> this.experimentalFollowTypeHintsParam = true;
-			default -> LOG.warn("Unknown @tf.function argument: " + paramName + " on " + Function.this);
+			default -> LOG.warn("Unknown @tf.function argument: " + paramName + " on " + Function.this + ".");
 			}
 		}
 

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testComputeParameters13/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testComputeParameters13/in/A.py
@@ -1,9 +1,14 @@
-# Exercises `markParam`'s `default` branch (the WARN log for an unrecognized `@tf.function` kwarg). `unknown_argument` is not a real
-# TF kwarg, so TF rejects it at decoration time; this fixture is not Python-runnable. The analyzer must still parse it without
-# error and leave every recognized `*Param` flag unset.
+# Exercises `markParam`'s `default` branch (the WARN log for an unrecognized `@tf.function` kwarg). `experimental_attributes` is a
+# real TF kwarg added in TF 2.13 that Hybridize does not yet model; the analyzer must parse it without error and leave every
+# recognized `*Param` flag unset. Pinning this fixture to `tensorflow==2.13.1` (newer than the project default 2.9.3) is
+# intentional—the whole point is to ship a kwarg the older recognized list misses.
 import tensorflow as tf
 
 
-@tf.function(unknown_argument=True)
+@tf.function(experimental_attributes=None)
 def func(x):
     return x
+
+
+if __name__ == "__main__":
+    func(tf.constant(1))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testComputeParameters13/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testComputeParameters13/in/A.py
@@ -1,0 +1,9 @@
+# Exercises `markParam`'s `default` branch (the WARN log for an unrecognized `@tf.function` kwarg). `unknown_argument` is not a real
+# TF kwarg, so TF rejects it at decoration time; this fixture is not Python-runnable. The analyzer must still parse it without
+# error and leave every recognized `*Param` flag unset.
+import tensorflow as tf
+
+
+@tf.function(unknown_argument=True)
+def func(x):
+    return x

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testComputeParameters13/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testComputeParameters13/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testComputeParameters13/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testComputeParameters13/in/requirements.txt
@@ -1,1 +1,1 @@
-tensorflow==2.9.3
+tensorflow==2.13.1

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1156,8 +1156,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	/**
 	 * Test that an unrecognized {@code @tf.function} keyword argument is parsed without error and that none of the recognized
 	 * {@code *Param} flags are set. Exercises the {@code default} branch of {@code markParam}, which logs a {@code WARNING} and otherwise
-	 * leaves state untouched. The fixture is intentionally not Python-runnable—TF rejects unknown kwargs at decoration time—so the standard
-	 * three-check protocol's runtime step does not apply; the analyzer-robustness guarantee is the whole point of this test.
+	 * leaves state untouched. The fixture uses {@code experimental_attributes}, a real TF kwarg added in TF 2.13 that Hybridize does not
+	 * yet model; the per-fixture {@code requirements.txt} pins {@code tensorflow==2.13.1} so the fixture is Python-runnable.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/204">Issue 204</a>
 	 */

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1157,12 +1157,11 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * Test that an unrecognized {@code @tf.function} keyword argument is parsed without error and that none of the recognized
 	 * {@code *Param} flags are set. Exercises the {@code default} branch of {@code markParam}, which logs a {@code WARNING} and otherwise
 	 * leaves state untouched. The fixture uses {@code experimental_attributes}, a real TF kwarg added in TF 2.13 that Hybridize does not
-	 * yet model; the per-fixture {@code requirements.txt} pins {@code tensorflow==2.13.1} so the fixture is Python-runnable.
-	 * <p>
-	 * NOTE: If Hybridize promotes {@code experimental_attributes} to a first-class recognized parameter (its own case in
-	 * {@code markParam}'s switch and a {@code hasExperimentalAttributesParam} accessor), this test will fail—the new flag would be set by
-	 * the fixture, and the conjunction below would also need to assert {@code !args.hasExperimentalAttributesParam()}. Re-pin the fixture
-	 * to a different real-but-unrecognized kwarg at that point to keep exercising the {@code default} WARN branch.
+	 * yet model; the per-fixture {@code requirements.txt} pins {@code tensorflow==2.13.1} so the fixture is Python-runnable. NOTE: If
+	 * Hybridize promotes {@code experimental_attributes} to a first-class recognized parameter (its own case in {@code markParam}'s switch
+	 * and a {@code hasExperimentalAttributesParam} accessor), this test will fail—the new flag would be set by the fixture, and the
+	 * conjunction below would also need to assert {@code !args.hasExperimentalAttributesParam()}. Re-pin the fixture to a different
+	 * real-but-unrecognized kwarg at that point to keep exercising the {@code default} WARN branch.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/204">Issue 204</a>
 	 */

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1154,6 +1154,32 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Test that an unrecognized {@code @tf.function} keyword argument is parsed without error and that none of the recognized
+	 * {@code *Param} flags are set. Exercises the {@code default} branch of {@code markParam}, which logs a {@code WARNING} and otherwise
+	 * leaves state untouched. The fixture is intentionally not Python-runnable—TF rejects unknown kwargs at decoration time—so the standard
+	 * three-check protocol's runtime step does not apply; the analyzer-robustness guarantee is the whole point of this test.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/204">Issue 204</a>
+	 */
+	@Test
+	public void testComputeParameters13() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertNotNull(functions);
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+		assertNotNull(function);
+
+		assertTrue(function.isHybrid());
+
+		Function.HybridizationParameters args = function.getHybridizationParameters();
+		assertNotNull(args);
+
+		assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && !args.hasAutoGraphParam() && !args.hasJitCompileParam()
+				&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
+				&& !args.hasExperimentalFollowTypeHintsParam());
+	}
+
+	/**
 	 * This simply tests whether we have the correct qualified name.
 	 */
 	@Test

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1158,6 +1158,11 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * {@code *Param} flags are set. Exercises the {@code default} branch of {@code markParam}, which logs a {@code WARNING} and otherwise
 	 * leaves state untouched. The fixture uses {@code experimental_attributes}, a real TF kwarg added in TF 2.13 that Hybridize does not
 	 * yet model; the per-fixture {@code requirements.txt} pins {@code tensorflow==2.13.1} so the fixture is Python-runnable.
+	 * <p>
+	 * NOTE: If Hybridize promotes {@code experimental_attributes} to a first-class recognized parameter (its own case in
+	 * {@code markParam}'s switch and a {@code hasExperimentalAttributesParam} accessor), this test will fail—the new flag would be set by
+	 * the fixture, and the conjunction below would also need to assert {@code !args.hasExperimentalAttributesParam()}. Re-pin the fixture
+	 * to a different real-but-unrecognized kwarg at that point to keep exercising the {@code default} WARN branch.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/204">Issue 204</a>
 	 */

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -67,7 +67,9 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
@@ -1159,28 +1161,40 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * leaves state untouched. The fixture uses {@code experimental_attributes}, a real TF kwarg added in TF 2.13 that Hybridize does not
 	 * yet model; the per-fixture {@code requirements.txt} pins {@code tensorflow==2.13.1} so the fixture is Python-runnable. NOTE: If
 	 * Hybridize promotes {@code experimental_attributes} to a first-class recognized parameter (its own case in {@code markParam}'s switch
-	 * and a {@code hasExperimentalAttributesParam} accessor), this test will fail—the new flag would be set by the fixture, and the
-	 * conjunction below would also need to assert {@code !args.hasExperimentalAttributesParam()}. Re-pin the fixture to a different
+	 * and a {@code hasExperimentalAttributesParam} accessor), this test will fail twice over—the new flag would be set by the fixture
+	 * (failing the conjunction below), and the WARN log assertion would no longer fire. Re-pin the fixture to a different
 	 * real-but-unrecognized kwarg at that point to keep exercising the {@code default} WARN branch.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/204">Issue 204</a>
 	 */
 	@Test
 	public void testComputeParameters13() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertNotNull(functions);
-		assertEquals(1, functions.size());
-		Function function = functions.iterator().next();
-		assertNotNull(function);
+		ILog functionLog = getLog(Function.class);
+		List<IStatus> captured = new ArrayList<>();
+		ILogListener listener = (status, plugin) -> captured.add(status);
+		functionLog.addLogListener(listener);
+		try {
+			Set<Function> functions = this.getFunctions();
+			assertNotNull(functions);
+			assertEquals(1, functions.size());
+			Function function = functions.iterator().next();
+			assertNotNull(function);
 
-		assertTrue(function.isHybrid());
+			assertTrue(function.isHybrid());
 
-		Function.HybridizationParameters args = function.getHybridizationParameters();
-		assertNotNull(args);
+			Function.HybridizationParameters args = function.getHybridizationParameters();
+			assertNotNull(args);
 
-		assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && !args.hasAutoGraphParam() && !args.hasJitCompileParam()
-				&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam() && !args.hasExperimentalAutographOptionsParam()
-				&& !args.hasExperimentalFollowTypeHintsParam());
+			assertTrue(!args.hasFuncParam() && !args.hasInputSignatureParam() && !args.hasAutoGraphParam() && !args.hasJitCompileParam()
+					&& !args.hasReduceRetracingParam() && !args.hasExperimentalImplementsParam()
+					&& !args.hasExperimentalAutographOptionsParam() && !args.hasExperimentalFollowTypeHintsParam());
+		} finally {
+			functionLog.removeLogListener(listener);
+		}
+
+		boolean warnFired = captured.stream().anyMatch(s -> s.getSeverity() == IStatus.WARNING
+				&& "Unknown @tf.function argument: experimental_attributes on func().".equals(s.getMessage()));
+		assertTrue("Expected WARN log for unknown kwarg `experimental_attributes`.", warnFired);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`Function.markParam` previously silently ignored `@tf.function` decorator-argument names it didn't recognize. The Javadoc justified the choice as forward-compatibility with future TF versions, but silent-ignore left no signal for tests, evaluator output, or the UI.

Add a `default` branch to the switch that logs the unknown argument name (and the owning function) at `WARNING` level via the existing `ILog LOG`. Forward-compatibility preserved; the signal is now visible in logs and CI output.

## Why Intermediate

This is a small, targeted step ahead of #204's original ask (a custom `UnknownHybridizationParameter` exception with matching test). The issue stays open for that larger work; this PR addresses the narrower visibility gap without committing to the exception's stricter semantics.

## Cross-Refs

- #204—stays open for the original exception + test ask.
- `Function.java:256-267`—the `markParam` switch.

## Test Plan

- [x] `./mvnw verify -pl edu.cuny.hunter.hybridize.tests`—492 tests, 0 failures, 11 skipped
- [ ] CI green
- [ ] Copilot threads clean
