### PR TITLE
Add `InputSignature.toTensorSpecList` formatter

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
@@ -1,6 +1,7 @@
 package edu.cuny.hunter.hybridize.core.analysis;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.StringJoiner;
 
 import com.ibm.wala.cast.python.ml.types.TensorType;
@@ -43,12 +44,23 @@ public record InputSignature(List<TensorType> parameterTypes) {
 		StringJoiner specs = new StringJoiner(", ", "[", "]");
 
 		for (TensorType t : parameterTypes) {
-			StringJoiner shapeDims = new StringJoiner(", ", "(", t.getDims().size() == 1 ? ",)" : ")");
-			for (Dimension<?> d : t.getDims())
-				shapeDims.add(d instanceof NumericDim ? d.value().toString() : "None");
+			List<Dimension<?>> dims = t.getDims();
+			String shape;
+			if (dims == null) {
+				// Shape-⊤ from `Function.inferSpec` Step 2 (rank disagrees across contexts, or any context has null dims). TF's
+				// `tf.TensorSpec(shape=None, ...)` accepts any shape at runtime—the appropriate encoding when rank itself is unknown.
+				shape = "None";
+			} else {
+				StringJoiner shapeDims = new StringJoiner(", ", "(", dims.size() == 1 ? ",)" : ")");
+				for (Dimension<?> d : dims)
+					shapeDims.add(d instanceof NumericDim ? d.value().toString() : "None");
+				shape = shapeDims.toString();
+			}
 
-			String dtype = tfPrefix + t.getDType().name().toLowerCase();
-			specs.add(tfPrefix + "TensorSpec(shape=" + shapeDims + ", dtype=" + dtype + ")");
+			// `Locale.ROOT` so dtype identifiers stay ASCII regardless of the JVM default (Turkish locale lower-cases `I` to a
+			// non-ASCII dotless-i, which would corrupt `INT32` → `ınt32`, `STRING` → `strıng`).
+			String dtype = tfPrefix + t.getDType().name().toLowerCase(Locale.ROOT);
+			specs.add(tfPrefix + "TensorSpec(shape=" + shape + ", dtype=" + dtype + ")");
 		}
 
 		return specs.toString();

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
@@ -1,8 +1,11 @@
 package edu.cuny.hunter.hybridize.core.analysis;
 
 import java.util.List;
+import java.util.StringJoiner;
 
 import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 
 /**
  * The inferred input signature of a hybridizable function: an ordered tuple of {@link TensorType}s in declaration order, one per
@@ -13,4 +16,41 @@ import com.ibm.wala.cast.python.ml.types.TensorType;
  * {@link Function#inferInputSignature}; see that method's Javadoc and #508 for the rules.
  */
 public record InputSignature(List<TensorType> parameterTypes) {
+
+	/**
+	 * Format this signature as a Python source-code expression suitable for the {@code input_signature=} keyword argument of
+	 * {@code @tf.function(...)}. Each parameter's {@link TensorType} renders as {@code tfPrefix + "TensorSpec(shape=(...), dtype=" +
+	 * tfPrefix + "<dtype>)"}; shape dims render as concrete integers for {@link NumericDim} and {@code None} for every other
+	 * {@link Dimension} subtype (dynamic, ragged, symbolic—all encoded the same way on the {@code TensorSpec} surface). The whole thing is
+	 * wrapped in {@code [...]} so it can drop straight into {@code @tf.function(input_signature=...)}.
+	 * <p>
+	 * Examples (with {@code tfPrefix = "tf."}):
+	 * <ul>
+	 * <li>Single rank-2 tensor {@code (FLOAT32, [DynamicDim, NumericDim(32)])} → {@code [tf.TensorSpec(shape=(None, 32),
+	 * dtype=tf.float32)]}
+	 * <li>Two tensors → {@code [tf.TensorSpec(...), tf.TensorSpec(...)]}
+	 * <li>Scalar tensor (empty dims) → {@code [tf.TensorSpec(shape=(), dtype=tf.int32)]}
+	 * </ul>
+	 * <p>
+	 * The {@code tfPrefix} argument carries the user's existing import shape so the emitted source matches what the user wrote:
+	 * {@code "tf."} for {@code import tensorflow as tf}, {@code "tensorflow."} for {@code import tensorflow}, or {@code ""} when
+	 * {@code TensorSpec} and the dtype constants are already in scope via {@code from tensorflow import *} or similar.
+	 *
+	 * @param tfPrefix The TensorFlow module prefix (e.g., {@code "tf."}), including the trailing dot. May be empty.
+	 * @return The Python source-code list expression.
+	 */
+	public String toTensorSpecList(String tfPrefix) {
+		StringJoiner specs = new StringJoiner(", ", "[", "]");
+
+		for (TensorType t : parameterTypes) {
+			StringJoiner shapeDims = new StringJoiner(", ", "(", t.getDims().size() == 1 ? ",)" : ")");
+			for (Dimension<?> d : t.getDims())
+				shapeDims.add(d instanceof NumericDim ? d.value().toString() : "None");
+
+			String dtype = tfPrefix + t.getDType().name().toLowerCase();
+			specs.add(tfPrefix + "TensorSpec(shape=" + shapeDims + ", dtype=" + dtype + ")");
+		}
+
+		return specs.toString();
+	}
 }

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
@@ -7,10 +7,12 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.STRING;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.Test;
 
 import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
@@ -102,5 +104,34 @@ public class InputSignatureTest {
 	public void testEmptyPrefix() {
 		InputSignature sig = new InputSignature(List.of(new TensorType(FLOAT32, List.of(new NumericDim(2)))));
 		assertEquals("[TensorSpec(shape=(2,), dtype=float32)]", sig.toTensorSpecList(""));
+	}
+
+	/**
+	 * Shape-⊤ tensors (rank disagrees across contexts, or any context has unknown rank): {@code Function.inferSpec} returns
+	 * {@code TensorType(dtype, null)}. The formatter must encode this as {@code shape=None}—TF's {@code tf.TensorSpec(shape=None, ...)}
+	 * accepts any shape at runtime.
+	 */
+	@Test
+	public void testShapeTopRendersAsNone() {
+		InputSignature sig = new InputSignature(List.of(new TensorType(FLOAT32, (List<Dimension<?>>) null)));
+		assertEquals("[tf.TensorSpec(shape=None, dtype=tf.float32)]", sig.toTensorSpecList("tf."));
+	}
+
+	/**
+	 * Locale-independence: dtype identifiers must lower-case under {@link Locale#ROOT}, not the JVM default. Under Turkish locale,
+	 * {@code "INT32".toLowerCase()} produces {@code "ınt32"} (dotless-i, non-ASCII), which would corrupt the emitted Python.
+	 */
+	@Test
+	public void testDtypeLowerCaseIsLocaleIndependent() {
+		Locale prior = Locale.getDefault();
+		Locale.setDefault(new Locale("tr", "TR"));
+		try {
+			InputSignature sig = new InputSignature(
+					List.of(new TensorType(INT32, List.of(new NumericDim(2))), new TensorType(STRING, List.of(new NumericDim(2)))));
+			assertEquals("[tf.TensorSpec(shape=(2,), dtype=tf.int32), tf.TensorSpec(shape=(2,), dtype=tf.string)]",
+					sig.toTensorSpecList("tf."));
+		} finally {
+			Locale.setDefault(prior);
+		}
 	}
 }

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
@@ -12,7 +12,6 @@ import java.util.Locale;
 import org.junit.Test;
 
 import com.ibm.wala.cast.python.ml.types.TensorType;
-import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
@@ -113,7 +112,7 @@ public class InputSignatureTest {
 	 */
 	@Test
 	public void testShapeTopRendersAsNone() {
-		InputSignature sig = new InputSignature(List.of(new TensorType(FLOAT32, (List<Dimension<?>>) null)));
+		InputSignature sig = new InputSignature(List.of(new TensorType(FLOAT32, null)));
 		assertEquals("[tf.TensorSpec(shape=None, dtype=tf.float32)]", sig.toTensorSpecList("tf."));
 	}
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
@@ -1,0 +1,106 @@
+package edu.cuny.hunter.hybridize.tests;
+
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.BOOL;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.INT32;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.STRING;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
+
+import edu.cuny.hunter.hybridize.core.analysis.InputSignature;
+
+/**
+ * Tests for {@link InputSignature#toTensorSpecList(String)}.
+ *
+ * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+ */
+@SuppressWarnings("static-method")
+public class InputSignatureTest {
+
+	/**
+	 * Single rank-2 dense tensor with a dynamic batch dim: the keras.Input shape.
+	 */
+	@Test
+	public void testSingleRank2WithDynamicBatch() {
+		InputSignature sig = new InputSignature(List.of(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(32)))));
+		assertEquals("[tf.TensorSpec(shape=(None, 32), dtype=tf.float32)]", sig.toTensorSpecList("tf."));
+	}
+
+	/**
+	 * Two parameters, fully concrete shapes, mixed dtypes.
+	 */
+	@Test
+	public void testTwoConcreteParameters() {
+		InputSignature sig = new InputSignature(List.of(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))),
+				new TensorType(INT32, List.of(new NumericDim(5)))));
+		assertEquals("[tf.TensorSpec(shape=(2, 3), dtype=tf.float32), tf.TensorSpec(shape=(5,), dtype=tf.int32)]",
+				sig.toTensorSpecList("tf."));
+	}
+
+	/**
+	 * Single-dim tensor renders with a trailing-comma tuple, matching Python's one-element tuple syntax.
+	 */
+	@Test
+	public void testRank1TupleHasTrailingComma() {
+		InputSignature sig = new InputSignature(List.of(new TensorType(INT32, List.of(new NumericDim(4)))));
+		assertEquals("[tf.TensorSpec(shape=(4,), dtype=tf.int32)]", sig.toTensorSpecList("tf."));
+	}
+
+	/**
+	 * Scalar (rank-0) tensor renders as an empty shape tuple.
+	 */
+	@Test
+	public void testScalarRendersAsEmptyTuple() {
+		InputSignature sig = new InputSignature(List.of(new TensorType(INT32, List.of())));
+		assertEquals("[tf.TensorSpec(shape=(), dtype=tf.int32)]", sig.toTensorSpecList("tf."));
+	}
+
+	/**
+	 * {@link SymbolicDim} and {@link RaggedDim} render as {@code None}, the same as {@link DynamicDim}. The {@code TensorSpec} surface
+	 * cannot encode raggedness; the {@code RaggedTensorSpec} flip is tracked separately at #524.
+	 */
+	@Test
+	public void testSymbolicAndRaggedDimsCollapseToNone() {
+		InputSignature sig = new InputSignature(
+				List.of(new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), RaggedDim.INSTANCE, DynamicDim.INSTANCE))));
+		assertEquals("[tf.TensorSpec(shape=(3, None, None, None), dtype=tf.int32)]", sig.toTensorSpecList("tf."));
+	}
+
+	/**
+	 * Non-numeric dtypes render with their lowercase name (e.g., {@code tf.string}, {@code tf.bool}).
+	 */
+	@Test
+	public void testNonNumericDtypes() {
+		InputSignature sig = new InputSignature(
+				List.of(new TensorType(STRING, List.of(new NumericDim(2))), new TensorType(BOOL, List.of(new NumericDim(2)))));
+		assertEquals("[tf.TensorSpec(shape=(2,), dtype=tf.string), tf.TensorSpec(shape=(2,), dtype=tf.bool)]", sig.toTensorSpecList("tf."));
+	}
+
+	/**
+	 * A {@code "tensorflow."} prefix (from {@code import tensorflow}) flows through both the constructor and the dtype reference.
+	 */
+	@Test
+	public void testFullModulePrefix() {
+		InputSignature sig = new InputSignature(List.of(new TensorType(FLOAT32, List.of(new NumericDim(2)))));
+		assertEquals("[tensorflow.TensorSpec(shape=(2,), dtype=tensorflow.float32)]", sig.toTensorSpecList("tensorflow."));
+	}
+
+	/**
+	 * An empty prefix (from {@code from tensorflow import *} or similar) emits bare {@code TensorSpec(...)} with bare dtype references. The
+	 * caller is responsible for ensuring those names are in scope; this method only formats.
+	 */
+	@Test
+	public void testEmptyPrefix() {
+		InputSignature sig = new InputSignature(List.of(new TensorType(FLOAT32, List.of(new NumericDim(2)))));
+		assertEquals("[TensorSpec(shape=(2,), dtype=float32)]", sig.toTensorSpecList(""));
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of #563. Adds `InputSignature.toTensorSpecList(String tfPrefix)`—a pure formatter that converts an inferred `InputSignature` to a Python source-code list of `tf.TensorSpec(shape=…, dtype=…)` calls suitable for the `input_signature=` keyword argument of `@tf.function(...)`. Self-contained: no callers yet, no behavior change. Subsequent phases of #563 will wire it into `convertToHybrid` and implement `Transformation.RECONFIGURE`.

## Behavior

For each `TensorType` parameter, the formatter renders:

- Shape dims: integer literal for `NumericDim`; `None` for every other dim (`DynamicDim`, `RaggedDim`, `SymbolicDim`—all encoded the same way on the `TensorSpec` surface).
- Rank-1 tuple gets the trailing-comma form `(n,)` to match Python's one-element tuple syntax.
- Scalar (rank 0) gets `()`.
- Dtype: `tfPrefix + getDType().name().toLowerCase()` (e.g., `tf.float32`).

The `tfPrefix` argument flows through both the constructor and the dtype reference, matching the user's import shape (`"tf."`, `"tensorflow."`, or `""`).

## Test Plan

- [x] 8 unit tests covering: dynamic-batch rank-2, two concrete parameters with mixed dtypes, rank-1 trailing-comma form, scalar empty-tuple form, mixed dim sentinels, non-numeric dtypes, full-module prefix, empty prefix.
- [x] Spotless clean.
- [ ] CI passes.

## Cross-Refs

- #563—source-write transformation (parent issue; subsequent phases wire the formatter into `convertToHybrid` and implement `RECONFIGURE`).
- #481—opt-in flag; will gate the source-write once it lands.
- #524/#533—orthogonal precision improvements (typed `RaggedTensorSpec`/`SparseTensorSpec` emission) that would refine the formatter's `RaggedDim`/sparse branches in the future.
