### PR TITLE
Bump Ariadne to 0.45.0

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -126,7 +126,9 @@ import org.python.pydev.ui.BundleInfoStub;
 
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 import com.python.pydev.analysis.additionalinfo.AbstractAdditionalDependencyInfo;
 import com.python.pydev.analysis.additionalinfo.AdditionalProjectInterpreterInfo;
@@ -3063,18 +3065,17 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `RaggedTensor.from_nested_row_splits`. Canonical TODO-anchored fixture for the ragged-tensor precision gap.
-	 * Runtime: {@code tf.RaggedTensor.from_nested_row_splits(values, splits)} dtype=int32, shape=(3, None, None). Ariadne emits an INT32
-	 * {@link TensorType} with three dims: a known constant 3 followed by two raggedness markers (raw {@code null}).
-	 * TODO(https://github.com/wala/ML/issues/544): flip the {@code null} entries to {@code new RaggedDim()} once Ariadne ships the typed
-	 * sentinel. The inference algorithm collapses ragged markers to {@code SymbolicDim("?")} wildcards in the inferred signature, producing
-	 * a {@code TensorSpec}-shaped signature that admits the runtime call but loses the raggedness signal.
-	 * TODO(https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/524): flip from a {@code TensorSpec} with wildcards to a
-	 * {@code RaggedTensorSpec} once the consumer-side emission lands.
+	 * Test for #2 for TF API `RaggedTensor.from_nested_row_splits`. Canonical fixture for the ragged-tensor precision gap. Runtime:
+	 * {@code tf.RaggedTensor.from_nested_row_splits(values, splits)} dtype=int32, shape=(3, None, None). Ariadne emits an INT32
+	 * {@link TensorType} with three dims: a known constant 3 followed by two {@link RaggedDim} raggedness markers (per wala/ML#544 /
+	 * ponder-lab/ML#320, shipped in Ariadne 0.45.0). The inference algorithm collapses ragged markers to {@code SymbolicDim("?")} wildcards
+	 * in the inferred signature, producing a {@code TensorSpec}-shaped signature that admits the runtime call but loses the raggedness
+	 * signal. TODO(https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/524): flip from a {@code TensorSpec} with wildcards
+	 * to a {@code RaggedTensorSpec} once the consumer-side emission lands.
 	 */
 	@Test
 	public void testHasLikelyTensorParameter59() throws Exception {
-		TensorType expectedParameterTensorType = new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null));
+		TensorType expectedParameterTensorType = new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 		TensorType expectedSignatureTensorType = new TensorType(INT32,
 				List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?")));
 		testHasLikelyTensorParameterHelper(expectedParameterTensorType, expectedSignatureTensorType);
@@ -3085,7 +3086,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter60() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3094,7 +3095,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter61() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3103,7 +3104,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter62() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3112,7 +3113,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter63() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3121,7 +3122,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter64() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3130,7 +3131,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter65() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3139,7 +3140,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter66() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(3), null, null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3148,7 +3149,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter67() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+		testHasLikelyTensorParameterHelper(
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
 				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3157,7 +3159,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter68() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+		testHasLikelyTensorParameterHelper(
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
 				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3166,7 +3169,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter69() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+		testHasLikelyTensorParameterHelper(
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
 				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3175,7 +3179,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter70() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+		testHasLikelyTensorParameterHelper(
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
 				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3184,7 +3189,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter71() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
@@ -3193,7 +3198,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter72() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
@@ -3202,7 +3207,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter73() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
@@ -3211,7 +3216,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter74() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
@@ -3220,7 +3225,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter75() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
@@ -3229,7 +3234,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter76() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
@@ -3238,7 +3243,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter77() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
@@ -3247,7 +3252,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter78() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
@@ -3256,7 +3261,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter79() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(5), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
 	}
 
@@ -3265,7 +3270,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter80() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(4), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(4), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(4), new SymbolicDim("?"))));
 	}
 
@@ -3274,7 +3279,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter81() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(4), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(4), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(4), new SymbolicDim("?"))));
 	}
 
@@ -3283,7 +3288,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter82() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(4), null)),
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(4), RaggedDim.INSTANCE)),
 				new TensorType(INT32, List.of(new NumericDim(4), new SymbolicDim("?"))));
 	}
 
@@ -3437,7 +3442,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter100() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(32))),
 				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
@@ -3446,7 +3451,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter101() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(32))),
 				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
@@ -3455,7 +3460,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter102() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(32))),
 				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
@@ -3464,7 +3469,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter103() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(32))),
 				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
@@ -3473,7 +3478,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter104() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(32))),
 				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
@@ -3547,8 +3552,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter112() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
-				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))),
+				new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))));
 	}
 
 	/**
@@ -3556,8 +3561,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter113() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
-				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))),
+				new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))));
 	}
 
 	/**
@@ -3565,8 +3570,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter114() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
-				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))),
+				new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))));
 	}
 
 	/**
@@ -3574,8 +3579,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter115() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
-				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))),
+				new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))));
 	}
 
 	/**
@@ -3583,8 +3588,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter116() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
-				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))),
+				new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))));
 	}
 
 	/**
@@ -3592,8 +3597,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter117() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, Arrays.asList(new NumericDim(1), null)),
-				new TensorType(INT32, List.of(new NumericDim(1), new SymbolicDim("?"))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))),
+				new TensorType(INT32, List.of(new NumericDim(1), new NumericDim(5))));
 	}
 
 	/**
@@ -3601,7 +3606,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter118() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+		testHasLikelyTensorParameterHelper(
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
 				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3610,7 +3616,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter119() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+		testHasLikelyTensorParameterHelper(
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
 				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3619,7 +3626,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter120() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+		testHasLikelyTensorParameterHelper(
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
 				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3628,7 +3636,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter121() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+		testHasLikelyTensorParameterHelper(
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
 				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3637,7 +3646,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter122() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(STRING, Arrays.asList(new NumericDim(4), null, null, null)),
+		testHasLikelyTensorParameterHelper(
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
 				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
 	}
 
@@ -3654,7 +3664,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter124() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(32))),
 				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 
@@ -3663,7 +3673,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter125() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, Arrays.asList(null, new NumericDim(32))),
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(32))),
 				new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(32))));
 	}
 

--- a/hybridize.target
+++ b/hybridize.target
@@ -57,7 +57,8 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.44.0</version>
+					<version>0.45.0</version>
+					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>
 			</dependencies>


### PR DESCRIPTION
## Summary

- Bump `com.ibm.wala.cast.python.ml` from `0.44.0` to `0.45.0` in `hybridize.target`.
- Add `<classifier>fat</classifier>` to the Ariadne dependency **as an interim measure**. Per wala/ML#418 and ponder-lab/ML#298, the slim default JAR is the intended consumption mode for library consumers like Hybridize, but slim consumption is currently blocked—see Why Not Slim below.
- Sweep 42 `testHasLikelyTensorParameter*` expectations to Ariadne 0.45.0's typed dim sentinels (`DynamicDim`, `RaggedDim`) and `RaggedRange` precision win.

Closes #559.

## Why Not Slim

ponder-lab/ML#298 stated the slim default JAR is the intended consumption mode: "library consumers like Hybridize now get exactly what [wala/ML#418] asked for: a thin-jar published artifact with proper Maven dependency resolution". Tried on the parallel branch [`bump-ariadne-0.45.0-slim`](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/tree/bump-ariadne-0.45.0-slim) (`includeDependencyDepth="infinite"`, no classifier), result:

```
[ERROR] Artifact org.python:jython3:0.0.1-SNAPSHOT ... could not be wrapped
as a bundle: The default package '.' is not permitted by the Import-Package
syntax.
```

`jython3` ships `ProxyDeserialization.class` at the default (unnamed) package level. Tycho 5+'s stricter bnd auto-wrap rejects this—same root cause documented in wala/ML#418 but a form wala/ML#418's fix doesn't cover. wala/ML#418's narrow patch (shade-exclude `ProxyDeserialization.class` from the fat JAR) keeps the fat path working but can't apply to the slim path: no shading means `jython3` flows through transitively with the bad class intact.

Tracking issue filed at wala/ML#557 (proposed fix: shade-exclude `ProxyDeserialization.class` at the `jython3` build step itself, mirroring the wala/ML#418 pattern one layer down).

**Once wala/ML#557 is resolved, this PR should be reworked** to drop the classifier and switch to `includeDependencyDepth="infinite"`.

## Test Expectation Sweep

`./mvnw verify` initially reported **42 failures** across `testHasLikelyTensorParameter*`. All were expectation drift, not regressions—Ariadne 0.45.0's typed-sentinel rollout (wala/ML#545 `DynamicDim`, ponder-lab/ML#320 `RaggedDim`) and one precision win (ponder-lab/ML#332 `RaggedRange`). Six unique diff patterns observed:

| Expected (0.44.0) | Actual (0.45.0) | Root Cause |
|---|---|---|
| `[null, D:Constant,32]` | `[D:Dynamic,null, D:Constant,32]` | wala/ML#545—`keras.Input` batch dim materialized as `DynamicDim` instead of raw `null` |
| `[D:Constant,4, null]` | `[D:Constant,4, D:Ragged,null]` | wala/ML#449 and ponder-lab/ML#320—ragged row dim materialized as `RaggedDim` instead of raw `null` |
| `[D:Constant,5, null]` | `[D:Constant,5, D:Ragged,null]` | same as above |
| `[D:Constant,3, null, null]` | `[D:Constant,3, D:Ragged,null, D:Ragged,null]` | same—applies to multi-axis ragged tensors |
| `[D:Constant,4, null, null, null]` | `[D:Constant,4, D:Ragged,null, D:Ragged,null, D:Dynamic,null]` | mixed—ragged dims + dynamic batch combined |
| `[D:Constant,1, null]` | `[D:Constant,1, D:Constant,5]` | ponder-lab/ML#332—`RaggedRange` precision improvement; `null` is now resolved to concrete `5` |

Confirmed via Python runtime: `keras.Input(shape=(32,))` followed by addition produces shape `(None, 32)`—rank 2—and Ariadne 0.45.0 returns rank 2 (`[D:Dynamic, D:Constant,32]`). `D:Dynamic,null` is the toString of a single `DynamicDim` (type=`Dynamic`, payload value=`null` since the type parameter is `Void`).

For the `ragged.range` case (sixth row above), both the parameter `TensorType` and the inferred signature `TensorType` shifted: signature dims tighten from `SymbolicDim("?")` to `NumericDim(5)` in lockstep.

### Fix Applied

Mechanical sweep on the Hybridize side. For each failing test, the `Arrays.asList(null, ...)` or `Arrays.asList(..., null, ...)` argument in the expected `TensorType` had `null` replaced by the appropriate typed sentinel:

- Batch dim (leading position on a non-ragged tensor) → `DynamicDim.INSTANCE`.
- Ragged row dim (interior position on a `RaggedTensor`) → `RaggedDim.INSTANCE`.
- Flat values dim (trailing position on a multi-axis `RaggedTensor`) → `DynamicDim.INSTANCE`.
- `RaggedRange` parameter and signature: `null` and `SymbolicDim("?")` → `NumericDim(5)`.

7 `keras.Input` sites + ~35 ragged-tensor sites updated. `DynamicDim` and `RaggedDim` imports added. The now-resolved `wala/ML#544` typed-sentinel TODO was dropped from `testHasLikelyTensorParameter59`'s docstring; the `Hybridize#524` `RaggedTensorSpec` emission TODO stays.

## Other Notes

- Without the `fat` classifier, Tycho target-platform resolution fails with `Missing requirement: ... requires 'java.package; com.google.common.collect 0.0.0'`—the slim default JAR doesn't bundle Guava (it's a transitive POM dep), and `includeDependencyDepth="none"` doesn't follow the POM.
- Build uses JDK 25 (matches CI's `actions/setup-java` config).
- Test count: 492 (compared to 471 baseline on the 0.44.0 bump at #493)—21 new tests added in the interim.

## Test Plan

- [x] Test expectations regenerated for the 42 affected `testHasLikelyTensorParameter*` cases (see table above).
- [ ] CI passes on the expectation-regenerated branch.
- [x] Hybridize consumer migration is tracked: #561 covers explicit `instanceof DynamicDim` and `instanceof RaggedDim` branching in `Function.inferSpec`, satisfying the "or a follow-up issue tracks that migration" half of #559's acceptance.

