### PR TITLE
Fix Tycho-surefire system-property config: `<systemPropertyVariables>` → `<systemProperties>`

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/pom.xml
+++ b/edu.cuny.hunter.hybridize.tests/pom.xml
@@ -27,10 +27,10 @@
         <configuration>
           <failIfNoTests>true</failIfNoTests>
           <providerHint>junit4</providerHint>
-          <systemPropertyVariables>
+          <systemProperties>
             <!-- Set JUL Formatting -->
             <java.util.logging.config.file>${logging.config.file}</java.util.logging.config.file>
-          </systemPropertyVariables>
+          </systemProperties>
           <explodedBundles>
             <bundle>org.junit</bundle>
           </explodedBundles>


### PR DESCRIPTION
`<systemPropertyVariables>` is a maven-surefire parameter; Tycho-surefire's equivalent is `<systemProperties>` (no "Variables" suffix). The existing config has been silently a no-op since it was written—`./mvnw verify -X` reports:

```
Parameter 'systemPropertyVariables' is unknown for plugin 'tycho-surefire-plugin:5.0.2:test (default-test)'
```

The visible effect of this fix is that `java.util.logging.config.file` is now actually propagated to the test JVM (it was being dropped before), so the project's `logging.properties` config applies to test output as originally intended. Other system properties referenced in the same block would also start propagating; this PR doesn't add any.

## Test Plan

- [x] All 503 tests pass locally with `JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64 ./mvnw verify`.
- [x] The `Parameter 'systemPropertyVariables' is unknown` warning no longer appears in `./mvnw verify -X`.
- [ ] CI passes.