### PR TITLE
Emit per-parameter `INFO` when `inferSpec` drops the signature

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1556,9 +1556,13 @@ public class Function {
 
 			Optional<TensorType> spec = inferSpec(contexts);
 			if (spec.isEmpty()) {
-				// `inferSpec` reduced to bottom. Post-#480 it only drops for two reasons: heterogeneous dtype (|D| ≠ 1) or dtype-⊤
-				// (a single agreed `UNKNOWN`). Shape-⊤ and symbolic-dim no longer drop here—the per-context reduction emits a coarse
-				// `TensorType(dtype, null)` or `SymbolicDim` wildcard instead. Emit a per-parameter INFO naming the reason (#510).
+				/*
+				 * `inferSpec` reduced to bottom. With the per-context reduction
+				 * (https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/480) it now drops for only two reasons:
+				 * heterogeneous dtype (|D| ≠ 1) or dtype-⊤ (a single agreed `UNKNOWN`). Shape-⊤ and symbolic-dim no longer drop here—it
+				 * emits a coarse `TensorType(dtype, null)` or a `SymbolicDim` wildcard instead. Emit a per-parameter INFO naming the
+				 * reason; see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/510.
+				 */
 				if (contexts.stream().map(TensorType::getDType).distinct().count() > 1)
 					this.addInfo(INPUT_SIGNATURE_INFERENCE, "Parameter `" + param.getName() + "` of `" + this
 							+ "` receives tensors with conflicting dtypes across call sites, so a single input signature cannot be inferred; it is dropped.");

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1560,11 +1560,11 @@ public class Function {
 				// (a single agreed `UNKNOWN`). Shape-⊤ and symbolic-dim no longer drop here—the per-context reduction emits a coarse
 				// `TensorType(dtype, null)` or `SymbolicDim` wildcard instead. Emit a per-parameter INFO naming the reason (#510).
 				if (contexts.stream().map(TensorType::getDType).distinct().count() > 1)
-					this.addInfo(INPUT_SIGNATURE_INFERENCE, "Parameter `" + param.getName() + "` of `" + this + "` has tensor types "
-							+ "with disagreeing dtypes across call sites (|D| ≠ 1); input-signature inference is dropped.");
+					this.addInfo(INPUT_SIGNATURE_INFERENCE, "Parameter `" + param.getName() + "` of `" + this
+							+ "` receives tensors with conflicting dtypes across call sites, so a single input signature cannot be inferred; it is dropped.");
 				else
 					this.addInfo(INPUT_SIGNATURE_INFERENCE, "Parameter `" + param.getName() + "` of `" + this
-							+ "` has dtype-⊤ (`tf.UNKNOWN`); input-signature inference is dropped pending dtype-⊤ handling (#494).");
+							+ "` receives a tensor whose dtype cannot be determined, so a single input signature cannot be inferred; it is dropped.");
 				blocked = true;
 				continue;
 			}

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1556,8 +1556,15 @@ public class Function {
 
 			Optional<TensorType> spec = inferSpec(contexts);
 			if (spec.isEmpty()) {
-				// Reduction returned bottom for this parameter; the whole signature collapses. Per-parameter INFO emission for the
-				// `inferSpec`-side drops (multi-context, dtype-⊤, symbolic dim) is tracked at #510.
+				// `inferSpec` reduced to bottom. Post-#480 it only drops for two reasons: heterogeneous dtype (|D| ≠ 1) or dtype-⊤
+				// (a single agreed `UNKNOWN`). Shape-⊤ and symbolic-dim no longer drop here—the per-context reduction emits a coarse
+				// `TensorType(dtype, null)` or `SymbolicDim` wildcard instead. Emit a per-parameter INFO naming the reason (#510).
+				if (contexts.stream().map(TensorType::getDType).distinct().count() > 1)
+					this.addInfo(INPUT_SIGNATURE_INFERENCE, "Parameter `" + param.getName() + "` of `" + this + "` has tensor types "
+							+ "with disagreeing dtypes across call sites (|D| ≠ 1); input-signature inference is dropped.");
+				else
+					this.addInfo(INPUT_SIGNATURE_INFERENCE, "Parameter `" + param.getName() + "` of `" + this
+							+ "` has dtype-⊤ (`tf.UNKNOWN`); input-signature inference is dropped pending dtype-⊤ handling (#494).");
 				blocked = true;
 				continue;
 			}

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInputSignatureDtypeTop/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInputSignatureDtypeTop/in/A.py
@@ -1,0 +1,14 @@
+# Pinning fixture for the dtype-⊤ drop. `tf.constant(np.ones(..., dtype=...))` currently loses the numpy dtype
+# (https://github.com/wala/ML/issues/539), so Ariadne infers a single full-⊤ `TensorType(UNKNOWN, null)` for `consume`'s
+# parameter. `inferSpec` drops on dtype-⊤ and the refactoring surfaces an INFO. When that issue is fixed, the dtype becomes
+# concrete and the test inverts.
+import numpy as np
+import tensorflow as tf
+
+
+def consume(x):
+    return x
+
+
+if __name__ == "__main__":
+    consume(tf.constant(np.ones((2, 3), dtype=np.float32)))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInputSignatureDtypeTop/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInputSignatureDtypeTop/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -2549,7 +2549,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Optional<InputSignature> dblSig = dbl.inferInputSignature();
 		assertFalse("Expected signature drop due to dtype disagreement across call sites.", dblSig.isPresent());
 
-		// #510: the `inferSpec`-side drop must surface a per-parameter INFO naming the reason, not collapse silently.
+		// See https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/510: the `inferSpec`-side drop must surface a
+		// per-parameter INFO naming the reason, not collapse silently.
 		RefactoringStatusEntry dblEntry = dbl.getStatus().getEntryMatchingCode(Function.PLUGIN_ID, INPUT_SIGNATURE_INFERENCE.getCode());
 		assertNotNull("Expected an INPUT_SIGNATURE_INFERENCE INFO for the `inferSpec` heterogeneous-dtype drop (#510).", dblEntry);
 		assertEquals("Status entry must be INFO severity.", INFO, dblEntry.getSeverity());

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -7716,6 +7716,46 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Pinning regression for the dtype-⊤ drop and its INFO (#510), which also covers #494's dtype-⊤ singleton and #491's full-⊤ marker via
+	 * the wala/ML#539 trigger. {@code tf.constant(np.ones(..., dtype=...))} currently loses the numpy dtype (wala/ML#539), so Ariadne
+	 * infers a single full-⊤ {@code TensorType(UNKNOWN, null)} for {@code consume}'s parameter. {@code inferSpec} drops on dtype-⊤ and
+	 * {@code inferInputSignature} surfaces an INFO naming the reason. When wala/ML#539 lands and the dtype becomes concrete, this test
+	 * inverts (signature present, no drop INFO).
+	 *
+	 * @see <a href="https://github.com/wala/ML/issues/539">wala/ML#539</a>
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/494">Issue 494</a>
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/491">Issue 491</a>
+	 */
+	@Test
+	public void testInputSignatureDtypeTop() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(1, parameters.size());
+		Parameter x = parameters.get(0);
+		assertEquals("x", x.getName());
+
+		// Pinning wala/ML#539: the numpy dtype is lost, so the only TensorType is full-⊤ (UNKNOWN dtype, null dims).
+		Set<TensorType> inferred = x.getTensorTypes();
+		assertEquals("Expected exactly one TensorType for `x`.", 1, inferred.size());
+		TensorType only = inferred.iterator().next();
+		assertEquals("dtype-⊤ pending wala/ML#539.", DType.UNKNOWN, only.getDType());
+		assertNull("shape-⊤ pending wala/ML#539.", only.getDims());
+
+		Optional<InputSignature> signature = function.inferInputSignature();
+		assertFalse("dtype-⊤ must collapse the signature.", signature.isPresent());
+
+		// #510: the dtype-⊤ drop surfaces a per-parameter INFO instead of collapsing silently.
+		RefactoringStatusEntry entry = function.getStatus().getEntryMatchingCode(Function.PLUGIN_ID, INPUT_SIGNATURE_INFERENCE.getCode());
+		assertNotNull("Expected an INPUT_SIGNATURE_INFERENCE INFO for the dtype-⊤ drop.", entry);
+		assertEquals("Status entry must be INFO severity.", INFO, entry.getSeverity());
+		assertTrue("Status message must cite parameter `x`.", entry.getMessage().contains("`x`"));
+		assertTrue("Status message must name the unknown-dtype reason.", entry.getMessage().contains("dtype cannot be determined"));
+	}
+
+	/**
 	 * Regression test for #508 category (b) (Phase-3 container path). A parameter classified as tensor-typed via Phase 3
 	 * (`hasTensorContainer`) but with no Phase 2 (Ariadne call-site) shape/dtype evidence: `xs.isTensor()` is TRUE while
 	 * `xs.getTensorTypes()` is empty. Per #508, `inferInputSignature` drops the signature and emits a per-parameter INFO referencing #509

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -2554,7 +2554,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertNotNull("Expected an INPUT_SIGNATURE_INFERENCE INFO for the `inferSpec` heterogeneous-dtype drop (#510).", dblEntry);
 		assertEquals("Status entry must be INFO severity.", INFO, dblEntry.getSeverity());
 		assertTrue("Status message must cite parameter `a`.", dblEntry.getMessage().contains("`a`"));
-		assertTrue("Status message must name the dtype-disagreement reason.", dblEntry.getMessage().contains("disagreeing dtypes"));
+		assertTrue("Status message must name the dtype-disagreement reason.", dblEntry.getMessage().contains("conflicting dtypes"));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -2548,6 +2548,13 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 				a.getTensorTypes());
 		Optional<InputSignature> dblSig = dbl.inferInputSignature();
 		assertFalse("Expected signature drop due to dtype disagreement across call sites.", dblSig.isPresent());
+
+		// #510: the `inferSpec`-side drop must surface a per-parameter INFO naming the reason, not collapse silently.
+		RefactoringStatusEntry dblEntry = dbl.getStatus().getEntryMatchingCode(Function.PLUGIN_ID, INPUT_SIGNATURE_INFERENCE.getCode());
+		assertNotNull("Expected an INPUT_SIGNATURE_INFERENCE INFO for the `inferSpec` heterogeneous-dtype drop (#510).", dblEntry);
+		assertEquals("Status entry must be INFO severity.", INFO, dblEntry.getSeverity());
+		assertTrue("Status message must cite parameter `a`.", dblEntry.getMessage().contains("`a`"));
+		assertTrue("Status message must name the dtype-disagreement reason.", dblEntry.getMessage().contains("disagreeing dtypes"));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Closes #510, closes #494, closes #491. `inferInputSignature` already emits an `INPUT_SIGNATURE_INFERENCE` INFO for its category (a) (non-tensor) and category (b) (no Phase-2 evidence) drops, but the `inferSpec`-side drop collapsed the signature silently. This adds a reason-aware per-parameter INFO at that drop site, with fixtures covering both reachable drop reasons (heterogeneous dtype and dtype-⊤).

## Re-Scope Note

#510 was written against the pre-#480 `inferSpec` and lists four drop branches. Against the current `inferSpec`, only two of them still drop:

- Heterogeneous dtype (`|D| ≠ 1`) — reachable and tested.
- Dtype-⊤ (a single agreed `UNKNOWN`) — reachable via `tf.constant(np_array)` (wala/ML#539) and tested.

The other branches #510 listed no longer drop: #480's per-context reduction emits a coarse `TensorType(dtype, null)` (shape-⊤) or a `SymbolicDim` wildcard (per-dim disagreement) instead, and multi-context is reduced rather than dropped. The INFO distinguishes the two real reasons in plain, wizard-facing prose (the message shows on the refactoring wizard).

## Test

Two fixtures, both asserting an INFO-severity `INPUT_SIGNATURE_INFERENCE` status citing the parameter and the drop reason:

- `testHasLikelyTensorParameter15` (the existing `double` fixture, INT32/FLOAT32/STRING) — the heterogeneous-dtype drop.
- `testInputSignatureDtypeTop` (new, `consume(tf.constant(np.ones(..., dtype=...)))`) — the dtype-⊤ drop, pinning the current wala/ML#539 behavior; it also covers #494's dtype-⊤ singleton and #491's full-⊤ marker, and inverts when wala/ML#539 lands.

Full suite green (510, 0 failures).

## Cross-Refs

- #510 — this PR.
- #480 — introduced the per-context reduction that narrowed `inferSpec`'s drop set.
- #494 — dtype-⊤ branch coverage; this PR's `testInputSignatureDtypeTop` covers it.
- #491 — full-⊤ marker; covered by the same fixture.
- wala/ML#539 — the `tf.constant(np_array)` dtype-loss that makes the dtype-⊤ branch reachable (and that the pinning test tracks).
- #508 — the category (a)/(b) INFO design this extends.

