### PR TITLE
Bump Ariadne to 0.46.1

### DIFF
--- a/hybridize.target
+++ b/hybridize.target
@@ -57,7 +57,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.45.0</version>
+					<version>0.46.1</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
## Summary

- Bump `com.ibm.wala.cast.python.ml` from `0.45.0` to `0.46.1` in `hybridize.target`. Continues to consume the fat classifier (wala/ML#557 still blocks slim consumption from Tycho).

Closes #568.

## Verification

`./mvnw verify -B` passes all **503 tests** locally (493 `HybridizeFunctionRefactoringTest` + 10 `InputSignatureTest`), no failures, no test-expectation drift from any of the 0.46.1 changes. In particular:

- **wala/ML#107 inherited method dispatch** (ponder-lab/ML#345): no new failures from added call-graph reachability through `tf.keras.Model` subclass dispatch.
- **wala/ML#408 `from_generator` dtype lattice** (ponder-lab/ML#344): no new failures from the ⊥ → ⊤ promotion. No fixture in the current corpus exercises `from_generator` with a statically-unresolved element spec.
- **wala/ML#478 `PythonInvokeInstruction.hashCode`** (ponder-lab/ML#343): no impact—Hybridize doesn't rely on the prior default hashing.
- **wala/ML#558 `Dimension.toString` cleanup** (ponder-lab/ML#342): the `D:Dynamic,null` → `D:Dynamic` change shows up only in JUnit failure messages (when `assertEquals` calls `.toString` on actual vs expected `TensorType`s). No source code asserts on the `toString` form directly, so the cleanup is transparent.

## Other Notes

- Continues to specify `<classifier>fat</classifier>` per the slim-jar block at wala/ML#557 (Tycho 5+'s bnd auto-wrap rejects `jython3`'s default-package class). When wala/ML#557 resolves, the classifier should be dropped + `includeDependencyDepth="infinite"` re-tried.
- Build uses JDK 25 (matches CI's `actions/setup-java` config and Ariadne's `<maven.compiler.release>25`).

## Test Plan

- [x] All 503 tests pass locally with `JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64 ./mvnw verify`.
- [ ] CI passes.
