### PR TITLE
Type-discriminate `DynamicDim`/`RaggedDim` in `Function.inferSpec`

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1594,9 +1594,10 @@ public class Function {
 		}
 
 		// Step 3: per-dim consensus or wildcard. If all contexts agree on a concrete value at position j, keep it; else emit a
-		// `SymbolicDim("?")` wildcard. `DynamicDim` and `RaggedDim` (typed sentinels shipped in Ariadne 0.45.0 per wala/ML#545 and
-		// ponder-lab/ML#320) get explicit branches so future precision improvements can refine each case independently—#524 routes the
-		// `RaggedDim` branch to `RaggedTensorSpec` emission.
+		// `SymbolicDim("?")` wildcard. `DynamicDim` and `RaggedDim` (typed sentinels shipped in Ariadne 0.45.0 per
+		// https://github.com/wala/ML/issues/545 and https://github.com/ponder-lab/ML/issues/320) get explicit branches so future precision
+		// improvements can refine each case independently—https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/524 routes
+		// the `RaggedDim` branch to `RaggedTensorSpec` emission.
 		List<Dimension<?>> shape = new ArrayList<>(rank);
 		for (int j = 0; j < rank; j++) {
 			Dimension<?> consensus = null;
@@ -1617,7 +1618,8 @@ public class Function {
 			else if (consensus instanceof DynamicDim)
 				shape.add(new SymbolicDim("?"));
 			else if (consensus instanceof RaggedDim)
-				// TODO(#524): once `RaggedTensorSpec` emission lands, route ragged dims there instead of collapsing.
+				// TODO(https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/524): once `RaggedTensorSpec` emission lands,
+				// route ragged dims there instead of collapsing.
 				shape.add(new SymbolicDim("?"));
 			else
 				shape.add(new SymbolicDim("?"));

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -88,7 +88,9 @@ import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 import com.ibm.wala.cast.python.types.PythonTypes;
 import com.ibm.wala.cast.types.AstMethodReference;
@@ -1592,9 +1594,9 @@ public class Function {
 		}
 
 		// Step 3: per-dim consensus or wildcard. If all contexts agree on a concrete value at position j, keep it; else emit a
-		// `SymbolicDim("?")` wildcard.
-		// TODO(wala/ML#544, #524): once Ariadne ships a typed `RaggedDim` and this side emits `RaggedTensorSpec`, branch on
-		// raggedness here rather than collapsing every non-`NumericDim` to a wildcard.
+		// `SymbolicDim("?")` wildcard. `DynamicDim` and `RaggedDim` (typed sentinels shipped in Ariadne 0.45.0 per wala/ML#545 and
+		// ponder-lab/ML#320) get explicit branches so future precision improvements can refine each case independently—#524 routes the
+		// `RaggedDim` branch to `RaggedTensorSpec` emission.
 		List<Dimension<?>> shape = new ArrayList<>(rank);
 		for (int j = 0; j < rank; j++) {
 			Dimension<?> consensus = null;
@@ -1608,8 +1610,15 @@ public class Function {
 					break;
 				}
 			}
-			if (!disagreement && consensus instanceof NumericDim)
+			if (disagreement)
+				shape.add(new SymbolicDim("?"));
+			else if (consensus instanceof NumericDim)
 				shape.add(consensus);
+			else if (consensus instanceof DynamicDim)
+				shape.add(new SymbolicDim("?"));
+			else if (consensus instanceof RaggedDim)
+				// TODO(#524): once `RaggedTensorSpec` emission lands, route ragged dims there instead of collapsing.
+				shape.add(new SymbolicDim("?"));
 			else
 				shape.add(new SymbolicDim("?"));
 		}


### PR DESCRIPTION
## Summary

Refactors `Function.inferSpec`'s per-position consensus loop to type-discriminate `DynamicDim` and `RaggedDim` explicitly, satisfying acceptance criterion 3 of #559 (the Ariadne 0.45.0 bump). Surface behavior is unchanged.

Closes #561.

## Change

The per-position consensus loop previously collapsed every non-`NumericDim` element to a `SymbolicDim("?")` wildcard through a single fall-through `else`. The new structure fans the cases out into independent branches—disagreement, `NumericDim`, `DynamicDim`, `RaggedDim`, and the residual default—so future precision improvements can refine each case in isolation. #524 will route the `RaggedDim` branch to `RaggedTensorSpec` emission, and the actionable in-tree TODO now anchors there. The stale `wala/ML#544` reference is dropped from the header comment since the typed-sentinel half of that TODO shipped in Ariadne 0.45.0.

## Test Plan

- [x] All 492 `HybridizeFunctionRefactoringTest` cases pass locally with `JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64 ./mvnw verify`.
- [x] Spotless clean.
- [ ] CI passes.

## Cross-Refs

- #559—Ariadne 0.45.0 bump tracker (this PR satisfies acceptance bullet 3).
- #560—Ariadne 0.45.0 bump PR; merged at 60c6038c.
- #524—`RaggedTensorSpec` emission for ragged tensor parameters; the actionable TODO this PR plants in the `RaggedDim` branch.
