### PR TITLE
Fix `getImportContext` early return missing later TensorSpec-reaching imports

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1933,23 +1933,47 @@ public class Function {
 	private static ImportContext getImportContext(IDocument doc) {
 		PyImportsHandling handling = new PyImportsHandling(doc);
 
+		// Full pass over every import, then decide — a single `from tensorflow import function` must not short-circuit the scan and
+		// miss a later `import tensorflow as tf` (or a `TensorSpec` in the same statement) that does make the signature emittable (#578).
+		String qualifiedPrefix = null;
+		boolean wildcard = false;
+		boolean functionImported = false;
+		boolean tensorSpecImported = false;
+
 		for (ImportHandle importHandle : handling)
-			for (ImportHandleInfo importHandleInfo : importHandle.getImportInfo())
+			for (ImportHandleInfo importHandleInfo : importHandle.getImportInfo()) {
+				String fromImportStr = importHandleInfo.getFromImportStrWithoutUnwantedChars();
+				boolean fromTensorflow = fromImportStr != null && fromImportStr.equals("tensorflow");
+
 				for (String importStr : importHandleInfo.getImportedStr())
 					if (importStr.equals("tensorflow"))
-						return new ImportContext("tensorflow.", true);
+						qualifiedPrefix = "tensorflow.";
 					else if (importStr.startsWith("tensorflow as"))
-						return new ImportContext(importStr.substring("tensorflow as ".length(), importStr.length()) + ".", true);
-					else {
-						String fromImportStr = importHandleInfo.getFromImportStrWithoutUnwantedChars();
-						if (fromImportStr != null && fromImportStr.equals("tensorflow"))
-							switch (importStr) {
-							case "*": // wildcard: TensorSpec and dtype constants are reachable unqualified.
-								return new ImportContext("", true);
-							case "function": // direct named import of `function` only; TensorSpec is not in scope.
-								return new ImportContext("", false);
-							}
-					}
+						qualifiedPrefix = importStr.substring("tensorflow as ".length(), importStr.length()) + ".";
+					else if (fromTensorflow)
+						switch (importStr) {
+						case "*": // wildcard: TensorSpec and the dtype constants are reachable unqualified.
+							wildcard = true;
+							break;
+						case "function":
+							functionImported = true;
+							break;
+						case "TensorSpec":
+							tensorSpecImported = true;
+							break;
+						}
+			}
+
+		// Precedence: a qualified `import tensorflow [as X]` qualifies `function`, `TensorSpec`, and the dtype constants under one
+		// prefix, so it wins over a named `from`-import that may bring only a subset into scope. A wildcard brings everything
+		// unqualified. Otherwise a named `from tensorflow import ...` makes `function` reachable unqualified, and `TensorSpec` only if
+		// it too was named.
+		if (qualifiedPrefix != null)
+			return new ImportContext(qualifiedPrefix, true);
+		if (wildcard)
+			return new ImportContext("", true);
+		if (functionImported)
+			return new ImportContext("", tensorSpecImported);
 
 		// not found.
 		return null;

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionBundledImport/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionBundledImport/in/A.py
@@ -1,4 +1,4 @@
-# Shape A (#578): a bundled `from tensorflow import function, TensorSpec, float32` makes `function`, `TensorSpec`, and the
+# Shape A (#578): a bundled `from tensorflow import function, TensorSpec, float32, constant` makes `function`, `TensorSpec`, and the
 # dtype constant all reachable unqualified, so the source-write emits an unqualified `input_signature`. The first imported
 # name (`function`) must not short-circuit the scan and skip emission.
 from tensorflow import function, TensorSpec, float32, constant

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionBundledImport/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionBundledImport/in/A.py
@@ -1,0 +1,12 @@
+# Shape A (#578): a bundled `from tensorflow import function, TensorSpec, float32` makes `function`, `TensorSpec`, and the
+# dtype constant all reachable unqualified, so the source-write emits an unqualified `input_signature`. The first imported
+# name (`function`) must not short-circuit the scan and skip emission.
+from tensorflow import function, TensorSpec, float32, constant
+
+
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionBundledImport/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionBundledImport/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionBundledImport/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionBundledImport/out/A.py
@@ -1,4 +1,4 @@
-# Shape A (#578): a bundled `from tensorflow import function, TensorSpec, float32` makes `function`, `TensorSpec`, and the
+# Shape A (#578): a bundled `from tensorflow import function, TensorSpec, float32, constant` makes `function`, `TensorSpec`, and the
 # dtype constant all reachable unqualified, so the source-write emits an unqualified `input_signature`. The first imported
 # name (`function`) must not short-circuit the scan and skip emission.
 from tensorflow import function, TensorSpec, float32, constant

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionBundledImport/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionBundledImport/out/A.py
@@ -1,0 +1,13 @@
+# Shape A (#578): a bundled `from tensorflow import function, TensorSpec, float32` makes `function`, `TensorSpec`, and the
+# dtype constant all reachable unqualified, so the source-write emits an unqualified `input_signature`. The first imported
+# name (`function`) must not short-circuit the scan and skip emission.
+from tensorflow import function, TensorSpec, float32, constant
+
+
+@function(input_signature=[TensorSpec(shape=(), dtype=float32)])
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionMixedImport/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionMixedImport/in/A.py
@@ -1,0 +1,13 @@
+# Shape B (#578): `from tensorflow import function` plus a later `import tensorflow as tf`. The qualified `tf.` import makes
+# the whole signature reachable, so the scan must not stop at the bare `from`-import and skip emission — it emits a
+# `tf.`-qualified signature.
+from tensorflow import function
+import tensorflow as tf
+
+
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionMixedImport/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionMixedImport/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionMixedImport/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionMixedImport/out/A.py
@@ -1,0 +1,14 @@
+# Shape B (#578): `from tensorflow import function` plus a later `import tensorflow as tf`. The qualified `tf.` import makes
+# the whole signature reachable, so the scan must not stop at the bare `from`-import and skip emission — it emits a
+# `tf.`-qualified signature.
+from tensorflow import function
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1320,8 +1320,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Bundled-import variant (#578, shape A). {@code from tensorflow import function, TensorSpec, float32} brings the decorator, the spec
-	 * type, and the dtype constant all into scope unqualified. The first imported name ({@code function}) must not short-circuit
+	 * Bundled-import variant (#578, shape A). {@code from tensorflow import function, TensorSpec, float32, constant} brings the decorator,
+	 * the spec type, and the dtype constant all into scope unqualified. The first imported name ({@code function}) must not short-circuit
 	 * {@code getImportContext} and skip emission; the source-write emits an unqualified
 	 * {@code @function(input_signature=[TensorSpec(shape=(), dtype=float32)])}.
 	 *

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1320,6 +1320,32 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Bundled-import variant (#578, shape A). {@code from tensorflow import function, TensorSpec, float32} brings the decorator, the spec
+	 * type, and the dtype constant all into scope unqualified. The first imported name ({@code function}) must not short-circuit
+	 * {@code getImportContext} and skip emission; the source-write emits an unqualified
+	 * {@code @function(input_signature=[TensorSpec(shape=(), dtype=float32)])}.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/578">Issue 578</a>
+	 */
+	@Test
+	public void testInferInputSignatureEmissionBundledImport() throws Exception {
+		helperAssertInputSignatureEmission();
+	}
+
+	/**
+	 * Mixed-import variant (#578, shape B). {@code from tensorflow import function} plus a later {@code import tensorflow as tf}: the
+	 * qualified {@code tf.} import makes the whole signature reachable, so {@code getImportContext} must scan past the bare
+	 * {@code from}-import rather than returning early, and emit a {@code tf.}-qualified
+	 * {@code @tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])}.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/578">Issue 578</a>
+	 */
+	@Test
+	public void testInferInputSignatureEmissionMixedImport() throws Exception {
+		helperAssertInputSignatureEmission();
+	}
+
+	/**
 	 * Runs the refactoring on the current test's fixture and asserts the produced source matches the expected {@code out/A.py}. The single
 	 * fixture function must be eager pre-refactoring, select {@link Transformation#CONVERT_TO_HYBRID}, and carry the harness-enabled
 	 * {@code inferInputSignatures} flag. Shared by the input-signature emission tests, which differ only in their import-shape fixture.


### PR DESCRIPTION
## Summary

Closes #578. `getImportContext` returned on the first tensorflow import, so a bare `from tensorflow import function` short-circuited the scan and missed a later `import tensorflow as tf` (or a `TensorSpec` named in the same `from` statement) that does make the signature emittable. The refactor fell back to a bare `@function` and dropped the `input_signature`.

## Change

Full pass over all imports, then decide with precedence:

1. A qualified `import tensorflow [as X]` — qualifies `function`, `TensorSpec`, and the dtype constants under one prefix → `(X., true)`.
2. A wildcard `from tensorflow import *` → `("", true)`.
3. A named `from tensorflow import ...` → `("", true)` if `TensorSpec` is also named, else `("", false)` (just `function`).

Existing import-shape results are unchanged (alias, wildcard, named-`function`-only, fully-qualified).

## Tests

Two new fixtures via the shared `helperAssertInputSignatureEmission`:

- `testInferInputSignatureEmissionBundledImport` — shape A: `from tensorflow import function, TensorSpec, float32` → emits unqualified `@function(input_signature=[TensorSpec(shape=(), dtype=float32)])`.
- `testInferInputSignatureEmissionMixedImport` — shape B: `from ... import function` + `import tensorflow as tf` → emits `tf.`-qualified.

Full suite green (512, 0 failures).

## Known Limitation (follow-up filed)

The named-`from`-import path (shape A) marks `TensorSpec` reachable from its presence alone, but the emitted `dtype=<name>` must also be imported unqualified — `getImportContext` can't see the inferred dtype. Tracked as #585; doesn't affect the qualified or wildcard paths.

## Cross-Refs

- #578 — this PR.
- #565 — introduced `getImportContext`.
- #585 — dtype-aware reachability follow-up for the named-`from`-import path.

