### PR TITLE
Emit inferred `input_signature` in `convertToHybrid`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,14 @@ repos:
     hooks:
       - id: black
         args: ["--fast", "--extend-exclude", "/out"]
+        # `--extend-exclude` only applies during black's own directory walk
+        # (as CI's `black ... .` does). pre-commit passes staged filenames
+        # explicitly, which black formats regardless of `--extend-exclude`,
+        # so `out/` refactoring-output fixtures would get reformatted (and
+        # long emitted decorator lines rewrapped) only locally, diverging
+        # from the tool's single-line output. Filter at the pre-commit level
+        # so the hook never receives them.
+        exclude: '/out/'
   - repo: local
     hooks:
       - id: spotless-apply

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@ repos:
     rev: 26.3.1
     hooks:
       - id: black
-        args: ["--fast", "--extend-exclude", "/out"]
-        # `--extend-exclude` only applies during black's own directory walk
-        # (as CI's `black ... .` does). pre-commit passes staged filenames
-        # explicitly, which black formats regardless of `--extend-exclude`,
-        # so `out/` refactoring-output fixtures would get reformatted (and
-        # long emitted decorator lines rewrapped) only locally, diverging
-        # from the tool's single-line output. Filter at the pre-commit level
-        # so the hook never receives them.
+        args: ["--fast"]
+        # pre-commit passes staged filenames explicitly, and black applies its
+        # exclude patterns only during its own directory walk -- not to files
+        # passed explicitly. So black's `--extend-exclude` would not skip `out/`
+        # refactoring-output fixtures here (it does in CI's `black ... .`, which
+        # is a directory walk). Filter at the pre-commit level instead, so the
+        # hook never receives them and long emitted decorator lines (which the
+        # tool emits unwrapped) aren't rewrapped locally.
         exclude: '/out/'
   - repo: local
     hooks:

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1841,9 +1841,9 @@ public class Function {
 
 		String precedingText = doc.get(lineBeginOffset, functionDef.beginColumn - 1);
 
-		String prefix = getImportPrefix(doc);
+		ImportContext ctx = getImportContext(doc);
 
-		if (prefix == null) {
+		if (ctx == null) {
 			// need to add an import if it doesn't already exist.
 			File file = this.getContainingFile();
 
@@ -1858,12 +1858,14 @@ public class Function {
 				filesWithAddedImport.add(file);
 			}
 
-			prefix = ""; // no prefix needed.
+			// The auto-injected `from tensorflow import function` makes only `function` reachable; `TensorSpec` is not. Extending
+			// the auto-inject to cover the signature's required symbols is tracked separately.
+			ctx = new ImportContext("", false);
 		}
 
 		MultiTextEdit mte = new MultiTextEdit();
-		mte.addChild(new InsertEdit(offset, "@" + prefix + "function"));
-		this.addInputSignature(offset, prefix).ifPresent(mte::addChild);
+		mte.addChild(new InsertEdit(offset, "@" + ctx.prefix() + "function"));
+		this.addInputSignature(offset, ctx).ifPresent(mte::addChild);
 		mte.addChild(new InsertEdit(offset, "\n" + precedingText));
 		ret.add(mte);
 
@@ -1871,34 +1873,47 @@ public class Function {
 	}
 
 	/**
-	 * Returns the {@code input_signature=[tfPrefix + "TensorSpec(...)", ...]} keyword argument when the flag is on and the inference
-	 * produces a signature. Returns {@link Optional#empty} otherwise (flag off, no signature, or the empty-prefix case where
-	 * {@code TensorSpec} isn't reachable). The keyword text only; callers handle the surrounding syntax (parenthesization via
-	 * {@link #addInputSignature(int, String)}, or a leading {@code ", "} when injecting into an existing arg list).
+	 * The TensorFlow import shape observed in a Python source file, carrying both the prefix to use when referring to TensorFlow names and
+	 * whether {@code TensorSpec} is reachable in the file's namespace. The two empty-prefix shapes ({@code from tensorflow import *} and
+	 * {@code from tensorflow import function}) differ on the latter: the wildcard form pulls all public names into scope (including
+	 * {@code TensorSpec}), while the named-import form does not.
 	 *
-	 * @param tfPrefix The TensorFlow module prefix (e.g., {@code "tf."}, {@code "tensorflow."}, or {@code ""}).
+	 * @param prefix The TensorFlow module prefix (e.g., {@code "tf."}, {@code "tensorflow."}, or {@code ""}).
+	 * @param tensorSpecReachable True iff {@code TensorSpec} (and the dtype constants like {@code float32}) can be referenced from the file
+	 *        using the {@code prefix}, without an additional import.
+	 */
+	private record ImportContext(String prefix, boolean tensorSpecReachable) {
+	}
+
+	/**
+	 * Returns the {@code input_signature=[tfPrefix + "TensorSpec(...)", ...]} keyword argument when the flag is on and the inference
+	 * produces a signature. Returns {@link Optional#empty} otherwise (flag off, no signature, or {@code TensorSpec} not reachable in the
+	 * import context). The keyword text only; callers handle the surrounding syntax (parenthesization via
+	 * {@link #addInputSignature(int, ImportContext)}, or a leading {@code ", "} when injecting into an existing arg list).
+	 *
+	 * @param ctx The import context for the containing file.
 	 * @return The {@code input_signature=...} keyword argument, or empty.
 	 */
-	private Optional<String> computeInputSignatureKeyword(String tfPrefix) {
-		if (!this.getInferInputSignatures() || tfPrefix.isEmpty())
+	private Optional<String> computeInputSignatureKeyword(ImportContext ctx) {
+		if (!this.getInferInputSignatures() || !ctx.tensorSpecReachable())
 			return Optional.empty();
-		return this.inferInputSignature().map(sig -> "input_signature=" + sig.toTensorSpecList(tfPrefix));
+		return this.inferInputSignature().map(sig -> "input_signature=" + sig.toTensorSpecList(ctx.prefix()));
 	}
 
 	/**
 	 * Returns an {@code InsertEdit} placing the parenthesized {@code (input_signature=[tf.TensorSpec(...)])} argument list at the given
-	 * offset, or empty if {@link #computeInputSignatureKeyword(String)}'s gate fails. Used for the fresh-decorator and argless-existing-
-	 * decorator cases (the latter is a Phase 3 {@code RECONFIGURE} sub-case). For injecting into an existing non-empty argument list, use
-	 * {@link #computeInputSignatureKeyword(String)} directly with a leading {@code ", "}.
+	 * offset, or empty if {@link #computeInputSignatureKeyword(ImportContext)}'s gate fails. Used for the fresh-decorator and
+	 * argless-existing-decorator cases (the latter is a Phase 3 {@code RECONFIGURE} sub-case). For injecting into an existing non-empty
+	 * argument list, use {@link #computeInputSignatureKeyword(ImportContext)} directly with a leading {@code ", "}.
 	 *
 	 * @param offset The original-document offset where the edit should land. {@link #convertToHybrid()} passes the same offset it uses for
 	 *        the surrounding {@code @function} insertion (multiple {@code InsertEdit}s at the same offset are sequenced by their order of
 	 *        addition to the parent {@link MultiTextEdit}). The {@code RECONFIGURE} caller will pass an AST-derived offset.
-	 * @param tfPrefix The TensorFlow module prefix (e.g., {@code "tf."}, {@code "tensorflow."}).
+	 * @param ctx The import context for the containing file.
 	 * @return The {@code InsertEdit}, or empty if the gate fails.
 	 */
-	private Optional<TextEdit> addInputSignature(int offset, String tfPrefix) {
-		return this.computeInputSignatureKeyword(tfPrefix).map(kw -> new InsertEdit(offset, "(" + kw + ")"));
+	private Optional<TextEdit> addInputSignature(int offset, ImportContext ctx) {
+		return this.computeInputSignatureKeyword(ctx).map(kw -> new InsertEdit(offset, "(" + kw + ")"));
 	}
 
 	private static int getLineToInsertImport(IDocument doc) {
@@ -1913,23 +1928,24 @@ public class Function {
 		return lastFoundImportLine + 1;
 	}
 
-	private static String getImportPrefix(IDocument doc) {
+	private static ImportContext getImportContext(IDocument doc) {
 		PyImportsHandling handling = new PyImportsHandling(doc);
 
 		for (ImportHandle importHandle : handling)
 			for (ImportHandleInfo importHandleInfo : importHandle.getImportInfo())
 				for (String importStr : importHandleInfo.getImportedStr())
 					if (importStr.equals("tensorflow"))
-						return "tensorflow.";
+						return new ImportContext("tensorflow.", true);
 					else if (importStr.startsWith("tensorflow as"))
-						return importStr.substring("tensorflow as ".length(), importStr.length()) + ".";
+						return new ImportContext(importStr.substring("tensorflow as ".length(), importStr.length()) + ".", true);
 					else {
 						String fromImportStr = importHandleInfo.getFromImportStrWithoutUnwantedChars();
 						if (fromImportStr != null && fromImportStr.equals("tensorflow"))
 							switch (importStr) {
-							case "*": // wild card import.
-							case "function": // direct import.
-								return ""; // no prefix needed.
+							case "*": // wildcard: TensorSpec and dtype constants are reachable unqualified.
+								return new ImportContext("", true);
+							case "function": // direct named import of `function` only; TensorSpec is not in scope.
+								return new ImportContext("", false);
 							}
 					}
 

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1861,20 +1861,29 @@ public class Function {
 			prefix = ""; // no prefix needed.
 		}
 
-		// Emit `input_signature=[tf.TensorSpec(...)]` when the flag is set, the inference produced a signature, and the prefix is
-		// non-empty (so `TensorSpec` and the dtype constants are reachable). The empty-prefix case (from `from tensorflow import
-		// function`) skips emission: `TensorSpec` isn't imported in that form, and adding the import is non-trivial.
-		final String tfPrefix = prefix;
-		String decoratorSuffix = this.getInferInputSignatures() && !tfPrefix.isEmpty()
-				? this.inferInputSignature().map(sig -> "(input_signature=" + sig.toTensorSpecList(tfPrefix) + ")").orElse("")
-				: "";
-
+		String decoratorSuffix = this.computeInputSignatureKeyword(prefix).map(kw -> "(" + kw + ")").orElse("");
 		TextEdit edit = new InsertEdit(offset, "@" + prefix + "function" + decoratorSuffix + "\n" + precedingText);
 		MultiTextEdit mte = new MultiTextEdit();
 		mte.addChild(edit);
 		ret.add(mte);
 
 		return ret;
+	}
+
+	/**
+	 * Returns the {@code input_signature=[tfPrefix + "TensorSpec(...)", ...]} keyword argument to inject into the {@code @tf.function(...)}
+	 * decorator call when the flag is on and the inference produces a signature. Returns {@link Optional#empty} otherwise (flag off, no
+	 * signature, or the empty-prefix case where {@code TensorSpec} isn't reachable). Shared by {@link #convertToHybrid()} (which wraps the
+	 * keyword in parentheses to form the bare decorator's argument list) and the {@code RECONFIGURE} case (which injects the keyword into
+	 * an existing decorator's argument list).
+	 *
+	 * @param tfPrefix The TensorFlow module prefix (e.g., {@code "tf."}, {@code "tensorflow."}, or {@code ""}).
+	 * @return The {@code input_signature=...} keyword argument, or empty.
+	 */
+	private Optional<String> computeInputSignatureKeyword(String tfPrefix) {
+		if (!this.getInferInputSignatures() || tfPrefix.isEmpty())
+			return Optional.empty();
+		return this.inferInputSignature().map(sig -> "input_signature=" + sig.toTensorSpecList(tfPrefix));
 	}
 
 	private static int getLineToInsertImport(IDocument doc) {

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1035,15 +1035,6 @@ public class Function {
 		return this.inferInputSignatures;
 	}
 
-	/**
-	 * Sets whether the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator.
-	 *
-	 * @param inferInputSignatures True iff the inferred {@code input_signature} keyword should be emitted into the generated decorator.
-	 */
-	public void setInferInputSignatures(boolean inferInputSignatures) {
-		this.inferInputSignatures = inferInputSignatures;
-	}
-
 	public IDocument getContainingDocument() {
 		return this.getFunctionDefinition().containingDocument;
 	}

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -605,10 +605,7 @@ public class Function {
 	private boolean useSpeculativeAnalysis;
 
 	/**
-	 * True iff {@code convertToHybrid} should emit an {@code input_signature=...} keyword into the generated {@code @tf.function(...)}
-	 * decorator when {@link #inferInputSignature()} produces a signature. Defaults to {@code false} (existing behavior—bare
-	 * {@code @tf.function}). Wired by {@code HybridizeFunctionRefactoringProcessor}; user/eval-facing gating is tracked at
-	 * https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481.
+	 * True iff the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
 	 */
@@ -1029,10 +1026,9 @@ public class Function {
 	}
 
 	/**
-	 * True iff {@code convertToHybrid} should emit an {@code input_signature=...} keyword into the generated {@code @tf.function(...)}
-	 * decorator when {@link #inferInputSignature()} produces a signature.
+	 * Returns true iff the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator.
 	 *
-	 * @return True iff the source-write transformation should emit an inferred {@code input_signature=...} keyword.
+	 * @return True iff the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator.
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
 	 */
 	public boolean getInferInputSignatures() {
@@ -1040,12 +1036,9 @@ public class Function {
 	}
 
 	/**
-	 * Sets whether {@code convertToHybrid} should emit an {@code input_signature=...} keyword into the generated {@code @tf.function(...)}
-	 * decorator. Primarily used by {@code edu.cuny.hunter.hybridize.core.refactorings.HybridizeFunctionRefactoringProcessor} when wiring
-	 * the opt-in flag (https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481) and by tests exercising the source-write
-	 * path.
+	 * Sets whether the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator.
 	 *
-	 * @param inferInputSignatures True iff the inferred input signature should be emitted into the generated decorator.
+	 * @param inferInputSignatures True iff the inferred {@code input_signature} keyword should be emitted into the generated decorator.
 	 */
 	public void setInferInputSignatures(boolean inferInputSignatures) {
 		this.inferInputSignatures = inferInputSignatures;

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1861,21 +1861,20 @@ public class Function {
 			prefix = ""; // no prefix needed.
 		}
 
-		String decoratorSuffix = this.computeInputSignatureKeyword(prefix).map(kw -> "(" + kw + ")").orElse("");
-		TextEdit edit = new InsertEdit(offset, "@" + prefix + "function" + decoratorSuffix + "\n" + precedingText);
 		MultiTextEdit mte = new MultiTextEdit();
-		mte.addChild(edit);
+		mte.addChild(new InsertEdit(offset, "@" + prefix + "function"));
+		this.addInputSignature(offset, prefix).ifPresent(mte::addChild);
+		mte.addChild(new InsertEdit(offset, "\n" + precedingText));
 		ret.add(mte);
 
 		return ret;
 	}
 
 	/**
-	 * Returns the {@code input_signature=[tfPrefix + "TensorSpec(...)", ...]} keyword argument to inject into the {@code @tf.function(...)}
-	 * decorator call when the flag is on and the inference produces a signature. Returns {@link Optional#empty} otherwise (flag off, no
-	 * signature, or the empty-prefix case where {@code TensorSpec} isn't reachable). Shared by {@link #convertToHybrid()} (which wraps the
-	 * keyword in parentheses to form the bare decorator's argument list) and the {@code RECONFIGURE} case (which injects the keyword into
-	 * an existing decorator's argument list).
+	 * Returns the {@code input_signature=[tfPrefix + "TensorSpec(...)", ...]} keyword argument when the flag is on and the inference
+	 * produces a signature. Returns {@link Optional#empty} otherwise (flag off, no signature, or the empty-prefix case where
+	 * {@code TensorSpec} isn't reachable). The keyword text only; callers handle the surrounding syntax (parenthesization via
+	 * {@link #addInputSignature(int, String)}, or a leading {@code ", "} when injecting into an existing arg list).
 	 *
 	 * @param tfPrefix The TensorFlow module prefix (e.g., {@code "tf."}, {@code "tensorflow."}, or {@code ""}).
 	 * @return The {@code input_signature=...} keyword argument, or empty.
@@ -1884,6 +1883,22 @@ public class Function {
 		if (!this.getInferInputSignatures() || tfPrefix.isEmpty())
 			return Optional.empty();
 		return this.inferInputSignature().map(sig -> "input_signature=" + sig.toTensorSpecList(tfPrefix));
+	}
+
+	/**
+	 * Returns an {@code InsertEdit} placing the parenthesized {@code (input_signature=[tf.TensorSpec(...)])} argument list at the given
+	 * offset, or empty if {@link #computeInputSignatureKeyword(String)}'s gate fails. Used for the fresh-decorator and argless-existing-
+	 * decorator cases (the latter is a Phase 3 {@code RECONFIGURE} sub-case). For injecting into an existing non-empty argument list, use
+	 * {@link #computeInputSignatureKeyword(String)} directly with a leading {@code ", "}.
+	 *
+	 * @param offset The original-document offset where the edit should land. {@link #convertToHybrid()} passes the same offset it uses for
+	 *        the surrounding {@code @function} insertion (multiple {@code InsertEdit}s at the same offset are sequenced by their order of
+	 *        addition to the parent {@link MultiTextEdit}). The {@code RECONFIGURE} caller will pass an AST-derived offset.
+	 * @param tfPrefix The TensorFlow module prefix (e.g., {@code "tf."}, {@code "tensorflow."}).
+	 * @return The {@code InsertEdit}, or empty if the gate fails.
+	 */
+	private Optional<TextEdit> addInputSignature(int offset, String tfPrefix) {
+		return this.computeInputSignatureKeyword(tfPrefix).map(kw -> new InsertEdit(offset, "(" + kw + ")"));
 	}
 
 	private static int getLineToInsertImport(IDocument doc) {

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -605,6 +605,16 @@ public class Function {
 	private boolean useSpeculativeAnalysis;
 
 	/**
+	 * True iff {@code convertToHybrid} should emit an {@code input_signature=...} keyword into the generated {@code @tf.function(...)}
+	 * decorator when {@link #inferInputSignature()} produces a signature. Defaults to {@code false} (existing behavior—bare
+	 * {@code @tf.function}). Wired by {@code HybridizeFunctionRefactoringProcessor}; user/eval-facing gating is tracked at
+	 * https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	private boolean inferInputSignatures;
+
+	/**
 	 * The {@link FunctionDefinition} representing this {@link Function}.
 	 */
 	private FunctionDefinition functionDefinition;
@@ -666,10 +676,16 @@ public class Function {
 	private final List<Parameter> parameters;
 
 	public Function(FunctionDefinition fd, boolean ignoreBooleans, boolean alwaysFollowTypeHints, boolean useSpeculativeAnalysis) {
+		this(fd, ignoreBooleans, alwaysFollowTypeHints, useSpeculativeAnalysis, false);
+	}
+
+	public Function(FunctionDefinition fd, boolean ignoreBooleans, boolean alwaysFollowTypeHints, boolean useSpeculativeAnalysis,
+			boolean inferInputSignatures) {
 		this.functionDefinition = fd;
 		this.ignoreBooleans = ignoreBooleans;
 		this.alwaysFollowTypeHints = alwaysFollowTypeHints;
 		this.useSpeculativeAnalysis = useSpeculativeAnalysis;
+		this.inferInputSignatures = inferInputSignatures;
 
 		// Jython's `argumentsType` is the whole parameter-list node; its `.args` field is the positional/positional-or-keyword name array.
 		// `vararg`, `kwarg`, and `kwonlyargs` are sibling fields on the same node that we don't currently wrap.
@@ -1010,6 +1026,29 @@ public class Function {
 	 */
 	public boolean getUseSpeculativeAnalysis() {
 		return useSpeculativeAnalysis;
+	}
+
+	/**
+	 * True iff {@code convertToHybrid} should emit an {@code input_signature=...} keyword into the generated {@code @tf.function(...)}
+	 * decorator when {@link #inferInputSignature()} produces a signature.
+	 *
+	 * @return True iff the source-write transformation should emit an inferred {@code input_signature=...} keyword.
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	public boolean getInferInputSignatures() {
+		return this.inferInputSignatures;
+	}
+
+	/**
+	 * Sets whether {@code convertToHybrid} should emit an {@code input_signature=...} keyword into the generated {@code @tf.function(...)}
+	 * decorator. Primarily used by {@code edu.cuny.hunter.hybridize.core.refactorings.HybridizeFunctionRefactoringProcessor} when wiring
+	 * the opt-in flag (https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481) and by tests exercising the source-write
+	 * path.
+	 *
+	 * @param inferInputSignatures True iff the inferred input signature should be emitted into the generated decorator.
+	 */
+	public void setInferInputSignatures(boolean inferInputSignatures) {
+		this.inferInputSignatures = inferInputSignatures;
 	}
 
 	public IDocument getContainingDocument() {
@@ -1829,7 +1868,15 @@ public class Function {
 			prefix = ""; // no prefix needed.
 		}
 
-		TextEdit edit = new InsertEdit(offset, "@" + prefix + "function\n" + precedingText);
+		// Emit `input_signature=[tf.TensorSpec(...)]` when the flag is set, the inference produced a signature, and the prefix is
+		// non-empty (so `TensorSpec` and the dtype constants are reachable). The empty-prefix case (from `from tensorflow import
+		// function`) skips emission: `TensorSpec` isn't imported in that form, and adding the import is non-trivial.
+		final String tfPrefix = prefix;
+		String decoratorSuffix = this.getInferInputSignatures() && !tfPrefix.isEmpty()
+				? this.inferInputSignature().map(sig -> "(input_signature=" + sig.toTensorSpecList(tfPrefix) + ")").orElse("")
+				: "";
+
+		TextEdit edit = new InsertEdit(offset, "@" + prefix + "function" + decoratorSuffix + "\n" + precedingText);
 		MultiTextEdit mte = new MultiTextEdit();
 		mte.addChild(edit);
 		ret.add(mte);

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
@@ -119,6 +119,16 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 	 */
 	private boolean useSpeculativeAnalysis;
 
+	/**
+	 * True iff {@code Function.convertToHybrid} should emit an {@code input_signature=...} keyword into the generated
+	 * {@code @tf.function(...)} decorator when {@link Function#inferInputSignature()} produces a signature. Default {@code false}; the
+	 * user-facing/eval-facing gating that flips this flag is tracked at
+	 * https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	private boolean inferInputSignatures;
+
 	public HybridizeFunctionRefactoringProcessor() {
 		// Force the use of typeshed. It's an experimental feature of PyDev.
 		InterpreterGeneralPreferences.FORCE_USE_TYPESHED = TRUE;
@@ -166,8 +176,16 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 			boolean alwaysCheckRecusion, boolean ignoreBooleansInLiteralCheck, boolean useTestEntryPoints, boolean alwaysFollowTypeHints,
 			boolean useSpeculativeAnalysis) {
 		this(alwaysCheckPythonSideEffects, processFunctionsInParallel, alwaysCheckRecusion, ignoreBooleansInLiteralCheck,
+				useTestEntryPoints, alwaysFollowTypeHints, useSpeculativeAnalysis, false);
+	}
+
+	public HybridizeFunctionRefactoringProcessor(boolean alwaysCheckPythonSideEffects, boolean processFunctionsInParallel,
+			boolean alwaysCheckRecusion, boolean ignoreBooleansInLiteralCheck, boolean useTestEntryPoints, boolean alwaysFollowTypeHints,
+			boolean useSpeculativeAnalysis, boolean inferInputSignatures) {
+		this(alwaysCheckPythonSideEffects, processFunctionsInParallel, alwaysCheckRecusion, ignoreBooleansInLiteralCheck,
 				useTestEntryPoints, alwaysFollowTypeHints);
 		this.useSpeculativeAnalysis = useSpeculativeAnalysis;
+		this.inferInputSignatures = inferInputSignatures;
 	}
 
 	public HybridizeFunctionRefactoringProcessor(Set<FunctionDefinition> functionDefinitionSet)
@@ -180,7 +198,7 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 
 			for (FunctionDefinition fd : functionDefinitionSet) {
 				Function function = new Function(fd, this.ignoreBooleansInLiteralCheck, this.alwaysFollowTypeHints,
-						this.useSpeculativeAnalysis);
+						this.useSpeculativeAnalysis, this.inferInputSignatures);
 
 				// Add the Function to the Function set.
 				functionSet.add(function);
@@ -224,6 +242,13 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 	public HybridizeFunctionRefactoringProcessor(Set<FunctionDefinition> functionDefinitionSet, boolean alwaysCheckPythonSideEffects,
 			boolean processFunctionsInParallel, boolean alwaysCheckRecursion, boolean useTestEntryPoints, boolean alwaysFollowTypeHints,
 			boolean useSpeculativeAnalysis) throws TooManyMatchesException /* FIXME: This exception sounds too low-level. */ {
+		this(functionDefinitionSet, alwaysCheckPythonSideEffects, processFunctionsInParallel, alwaysCheckRecursion, useTestEntryPoints,
+				alwaysFollowTypeHints, useSpeculativeAnalysis, false);
+	}
+
+	public HybridizeFunctionRefactoringProcessor(Set<FunctionDefinition> functionDefinitionSet, boolean alwaysCheckPythonSideEffects,
+			boolean processFunctionsInParallel, boolean alwaysCheckRecursion, boolean useTestEntryPoints, boolean alwaysFollowTypeHints,
+			boolean useSpeculativeAnalysis, boolean inferInputSignatures) throws TooManyMatchesException /* FIXME: low-level. */ {
 		this();
 
 		this.alwaysCheckPythonSideEffects = alwaysCheckPythonSideEffects;
@@ -232,6 +257,7 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 		this.useTestEntryPoints = useTestEntryPoints;
 		this.alwaysFollowTypeHints = alwaysFollowTypeHints;
 		this.useSpeculativeAnalysis = useSpeculativeAnalysis;
+		this.inferInputSignatures = inferInputSignatures;
 
 		// Convert the FunctionDefs to Functions.
 		if (functions != null) {
@@ -239,7 +265,7 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 
 			for (FunctionDefinition fd : functionDefinitionSet) {
 				Function function = new Function(fd, this.ignoreBooleansInLiteralCheck, this.alwaysFollowTypeHints,
-						this.useSpeculativeAnalysis);
+						this.useSpeculativeAnalysis, this.inferInputSignatures);
 
 				// Add the Function to the Function set.
 				functionSet.add(function);

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
@@ -616,18 +616,6 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 		return this.inferInputSignatures;
 	}
 
-	/**
-	 * Sets whether the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator. Propagates to
-	 * every already-constructed {@link Function} owned by this processor so subsequent {@code transform()} calls observe the value.
-	 *
-	 * @param inferInputSignatures True iff the inferred {@code input_signature} keyword should be emitted into the generated decorator.
-	 */
-	public void setInferInputSignatures(boolean inferInputSignatures) {
-		this.inferInputSignatures = inferInputSignatures;
-		for (Function function : this.functions)
-			function.setInferInputSignatures(inferInputSignatures);
-	}
-
 	public Set<Function> getOptimizableFunctions() {
 		return this.getFunctions().parallelStream().filter(f -> !f.getStatus().hasError()).collect(Collectors.toSet());
 	}

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
@@ -609,6 +609,31 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 		return this.functions;
 	}
 
+	/**
+	 * True iff {@code Function.convertToHybrid} should emit an {@code input_signature=...} keyword into the generated
+	 * {@code @tf.function(...)} decorator.
+	 *
+	 * @return True iff the source-write transformation should emit an inferred {@code input_signature=...} keyword.
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	public boolean getInferInputSignatures() {
+		return this.inferInputSignatures;
+	}
+
+	/**
+	 * Sets whether the refactoring should emit an inferred {@code input_signature=...} keyword. Propagates to every already-constructed
+	 * {@link Function} owned by this processor so subsequent calls to {@code transform()} observe the new value. The user-facing (UI
+	 * checkbox + system property) and eval-facing wiring at https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481 calls
+	 * this method.
+	 *
+	 * @param inferInputSignatures True iff the inferred input signature should be emitted into the generated decorator.
+	 */
+	public void setInferInputSignatures(boolean inferInputSignatures) {
+		this.inferInputSignatures = inferInputSignatures;
+		for (Function function : this.functions)
+			function.setInferInputSignatures(inferInputSignatures);
+	}
+
 	public Set<Function> getOptimizableFunctions() {
 		return this.getFunctions().parallelStream().filter(f -> !f.getStatus().hasError()).collect(Collectors.toSet());
 	}

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
@@ -120,10 +120,7 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 	private boolean useSpeculativeAnalysis;
 
 	/**
-	 * True iff {@code Function.convertToHybrid} should emit an {@code input_signature=...} keyword into the generated
-	 * {@code @tf.function(...)} decorator when {@link Function#inferInputSignature()} produces a signature. Default {@code false}; the
-	 * user-facing/eval-facing gating that flips this flag is tracked at
-	 * https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481.
+	 * True iff the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
 	 */
@@ -610,10 +607,9 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 	}
 
 	/**
-	 * True iff {@code Function.convertToHybrid} should emit an {@code input_signature=...} keyword into the generated
-	 * {@code @tf.function(...)} decorator.
+	 * Returns true iff the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator.
 	 *
-	 * @return True iff the source-write transformation should emit an inferred {@code input_signature=...} keyword.
+	 * @return True iff the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator.
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
 	 */
 	public boolean getInferInputSignatures() {
@@ -621,12 +617,10 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 	}
 
 	/**
-	 * Sets whether the refactoring should emit an inferred {@code input_signature=...} keyword. Propagates to every already-constructed
-	 * {@link Function} owned by this processor so subsequent calls to {@code transform()} observe the new value. The user-facing (UI
-	 * checkbox + system property) and eval-facing wiring at https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481 calls
-	 * this method.
+	 * Sets whether the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator. Propagates to
+	 * every already-constructed {@link Function} owned by this processor so subsequent {@code transform()} calls observe the value.
 	 *
-	 * @param inferInputSignatures True iff the inferred input signature should be emitted into the generated decorator.
+	 * @param inferInputSignatures True iff the inferred {@code input_signature} keyword should be emitted into the generated decorator.
 	 */
 	public void setInferInputSignatures(boolean inferInputSignatures) {
 		this.inferInputSignatures = inferInputSignatures;

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmission/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmission/in/A.py
@@ -1,0 +1,12 @@
+# Eager function with a single tensor parameter. Analysis selects `CONVERT_TO_HYBRID` and `inferInputSignature` produces
+# `[tf.TensorSpec(shape=(), dtype=tf.float32)]`. The test flips `inferInputSignatures` on and asserts the source-write emits
+# the `input_signature=...` argument into the generated `@tf.function(...)` decorator.
+import tensorflow as tf
+
+
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmission/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmission/in/A.py
@@ -1,5 +1,5 @@
 # Eager function with a single tensor parameter. Analysis selects `CONVERT_TO_HYBRID` and `inferInputSignature` produces
-# `[tf.TensorSpec(shape=(), dtype=tf.float32)]`. The test flips `inferInputSignatures` on and asserts the source-write emits
+# `[tf.TensorSpec(shape=(), dtype=tf.float32)]`. The test harness enables `inferInputSignatures` and asserts the source-write emits
 # the `input_signature=...` argument into the generated `@tf.function(...)` decorator.
 import tensorflow as tf
 

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmission/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmission/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmission/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmission/out/A.py
@@ -1,5 +1,5 @@
 # Eager function with a single tensor parameter. Analysis selects `CONVERT_TO_HYBRID` and `inferInputSignature` produces
-# `[tf.TensorSpec(shape=(), dtype=tf.float32)]`. The test flips `inferInputSignatures` on and asserts the source-write emits
+# `[tf.TensorSpec(shape=(), dtype=tf.float32)]`. The test harness enables `inferInputSignatures` and asserts the source-write emits
 # the `input_signature=...` argument into the generated `@tf.function(...)` decorator.
 import tensorflow as tf
 

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmission/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmission/out/A.py
@@ -1,0 +1,13 @@
+# Eager function with a single tensor parameter. Analysis selects `CONVERT_TO_HYBRID` and `inferInputSignature` produces
+# `[tf.TensorSpec(shape=(), dtype=tf.float32)]`. The test flips `inferInputSignatures` on and asserts the source-write emits
+# the `input_signature=...` argument into the generated `@tf.function(...)` decorator.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionFullyQualifiedImport/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionFullyQualifiedImport/in/A.py
@@ -1,0 +1,12 @@
+# Fully-qualified-import variant of `testInferInputSignatureEmission`. Bare `import tensorflow` (no `as` alias) means the
+# source-write must qualify every emitted name with the `tensorflow.` prefix, producing
+# `@tensorflow.function(input_signature=[tensorflow.TensorSpec(shape=(), dtype=tensorflow.float32)])`.
+import tensorflow
+
+
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tensorflow.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionFullyQualifiedImport/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionFullyQualifiedImport/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionFullyQualifiedImport/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionFullyQualifiedImport/out/A.py
@@ -1,0 +1,13 @@
+# Fully-qualified-import variant of `testInferInputSignatureEmission`. Bare `import tensorflow` (no `as` alias) means the
+# source-write must qualify every emitted name with the `tensorflow.` prefix, producing
+# `@tensorflow.function(input_signature=[tensorflow.TensorSpec(shape=(), dtype=tensorflow.float32)])`.
+import tensorflow
+
+
+@tensorflow.function(input_signature=[tensorflow.TensorSpec(shape=(), dtype=tensorflow.float32)])
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tensorflow.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionNamedImport/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionNamedImport/in/A.py
@@ -1,0 +1,13 @@
+# Named-import variant of `testInferInputSignatureEmission`. `from tensorflow import function, constant` makes `function`
+# reachable but NOT `TensorSpec`. Even though analysis classifies `x` as a tensor and `inferInputSignature` would produce
+# `[TensorSpec(shape=(), dtype=float32)]`, the source-write must skip emission because `TensorSpec` is not in scope under
+# this import shape; the generated decorator is a bare `@function`.
+from tensorflow import function, constant
+
+
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionNamedImport/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionNamedImport/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionNamedImport/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionNamedImport/out/A.py
@@ -1,0 +1,14 @@
+# Named-import variant of `testInferInputSignatureEmission`. `from tensorflow import function, constant` makes `function`
+# reachable but NOT `TensorSpec`. Even though analysis classifies `x` as a tensor and `inferInputSignature` would produce
+# `[TensorSpec(shape=(), dtype=float32)]`, the source-write must skip emission because `TensorSpec` is not in scope under
+# this import shape; the generated decorator is a bare `@function`.
+from tensorflow import function, constant
+
+
+@function
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionWildcardImport/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionWildcardImport/in/A.py
@@ -1,0 +1,13 @@
+# Wildcard-import variant of `testInferInputSignatureEmission`. `from tensorflow import *` makes both `function` and
+# `TensorSpec` (plus the dtype constants) reachable unqualified, so the source-write should emit an unqualified
+# `@function(input_signature=[TensorSpec(shape=(), dtype=float32)])` rather than skipping emission because the prefix is
+# empty.
+from tensorflow import *
+
+
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionWildcardImport/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionWildcardImport/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionWildcardImport/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionWildcardImport/out/A.py
@@ -1,0 +1,14 @@
+# Wildcard-import variant of `testInferInputSignatureEmission`. `from tensorflow import *` makes both `function` and
+# `TensorSpec` (plus the dtype constants) reachable unqualified, so the source-write should emit an unqualified
+# `@function(input_signature=[TensorSpec(shape=(), dtype=float32)])` rather than skipping emission because the prefix is
+# empty.
+from tensorflow import *
+
+
+@function(input_signature=[TensorSpec(shape=(), dtype=float32)])
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringProcessorTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringProcessorTest.java
@@ -1,0 +1,56 @@
+package edu.cuny.hunter.hybridize.tests;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import edu.cuny.hunter.hybridize.core.refactorings.HybridizeFunctionRefactoringProcessor;
+
+/**
+ * Tests for the {@code inferInputSignatures} flag API on {@link HybridizeFunctionRefactoringProcessor}: the 8-arg no-{@code Set}
+ * constructor, the {@link HybridizeFunctionRefactoringProcessor#getInferInputSignatures()} accessor, and the propagating
+ * {@link HybridizeFunctionRefactoringProcessor#setInferInputSignatures(boolean)} mutator (the API surface that issue 481's UI checkbox /
+ * eval wiring will call).
+ *
+ * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481">Issue 481</a>
+ * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+ */
+@SuppressWarnings("static-method")
+public class HybridizeFunctionRefactoringProcessorTest {
+
+	/**
+	 * The 8-arg no-{@code Set} constructor records the {@code inferInputSignatures} value, and the accessor returns it.
+	 */
+	@Test
+	public void testConstructorSetsInferInputSignatures() {
+		HybridizeFunctionRefactoringProcessor processor = new HybridizeFunctionRefactoringProcessor(false, false, false, true, false, false,
+				false, true);
+		assertTrue(processor.getInferInputSignatures());
+	}
+
+	/**
+	 * Default for the 7-arg overload is {@code inferInputSignatures = false}.
+	 */
+	@Test
+	public void testSevenArgOverloadDefaultsToFalse() {
+		HybridizeFunctionRefactoringProcessor processor = new HybridizeFunctionRefactoringProcessor(false, false, false, true, false, false,
+				false);
+		assertFalse(processor.getInferInputSignatures());
+	}
+
+	/**
+	 * Setter flips the value and the accessor reflects it. The propagation loop runs over an empty function set without throwing—exercises
+	 * the loop's no-iteration branch.
+	 */
+	@Test
+	public void testSetterFlipsValue() {
+		HybridizeFunctionRefactoringProcessor processor = new HybridizeFunctionRefactoringProcessor(false, false, false, true, false, false,
+				false);
+		assertFalse(processor.getInferInputSignatures());
+		processor.setInferInputSignatures(true);
+		assertTrue(processor.getInferInputSignatures());
+		processor.setInferInputSignatures(false);
+		assertFalse(processor.getInferInputSignatures());
+	}
+}

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringProcessorTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringProcessorTest.java
@@ -9,9 +9,8 @@ import edu.cuny.hunter.hybridize.core.refactorings.HybridizeFunctionRefactoringP
 
 /**
  * Tests for the {@code inferInputSignatures} flag API on {@link HybridizeFunctionRefactoringProcessor}: the 8-arg no-{@code Set}
- * constructor, the {@link HybridizeFunctionRefactoringProcessor#getInferInputSignatures()} accessor, and the propagating
- * {@link HybridizeFunctionRefactoringProcessor#setInferInputSignatures(boolean)} mutator (the API surface that issue 481's UI checkbox /
- * eval wiring will call).
+ * constructor and the {@link HybridizeFunctionRefactoringProcessor#getInferInputSignatures()} accessor (the API surface that issue 481's UI
+ * checkbox / eval wiring will call).
  *
  * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481">Issue 481</a>
  * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
@@ -36,21 +35,6 @@ public class HybridizeFunctionRefactoringProcessorTest {
 	public void testSevenArgOverloadDefaultsToFalse() {
 		HybridizeFunctionRefactoringProcessor processor = new HybridizeFunctionRefactoringProcessor(false, false, false, true, false, false,
 				false);
-		assertFalse(processor.getInferInputSignatures());
-	}
-
-	/**
-	 * Setter flips the value and the accessor reflects it. The propagation loop runs over an empty function set without throwing—exercises
-	 * the loop's no-iteration branch.
-	 */
-	@Test
-	public void testSetterFlipsValue() {
-		HybridizeFunctionRefactoringProcessor processor = new HybridizeFunctionRefactoringProcessor(false, false, false, true, false, false,
-				false);
-		assertFalse(processor.getInferInputSignatures());
-		processor.setInferInputSignatures(true);
-		assertTrue(processor.getInferInputSignatures());
-		processor.setInferInputSignatures(false);
 		assertFalse(processor.getInferInputSignatures());
 	}
 }

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1287,6 +1287,36 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Fully-qualified-import variant of {@link #testInferInputSignatureEmission()}. With bare {@code import tensorflow} (no {@code as}
+	 * alias), the source-write must qualify every emitted name with the {@code tensorflow.} prefix, producing
+	 * {@code @tensorflow.function(input_signature=[tensorflow.TensorSpec(shape=(), dtype=tensorflow.float32)])}. Exercises the
+	 * {@code import tensorflow} branch of the import-context detection and the non-empty-prefix path of
+	 * {@link edu.cuny.hunter.hybridize.core.analysis.InputSignature#toTensorSpecList(String)}. The emitted decorator line exceeds black's
+	 * 88-column limit, so the expected {@code out/A.py} is intentionally a single unwrapped line matching the tool's output; the pre-commit
+	 * black hook is configured to skip {@code out/} fixtures.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/565">PR 565</a>
+	 */
+	@Test
+	public void testInferInputSignatureEmissionFullyQualifiedImport() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertFalse("Fixture function `f` should be eager pre-refactoring.", f.isHybrid());
+		assertTrue("Fixture function `f` should select `CONVERT_TO_HYBRID` after analysis.",
+				f.getTransformations().contains(Transformation.CONVERT_TO_HYBRID));
+		assertTrue("Test-class `INFER_INPUT_SIGNATURES` constant should propagate to the analyzed function's flag.",
+				f.getInferInputSignatures());
+
+		IDocument doc = f.getContainingDocument();
+		for (TextEdit edit : f.transform())
+			edit.apply(doc);
+
+		String expected = this.getFileContents(this.getOutputTestFileName("A"));
+		assertEqualLines(expected, doc.get());
+	}
+
+	/**
 	 * This simply tests whether we have the correct qualified name.
 	 */
 	@Test

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1266,8 +1266,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	/**
 	 * Test that {@code convertToHybrid} emits an inferred {@code input_signature=[tf.TensorSpec(...)]} keyword into the generated
 	 * {@code @tf.function(...)} decorator. Phase 2 of #563: the formatter from #564 plus the wired-through flag on {@link Function} and
-	 * {@code HybridizeFunctionRefactoringProcessor}. The user-facing/eval-facing gating that flips the flag in production wiring is tracked
-	 * at #481.
+	 * {@code HybridizeFunctionRefactoringProcessor}. The harness enables the flag via the {@code INFER_INPUT_SIGNATURES} constant; the
+	 * user-facing/eval-facing gating in production wiring is tracked at #481.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
 	 */

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1259,6 +1259,34 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Named-import variant of {@link #testInferInputSignatureEmission()}. With {@code from tensorflow import function, constant},
+	 * {@code function} is reachable but {@code TensorSpec} is not. Even though analysis classifies {@code x} as a tensor and
+	 * {@code inferInputSignature} would produce a signature, the source-write must skip the {@code input_signature=...} argument because
+	 * {@code TensorSpec} is not in scope under this import shape, emitting a bare {@code @function}. Exercises the
+	 * {@code tensorSpecReachable == false} gate that distinguishes the named-import shape from the wildcard shape.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/565">PR 565</a>
+	 */
+	@Test
+	public void testInferInputSignatureEmissionNamedImport() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertFalse("Fixture function `f` should be eager pre-refactoring.", f.isHybrid());
+		assertTrue("Fixture function `f` should select `CONVERT_TO_HYBRID` after analysis.",
+				f.getTransformations().contains(Transformation.CONVERT_TO_HYBRID));
+		assertTrue("Test-class `INFER_INPUT_SIGNATURES` constant should propagate to the analyzed function's flag.",
+				f.getInferInputSignatures());
+
+		IDocument doc = f.getContainingDocument();
+		for (TextEdit edit : f.transform())
+			edit.apply(doc);
+
+		String expected = this.getFileContents(this.getOutputTestFileName("A"));
+		assertEqualLines(expected, doc.get());
+	}
+
+	/**
 	 * This simply tests whether we have the correct qualified name.
 	 */
 	@Test

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1218,11 +1218,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 		f.setInferInputSignatures(true);
 
-		// Apply the `TextEdit`s directly to the function's in-memory document. The shared `compareOutputTestFile` path
-		// (which runs `refactoring.createChange(...)` + `performChange(...)` and `assertEqualLines` against `out/A.py`)
-		// would do the same comparison via the existing infrastructure, but it currently throws
-		// `TextFileChange has not been initialialized`—tracked at #359. When that lands, this test can collapse to
-		// setting the existing flag instead of applying edits inline.
+		// Apply the `TextEdit`s directly to the function's in-memory document. The shared `compareOutputTestFile` path would do the
+		// same comparison via the existing infrastructure, but the test's `ResourceStub`-backed `IFile` can't be resolved to a URI by
+		// `TextFileBufferManager`. Tracked at #359. When that lands, this test can collapse to setting `compareOutputTestFile` and
+		// an `inferInputSignatures` test-class field instead of applying edits inline.
 		IDocument doc = f.getContainingDocument();
 		for (TextEdit edit : f.transform())
 			edit.apply(doc);

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1218,6 +1218,11 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 		f.setInferInputSignatures(true);
 
+		// Apply the `TextEdit`s directly to the function's in-memory document. The shared `compareOutputTestFile` path
+		// (which runs `refactoring.createChange(...)` + `performChange(...)` and `assertEqualLines` against `out/A.py`)
+		// would do the same comparison via the existing infrastructure, but it currently throws
+		// `TextFileChange has not been initialialized`—tracked at #359. When that lands, this test can collapse to
+		// setting the existing flag instead of applying edits inline.
 		IDocument doc = f.getContainingDocument();
 		for (TextEdit edit : f.transform())
 			edit.apply(doc);

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1218,10 +1218,12 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 		f.setInferInputSignatures(true);
 
-		List<TextEdit> edits = f.transform();
-		String emitted = edits.stream().map(TextEdit::toString).reduce("", (a, b) -> a + b);
-		assertTrue("Expected `@tf.function(input_signature=[tf.TensorSpec(...)])` emission; got: " + emitted,
-				emitted.contains("@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])"));
+		IDocument doc = f.getContainingDocument();
+		for (TextEdit edit : f.transform())
+			edit.apply(doc);
+
+		String expected = this.getFileContents(this.getOutputTestFileName("A"));
+		assertEqualLines(expected, doc.get());
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1273,24 +1273,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testInferInputSignatureEmission() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertEquals(1, functions.size());
-		Function f = functions.iterator().next();
-		assertFalse("Fixture function `f` should be eager pre-refactoring.", f.isHybrid());
-		assertTrue("Fixture function `f` should select `CONVERT_TO_HYBRID` after analysis.",
-				f.getTransformations().contains(Transformation.CONVERT_TO_HYBRID));
-		assertTrue("Test-class `INFER_INPUT_SIGNATURES` constant should propagate to the analyzed function's flag.",
-				f.getInferInputSignatures());
-
-		// Apply the `TextEdit`s directly to the function's in-memory document. The shared `compareOutputTestFile` path would do the
-		// same comparison via the existing infrastructure, but the test's `ResourceStub`-backed `IFile` can't be resolved to a URI by
-		// `TextFileBufferManager`. Tracked at #359. When that lands, this test can collapse to setting `compareOutputTestFile`.
-		IDocument doc = f.getContainingDocument();
-		for (TextEdit edit : f.transform())
-			edit.apply(doc);
-
-		String expected = this.getFileContents(this.getOutputTestFileName("A"));
-		assertEqualLines(expected, doc.get());
+		helperAssertInputSignatureEmission();
 	}
 
 	/**
@@ -1303,21 +1286,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testInferInputSignatureEmissionWildcardImport() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertEquals(1, functions.size());
-		Function f = functions.iterator().next();
-		assertFalse("Fixture function `f` should be eager pre-refactoring.", f.isHybrid());
-		assertTrue("Fixture function `f` should select `CONVERT_TO_HYBRID` after analysis.",
-				f.getTransformations().contains(Transformation.CONVERT_TO_HYBRID));
-		assertTrue("Test-class `INFER_INPUT_SIGNATURES` constant should propagate to the analyzed function's flag.",
-				f.getInferInputSignatures());
-
-		IDocument doc = f.getContainingDocument();
-		for (TextEdit edit : f.transform())
-			edit.apply(doc);
-
-		String expected = this.getFileContents(this.getOutputTestFileName("A"));
-		assertEqualLines(expected, doc.get());
+		helperAssertInputSignatureEmission();
 	}
 
 	/**
@@ -1331,21 +1300,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testInferInputSignatureEmissionNamedImport() throws Exception {
-		Set<Function> functions = this.getFunctions();
-		assertEquals(1, functions.size());
-		Function f = functions.iterator().next();
-		assertFalse("Fixture function `f` should be eager pre-refactoring.", f.isHybrid());
-		assertTrue("Fixture function `f` should select `CONVERT_TO_HYBRID` after analysis.",
-				f.getTransformations().contains(Transformation.CONVERT_TO_HYBRID));
-		assertTrue("Test-class `INFER_INPUT_SIGNATURES` constant should propagate to the analyzed function's flag.",
-				f.getInferInputSignatures());
-
-		IDocument doc = f.getContainingDocument();
-		for (TextEdit edit : f.transform())
-			edit.apply(doc);
-
-		String expected = this.getFileContents(this.getOutputTestFileName("A"));
-		assertEqualLines(expected, doc.get());
+		helperAssertInputSignatureEmission();
 	}
 
 	/**
@@ -1361,6 +1316,15 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testInferInputSignatureEmissionFullyQualifiedImport() throws Exception {
+		helperAssertInputSignatureEmission();
+	}
+
+	/**
+	 * Runs the refactoring on the current test's fixture and asserts the produced source matches the expected {@code out/A.py}. The single
+	 * fixture function must be eager pre-refactoring, select {@link Transformation#CONVERT_TO_HYBRID}, and carry the harness-enabled
+	 * {@code inferInputSignatures} flag. Shared by the input-signature emission tests, which differ only in their import-shape fixture.
+	 */
+	private void helperAssertInputSignatureEmission() throws Exception {
 		Set<Function> functions = this.getFunctions();
 		assertEquals(1, functions.size());
 		Function f = functions.iterator().next();
@@ -1370,7 +1334,11 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertTrue("Test-class `INFER_INPUT_SIGNATURES` constant should propagate to the analyzed function's flag.",
 				f.getInferInputSignatures());
 
+		// Apply the `TextEdit`s directly to the function's in-memory document. The shared `compareOutputTestFile` path would do the
+		// same comparison via the existing infrastructure, but the test's `ResourceStub`-backed `IFile` can't be resolved to a URI by
+		// `TextFileBufferManager`. Tracked at #359. When that lands, these tests can collapse to setting `compareOutputTestFile`.
 		IDocument doc = f.getContainingDocument();
+
 		for (TextEdit edit : f.transform())
 			edit.apply(doc);
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -162,6 +162,14 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	private static final ILog LOG = getLog(HybridizeFunctionRefactoringTest.class);
 
 	/**
+	 * The {@link HybridizeFunctionRefactoringProcessor} most recently constructed by {@link #getFunctions(String)}. Test methods that need
+	 * to invoke the processor's API (e.g., to exercise the propagating
+	 * {@link HybridizeFunctionRefactoringProcessor#setInferInputSignatures(boolean)} setter through the analyzed function set) read this
+	 * after calling {@code getFunctions}.
+	 */
+	private HybridizeFunctionRefactoringProcessor lastProcessor;
+
+	/**
 	 * The {@link PythonNature} to be used for the tests.
 	 */
 	private static PythonNature nature = new PythonNature() {
@@ -691,6 +699,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		HybridizeFunctionRefactoringProcessor processor = new HybridizeFunctionRefactoringProcessor(inputFunctionDefinitions,
 				ALWAYS_CHECK_PYTHON_SIDE_EFFECTS, PROCESS_FUNCTIONS_IN_PARALLEL, ALWAYS_CHECK_RECURSION, USE_TEST_ENTRYPOINTS,
 				ALWAYS_FOLLOW_TYPE_HINTS, USE_SPECULATIVE_ANALYSIS);
+		this.lastProcessor = processor;
 
 		ProcessorBasedRefactoring refactoring = new ProcessorBasedRefactoring(processor);
 
@@ -1216,12 +1225,43 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertTrue("Fixture function `f` should select `CONVERT_TO_HYBRID` after analysis.",
 				f.getTransformations().contains(Transformation.CONVERT_TO_HYBRID));
 
-		f.setInferInputSignatures(true);
+		// Route through the processor's propagating setter rather than the per-`Function` setter so the propagation loop body in
+		// `HybridizeFunctionRefactoringProcessor.setInferInputSignatures` is exercised.
+		this.lastProcessor.setInferInputSignatures(true);
+		assertTrue("Processor's propagating setter should flip the analyzed function's flag.", f.getInferInputSignatures());
 
 		// Apply the `TextEdit`s directly to the function's in-memory document. The shared `compareOutputTestFile` path would do the
 		// same comparison via the existing infrastructure, but the test's `ResourceStub`-backed `IFile` can't be resolved to a URI by
 		// `TextFileBufferManager`. Tracked at #359. When that lands, this test can collapse to setting `compareOutputTestFile` and
 		// an `inferInputSignatures` test-class field instead of applying edits inline.
+		IDocument doc = f.getContainingDocument();
+		for (TextEdit edit : f.transform())
+			edit.apply(doc);
+
+		String expected = this.getFileContents(this.getOutputTestFileName("A"));
+		assertEqualLines(expected, doc.get());
+	}
+
+	/**
+	 * Wildcard-import variant of {@link #testInferInputSignatureEmission()}. With {@code from tensorflow import *}, both {@code function}
+	 * and {@code TensorSpec} (plus the dtype constants) are reachable unqualified. The source-write should distinguish this empty-prefix
+	 * shape from the {@code from tensorflow import function} shape and emit an unqualified
+	 * {@code @function(input_signature=[TensorSpec(shape=(), dtype=float32)])} rather than skipping emission.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/565">PR 565</a>
+	 */
+	@Test
+	public void testInferInputSignatureEmissionWildcardImport() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertFalse("Fixture function `f` should be eager pre-refactoring.", f.isHybrid());
+		assertTrue("Fixture function `f` should select `CONVERT_TO_HYBRID` after analysis.",
+				f.getTransformations().contains(Transformation.CONVERT_TO_HYBRID));
+
+		this.lastProcessor.setInferInputSignatures(true);
+		assertTrue("Processor's propagating setter should flip the analyzed function's flag.", f.getInferInputSignatures());
+
 		IDocument doc = f.getContainingDocument();
 		for (TextEdit edit : f.transform())
 			edit.apply(doc);

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -162,14 +162,6 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	private static final ILog LOG = getLog(HybridizeFunctionRefactoringTest.class);
 
 	/**
-	 * The {@link HybridizeFunctionRefactoringProcessor} most recently constructed by {@link #getFunctions(String)}. Test methods that need
-	 * to invoke the processor's API (e.g., to exercise the propagating
-	 * {@link HybridizeFunctionRefactoringProcessor#setInferInputSignatures(boolean)} setter through the analyzed function set) read this
-	 * after calling {@code getFunctions}.
-	 */
-	private HybridizeFunctionRefactoringProcessor lastProcessor;
-
-	/**
 	 * The {@link PythonNature} to be used for the tests.
 	 */
 	private static PythonNature nature = new PythonNature() {
@@ -207,6 +199,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	private static final boolean ALWAYS_FOLLOW_TYPE_HINTS = true;
 
 	private static final boolean USE_SPECULATIVE_ANALYSIS = true;
+
+	private static final boolean INFER_INPUT_SIGNATURES = true;
 
 	/**
 	 * Whether we should run the function processing in parallel. Running in parallel makes the logs difficult to read and doesn't offer
@@ -698,8 +692,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 		HybridizeFunctionRefactoringProcessor processor = new HybridizeFunctionRefactoringProcessor(inputFunctionDefinitions,
 				ALWAYS_CHECK_PYTHON_SIDE_EFFECTS, PROCESS_FUNCTIONS_IN_PARALLEL, ALWAYS_CHECK_RECURSION, USE_TEST_ENTRYPOINTS,
-				ALWAYS_FOLLOW_TYPE_HINTS, USE_SPECULATIVE_ANALYSIS);
-		this.lastProcessor = processor;
+				ALWAYS_FOLLOW_TYPE_HINTS, USE_SPECULATIVE_ANALYSIS, INFER_INPUT_SIGNATURES);
 
 		ProcessorBasedRefactoring refactoring = new ProcessorBasedRefactoring(processor);
 
@@ -1210,9 +1203,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 	/**
 	 * Test that {@code convertToHybrid} emits an inferred {@code input_signature=[tf.TensorSpec(...)]} keyword into the generated
-	 * {@code @tf.function(...)} decorator when {@link Function#setInferInputSignatures(boolean)} flips the flag on. Phase 2 of #563: the
-	 * formatter from #564 plus the wired-through flag on {@link Function} and {@code HybridizeFunctionRefactoringProcessor}. The
-	 * user-facing/eval-facing gating that flips the flag in production wiring is tracked at #481.
+	 * {@code @tf.function(...)} decorator. Phase 2 of #563: the formatter from #564 plus the wired-through flag on {@link Function} and
+	 * {@code HybridizeFunctionRefactoringProcessor}. The user-facing/eval-facing gating that flips the flag in production wiring is tracked
+	 * at #481.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
 	 */
@@ -1224,16 +1217,12 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertFalse("Fixture function `f` should be eager pre-refactoring.", f.isHybrid());
 		assertTrue("Fixture function `f` should select `CONVERT_TO_HYBRID` after analysis.",
 				f.getTransformations().contains(Transformation.CONVERT_TO_HYBRID));
-
-		// Route through the processor's propagating setter rather than the per-`Function` setter so the propagation loop body in
-		// `HybridizeFunctionRefactoringProcessor.setInferInputSignatures` is exercised.
-		this.lastProcessor.setInferInputSignatures(true);
-		assertTrue("Processor's propagating setter should flip the analyzed function's flag.", f.getInferInputSignatures());
+		assertTrue("Test-class `INFER_INPUT_SIGNATURES` constant should propagate to the analyzed function's flag.",
+				f.getInferInputSignatures());
 
 		// Apply the `TextEdit`s directly to the function's in-memory document. The shared `compareOutputTestFile` path would do the
 		// same comparison via the existing infrastructure, but the test's `ResourceStub`-backed `IFile` can't be resolved to a URI by
-		// `TextFileBufferManager`. Tracked at #359. When that lands, this test can collapse to setting `compareOutputTestFile` and
-		// an `inferInputSignatures` test-class field instead of applying edits inline.
+		// `TextFileBufferManager`. Tracked at #359. When that lands, this test can collapse to setting `compareOutputTestFile`.
 		IDocument doc = f.getContainingDocument();
 		for (TextEdit edit : f.transform())
 			edit.apply(doc);
@@ -1258,9 +1247,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertFalse("Fixture function `f` should be eager pre-refactoring.", f.isHybrid());
 		assertTrue("Fixture function `f` should select `CONVERT_TO_HYBRID` after analysis.",
 				f.getTransformations().contains(Transformation.CONVERT_TO_HYBRID));
-
-		this.lastProcessor.setInferInputSignatures(true);
-		assertTrue("Processor's propagating setter should flip the analyzed function's flag.", f.getInferInputSignatures());
+		assertTrue("Test-class `INFER_INPUT_SIGNATURES` constant should propagate to the analyzed function's flag.",
+				f.getInferInputSignatures());
 
 		IDocument doc = f.getContainingDocument();
 		for (TextEdit edit : f.transform())

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -78,6 +78,7 @@ import org.eclipse.ltk.core.refactoring.RefactoringCore;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.RefactoringStatusEntry;
 import org.eclipse.ltk.core.refactoring.participants.ProcessorBasedRefactoring;
+import org.eclipse.text.edits.TextEdit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -1196,6 +1197,31 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		boolean warnFired = captured.stream().anyMatch(s -> s.getSeverity() == IStatus.WARNING
 				&& "Unknown @tf.function argument: experimental_attributes on func().".equals(s.getMessage()));
 		assertTrue("Expected WARN log for unknown kwarg `experimental_attributes`.", warnFired);
+	}
+
+	/**
+	 * Test that {@code convertToHybrid} emits an inferred {@code input_signature=[tf.TensorSpec(...)]} keyword into the generated
+	 * {@code @tf.function(...)} decorator when {@link Function#setInferInputSignatures(boolean)} flips the flag on. Phase 2 of #563: the
+	 * formatter from #564 plus the wired-through flag on {@link Function} and {@code HybridizeFunctionRefactoringProcessor}. The
+	 * user-facing/eval-facing gating that flips the flag in production wiring is tracked at #481.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	@Test
+	public void testInferInputSignatureEmission() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertFalse("Fixture function `f` should be eager pre-refactoring.", f.isHybrid());
+		assertTrue("Fixture function `f` should select `CONVERT_TO_HYBRID` after analysis.",
+				f.getTransformations().contains(Transformation.CONVERT_TO_HYBRID));
+
+		f.setInferInputSignatures(true);
+
+		List<TextEdit> edits = f.transform();
+		String emitted = edits.stream().map(TextEdit::toString).reduce("", (a, b) -> a + b);
+		assertTrue("Expected `@tf.function(input_signature=[tf.TensorSpec(...)])` emission; got: " + emitted,
+				emitted.contains("@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])"));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Phase 2 of #563. Wires the `InputSignature` formatter (landed in #564) into the refactoring's source-write pipeline, so eager-to-hybrid conversions optionally emit `@tf.function(input_signature=[tf.TensorSpec(...)])` instead of bare `@tf.function`. Closes the loop on the `CONVERT_TO_HYBRID` case—analysis output is now observable in the refactored source.

## Change

- New `inferInputSignatures` boolean on `Function` and `HybridizeFunctionRefactoringProcessor`, default `false`. Constructor-injected matching the existing pattern (`alwaysFollowTypeHints`, `useSpeculativeAnalysis`); accessor `getInferInputSignatures()` + setter `setInferInputSignatures(boolean)`. The processor threads its field to `Function` at the two `new Function(...)` call sites.
- `Function.convertToHybrid` consults the flag. When it's on, the inference produces a signature, and the import prefix is non-empty, the emitted decorator becomes `@<prefix>function(input_signature=<formatted>)`. Empty-prefix case (from `from tensorflow import function`) skips emission—`TensorSpec` isn't reachable in that form and adding the ancillary imports is non-trivial.
- Integration test `testInferInputSignatureEmission`: eager `f(x)` called with `tf.constant(2.0)`; analysis selects `CONVERT_TO_HYBRID`; setter flips the flag; `transform()` produces a `TextEdit` whose text contains `@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])`. Fixture verified Python-runnable under `tensorflow==2.9.3`.

## What's Next

- #481—wire the user-facing UI checkbox, system property, and eval-side `INFER_INPUT_SIGNATURES_KEY` to flip `setInferInputSignatures(true)` in production (eval and refactoring wizard paths). This PR's setter is the API surface that #481 will call.
- #563—`RECONFIGURE` case (function already hybrid but missing `input_signature`) is left for a follow-up.
- #557—the validate-then-overwrite vs use-as-is decision for functions that already have an `input_signature` is documented there; this PR's skip-when-already-present behavior is the conservative default until #557 lands a value-parsing path.

## Test Plan

- [x] `./mvnw verify` passes locally (see CI checks below for the live count and failures, if any).
- [x] Spotless clean.
- [x] Fixture runs under `python3.10` (three-check protocol step 1).
- [ ] CI passes.

## Cross-Refs

- #564—Phase 1, the formatter (merged at 46992106).
- #481—gating + eval wiring (the layer above this one).
- #557—parse user-supplied `input_signature` value.
