### PR TITLE
Replace deprecated `new Locale(...)` with `Locale.of(...)` in `InputSignatureTest`

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
@@ -123,7 +123,7 @@ public class InputSignatureTest {
 	@Test
 	public void testDtypeLowerCaseIsLocaleIndependent() {
 		Locale prior = Locale.getDefault();
-		Locale.setDefault(new Locale("tr", "TR"));
+		Locale.setDefault(Locale.of("tr", "TR"));
 		try {
 			InputSignature sig = new InputSignature(
 					List.of(new TensorType(INT32, List.of(new NumericDim(2))), new TensorType(STRING, List.of(new NumericDim(2)))));


### PR DESCRIPTION
Resolves the [`java/deprecated-call` CodeQL alert](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/27) introduced by #564. Java 19+ ships `Locale.of(language, country)` as the non-deprecated replacement; this project's Java 25 toolchain has it. Behavior unchanged—same Turkish locale used to lock dtype identifier lower-casing to ASCII.

## Test Plan

- [x] `./mvnw verify -Dtest=InputSignatureTest` passes locally (10/10).
- [x] Spotless clean.
- [ ] CI passes.