### PR TITLE
Call `Change.initializeValidationData` before `performChange` in compare-output path

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -699,13 +699,17 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		else
 			assertFalse(status.isOK());
 
-		// NOTE: Fix https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/359 first.
+		// NOTE: `compareOutputTestFile` is the existing infra for asserting refactored output against `out/A.py`. The first layer of
+		// #359 (missing `initializeValidationData(...)` before `performChange(...)`) is fixed here; the URI-resolution layer
+		// (`ResourceStub`-backed `IFile`s) remains open at
+		// https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/359.
 		if (this.getCompareOutputTestFile()) {
 			// check if there's an expected output.
 			File outputTestFile = this.getOutputTestFile(fileNameWithoutExtension);
 
 			if (outputTestFile.exists()) {
 				Change change = refactoring.createChange(new NullProgressMonitor());
+				change.initializeValidationData(new NullProgressMonitor());
 				this.performChange(change);
 
 				String expected = this.getFileContents(this.getOutputTestFileName(fileNameWithoutExtension));


### PR DESCRIPTION
Partial fix for #359. The `compareOutputTestFile` test path (gated by the `edu.cuny.hunter.hybridize.tests.compareOutput` system property) ran `refactoring.createChange(...)` and immediately called `performChange(...)`. Eclipse's refactoring-API contract requires `Change.initializeValidationData(monitor)` to have run before `Change.isValid()` (which `performChange` calls internally). Without it, every `compareOutputTestFile` invocation threw `CoreException: TextFileChange has not been initialialized`.

This adds the missing call. The remaining gap on #359 is that the test's `ResourceStub`-backed `IFile` doesn't expose a URI that `TextFileBufferManager` can resolve, so even with validation data initialized, `TextFileChange.acquireDocument` still fails (next layer of #359). The NOTE in the test is updated to call out the narrower remaining scope.

## Test Plan

- [x] `./mvnw verify` passes locally with no change in test count (the system property defaults off, so the path isn't exercised in CI).
- [x] Spotless clean.
- [ ] CI passes.