### PR TITLE
Wire eval-side `inferInputSignatures` flag

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/utils/Util.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/utils/Util.java
@@ -56,9 +56,17 @@ public class Util {
 			boolean alwaysCheckPythonSideEffects, boolean processFunctionsInParallel, boolean alwaysCheckRecusion,
 			boolean useTestEntryPoints, boolean alwaysFollowTypeHints, boolean useSpeculativeAnalysis)
 			throws ExecutionException, CoreException, IOException {
+		return createHybridizeFunctionRefactoring(projects, alwaysCheckPythonSideEffects, processFunctionsInParallel, alwaysCheckRecusion,
+				useTestEntryPoints, alwaysFollowTypeHints, useSpeculativeAnalysis, false);
+	}
+
+	public static HybridizeFunctionRefactoringProcessor createHybridizeFunctionRefactoring(IProject[] projects,
+			boolean alwaysCheckPythonSideEffects, boolean processFunctionsInParallel, boolean alwaysCheckRecusion,
+			boolean useTestEntryPoints, boolean alwaysFollowTypeHints, boolean useSpeculativeAnalysis, boolean inferInputSignatures)
+			throws ExecutionException, CoreException, IOException {
 		Set<FunctionDefinition> functionDefinitions = getFunctionDefinitions(Arrays.asList(projects));
 		return new HybridizeFunctionRefactoringProcessor(functionDefinitions, alwaysCheckPythonSideEffects, processFunctionsInParallel,
-				alwaysCheckRecusion, useTestEntryPoints, alwaysFollowTypeHints, useSpeculativeAnalysis);
+				alwaysCheckRecusion, useTestEntryPoints, alwaysFollowTypeHints, useSpeculativeAnalysis, inferInputSignatures);
 	}
 
 	public static Set<FunctionDefinition> getFunctionDefinitions(Iterable<?> iterable)

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -122,6 +122,8 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 	private static final String USE_SPECULATIVE_ANALYSIS_KEY = "edu.cuny.hunter.hybridize.eval.useSpeculativeAnalysis";
 
+	private static final String INFER_INPUT_SIGNATURES_KEY = "edu.cuny.hunter.hybridize.eval.inferInputSignatures";
+
 	private static final String OUTPUT_CALLS_KEY = "edu.cuny.hunter.hybridize.eval.outputCalls";
 
 	private static String[] buildAttributeColumnNames(String... additionalColumnNames) {
@@ -153,6 +155,15 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 	private boolean useSpeculativeAnalysis = Boolean.getBoolean(USE_SPECULATIVE_ANALYSIS_KEY);
 
+	/**
+	 * True iff the refactoring should emit an inferred {@code input_signature=...} keyword into the generated {@code @tf.function}
+	 * decorator. Off by default; set via the {@code edu.cuny.hunter.hybridize.eval.inferInputSignatures} system property.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481">Issue 481</a>
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	private boolean inferInputSignatures = Boolean.getBoolean(INFER_INPUT_SIGNATURES_KEY);
+
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		Job.create("Evaluating Hybridize Functions refactoring...", monitor -> {
@@ -169,7 +180,7 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 				resultsHeader.add(transformation.toString());
 
 			String[] experimentalSettingsHeader = new String[] { "side-effects", "recursion", "type hints", "parallel", "speculative",
-					"test entrypoints" };
+					"test entrypoints", "infer input signatures" };
 			resultsHeader.addAll(Arrays.asList(experimentalSettingsHeader));
 
 			resultsHeader.add("time (s)");
@@ -217,7 +228,7 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 					resultsTimeCollector.start();
 					processor = createHybridizeFunctionRefactoring(new IProject[] { project }, this.getAlwaysCheckPythonSideEffects(),
 							this.getProcessFunctionsInParallel(), this.getAlwaysCheckRecusion(), this.getUseTestEntrypoints(),
-							this.getAlwaysFollowTypeHints(), this.getUseSpeculativeAnalysis());
+							this.getAlwaysFollowTypeHints(), this.getUseSpeculativeAnalysis(), this.getInferInputSignatures());
 					resultsTimeCollector.stop();
 
 					// run the precondition checking.
@@ -316,6 +327,9 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 					// test entrypoints.
 					resultsPrinter.print(this.getUseTestEntrypoints());
+
+					// infer input signatures.
+					resultsPrinter.print(this.getInferInputSignatures());
 
 					// actually perform the refactoring if there are no fatal
 					// errors.
@@ -583,5 +597,9 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 	public boolean getUseSpeculativeAnalysis() {
 		return this.useSpeculativeAnalysis;
+	}
+
+	public boolean getInferInputSignatures() {
+		return this.inferInputSignatures;
 	}
 }


### PR DESCRIPTION
## Summary

Wires the eval-side surface of #481. Adds the `edu.cuny.hunter.hybridize.eval.inferInputSignatures` system property to the evaluator handler and threads it through to `Function.convertToHybrid` via a new `Util.createHybridizeFunctionRefactoring` overload. Eval runs can now toggle input-signature emission without going through the developer-facing wizard.

## Change

- `EvaluateHybridizeFunctionRefactoringHandler`:
  - New `INFER_INPUT_SIGNATURES_KEY` constant pointing at `edu.cuny.hunter.hybridize.eval.inferInputSignatures`.
  - `inferInputSignatures` field initialized from `Boolean.getBoolean(...)` (matches the existing pattern for `alwaysFollowTypeHints`, `useSpeculativeAnalysis`, etc.).
  - `getInferInputSignatures()` accessor.
  - Passes the flag to `createHybridizeFunctionRefactoring(...)` at the call site.
  - New `infer input signatures` column in the results CSV header + value.
- `Util.createHybridizeFunctionRefactoring`: new 8-arg overload taking the flag; the existing 7-arg overload delegates with `false` (existing behavior preserved for any other callers).

The user-facing wizard checkbox half of #481 is a follow-up; this PR covers the eval-side surface only, which is what paper runs need.

## Depends On

- #565 (Phase 2 of #563), which adds the `inferInputSignatures` field this PR consumes, has merged; this branch is rebased onto main.

## Test Plan

- [x] Eval module compiles against merged main (`./mvnw install -DskipTests -pl edu.cuny.hunter.hybridize.eval -am`).
- [x] Spotless clean.
- [x] Rebased onto main after #565 merged; CI re-running on the rebased branch.

## Cross-Refs

- #481—gating issue; this closes its eval-side half.
- #563—source-write transformation (the underlying capability this flag gates).
- #565—Phase 2 of #563 (Processor field this PR consumes).

