### PR TITLE
Close `InputStreamReader` in `runCommand` on error path

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -387,8 +387,9 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 		if (exitCode != 0) { // there's a problem.
 			// retrieve the error output.
-			BufferedReader errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream()));
-			errorOutput = errorReader.lines().collect(Collectors.joining("\n"));
+			try (BufferedReader errorReader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+				errorOutput = errorReader.lines().collect(Collectors.joining("\n"));
+			}
 		}
 
 		assertEquals("Error code should be 0. Error was:\n" + errorOutput + ".", 0, exitCode);


### PR DESCRIPTION
Resolves the [`java/input-resource-leak` CodeQL alert](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/security/code-scanning/22) at `HybridizeFunctionRefactoringTest.java:390`. The reader was constructed only on the non-zero exit code branch (capturing stderr for the assertion message), but never closed—try-with-resources fixes the leak without changing behavior.

## Test Plan

- [x] `./mvnw install -DskipTests=true` compiles cleanly.
- [x] Spotless clean.
- [ ] CI passes.