### PR TITLE
Gate `input_signature` emission on dtype-constant reachability

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1862,7 +1862,7 @@ public class Function {
 
 			// The auto-injected `from tensorflow import function` makes only `function` reachable; `TensorSpec` is not. Extending
 			// the auto-inject to cover the signature's required symbols is tracked separately.
-			ctx = new ImportContext("", false);
+			ctx = new ImportContext("", false, false, Collections.emptySet());
 		}
 
 		MultiTextEdit mte = new MultiTextEdit();
@@ -1875,31 +1875,57 @@ public class Function {
 	}
 
 	/**
-	 * The TensorFlow import shape observed in a Python source file, carrying both the prefix to use when referring to TensorFlow names and
-	 * whether {@code TensorSpec} is reachable in the file's namespace. The two empty-prefix shapes ({@code from tensorflow import *} and
-	 * {@code from tensorflow import function}) differ on the latter: the wildcard form pulls all public names into scope (including
-	 * {@code TensorSpec}), while the named-import form does not.
+	 * The TensorFlow import shape observed in a Python source file, carrying the prefix to use when referring to TensorFlow names, whether
+	 * {@code TensorSpec} is reachable in the file's namespace, and which other names are reachable under the prefix. The two empty-prefix
+	 * shapes ({@code from tensorflow import *} and {@code from tensorflow import function}) differ on the latter two: the wildcard form
+	 * pulls all public names into scope (including {@code TensorSpec} and every dtype constant), while the named-import form brings only
+	 * the explicitly listed names.
 	 *
 	 * @param prefix The TensorFlow module prefix (e.g., {@code "tf."}, {@code "tensorflow."}, or {@code ""}).
-	 * @param tensorSpecReachable True iff {@code TensorSpec} (and the dtype constants like {@code float32}) can be referenced from the file
-	 *        using the {@code prefix}, without an additional import.
+	 * @param tensorSpecReachable True iff {@code TensorSpec} can be referenced from the file using the {@code prefix}, without an
+	 *        additional import.
+	 * @param allNamesReachable True iff every TensorFlow name (including all dtype constants) is reachable under the {@code prefix} without
+	 *        an additional import—the case for qualified ({@code import tensorflow [as X]}) and wildcard ({@code from tensorflow import *})
+	 *        shapes. False for the named-import shape, where only {@code namedImports} are in scope.
+	 * @param namedImports The bare names brought into scope by a {@code from tensorflow import ...} statement; consulted only when
+	 *        {@code allNamesReachable} is false.
 	 */
-	private record ImportContext(String prefix, boolean tensorSpecReachable) {
+	private record ImportContext(String prefix, boolean tensorSpecReachable, boolean allNamesReachable, Set<String> namedImports) {
+
+		/**
+		 * Whether the bare TensorFlow name {@code name} (e.g., a dtype constant like {@code "float32"}) can be referenced as
+		 * {@code prefix + name} without an additional import. Qualified and wildcard shapes ({@code allNamesReachable}) bring every name
+		 * into scope; a named {@code from tensorflow import ...} brings only the explicitly listed {@link #namedImports}.
+		 *
+		 * @param name The bare TensorFlow name to test.
+		 * @return True iff {@code name} is reachable under this import shape.
+		 */
+		boolean nameReachable(String name) {
+			return this.allNamesReachable() || this.namedImports().contains(name);
+		}
 	}
 
 	/**
 	 * Returns the {@code input_signature=[tfPrefix + "TensorSpec(...)", ...]} keyword argument when the flag is on and the inference
-	 * produces a signature. Returns {@link Optional#empty} otherwise (flag off, no signature, or {@code TensorSpec} not reachable in the
-	 * import context). The keyword text only; callers handle the surrounding syntax (parenthesization via
-	 * {@link #addInputSignature(int, ImportContext)}, or a leading {@code ", "} when injecting into an existing arg list).
+	 * produces a signature whose names are all reachable under the import context. Returns {@link Optional#empty} otherwise (flag off, no
+	 * signature, {@code TensorSpec} not reachable, or a required dtype constant not reachable). The keyword text only; callers handle the
+	 * surrounding syntax (parenthesization via {@link #addInputSignature(int, ImportContext)}, or a leading {@code ", "} when injecting
+	 * into an existing arg list).
+	 * <p>
+	 * The dtype-reachability check guards the {@code from tensorflow import ...} named-import path: {@code TensorSpec} being in scope does
+	 * not imply the signature's dtype constants (e.g. {@code float32}) are too, so emitting unconditionally would produce a
+	 * {@code NameError}-raising decorator. When any required dtype constant is out of scope, emission is skipped rather than qualified—the
+	 * named-import shape has no module prefix to qualify with.
 	 *
 	 * @param ctx The import context for the containing file.
 	 * @return The {@code input_signature=...} keyword argument, or empty.
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/585">Issue 585</a>
 	 */
 	private Optional<String> computeInputSignatureKeyword(ImportContext ctx) {
 		if (!this.getInferInputSignatures() || !ctx.tensorSpecReachable())
 			return Optional.empty();
-		return this.inferInputSignature().map(sig -> "input_signature=" + sig.toTensorSpecList(ctx.prefix()));
+		return this.inferInputSignature().filter(sig -> sig.requiredDTypeNames().stream().allMatch(ctx::nameReachable))
+				.map(sig -> "input_signature=" + sig.toTensorSpecList(ctx.prefix()));
 	}
 
 	/**
@@ -1937,8 +1963,7 @@ public class Function {
 		// miss a later `import tensorflow as tf` (or a `TensorSpec` in the same statement) that does make the signature emittable (#578).
 		String qualifiedPrefix = null;
 		boolean wildcard = false;
-		boolean functionImported = false;
-		boolean tensorSpecImported = false;
+		Set<String> namedImports = new HashSet<>();
 
 		for (ImportHandle importHandle : handling)
 			for (ImportHandleInfo importHandleInfo : importHandle.getImportInfo()) {
@@ -1951,29 +1976,23 @@ public class Function {
 					else if (importStr.startsWith("tensorflow as"))
 						qualifiedPrefix = importStr.substring("tensorflow as ".length(), importStr.length()) + ".";
 					else if (fromTensorflow)
-						switch (importStr) {
-						case "*": // wildcard: TensorSpec and the dtype constants are reachable unqualified.
+						if (importStr.equals("*")) // wildcard: TensorSpec and the dtype constants are reachable unqualified.
 							wildcard = true;
-							break;
-						case "function":
-							functionImported = true;
-							break;
-						case "TensorSpec":
-							tensorSpecImported = true;
-							break;
-						}
+						else
+							// Every explicitly named symbol, so the gate can check `TensorSpec` and the signature's dtype constants.
+							namedImports.add(importStr);
 			}
 
 		// Precedence: a qualified `import tensorflow [as X]` qualifies `function`, `TensorSpec`, and the dtype constants under one
 		// prefix, so it wins over a named `from`-import that may bring only a subset into scope. A wildcard brings everything
-		// unqualified. Otherwise a named `from tensorflow import ...` makes `function` reachable unqualified, and `TensorSpec` only if
-		// it too was named.
+		// unqualified. Otherwise a named `from tensorflow import ...` makes `function` reachable unqualified, and `TensorSpec` and the
+		// dtype constants only if they too were named.
 		if (qualifiedPrefix != null)
-			return new ImportContext(qualifiedPrefix, true);
+			return new ImportContext(qualifiedPrefix, true, true, Collections.emptySet());
 		if (wildcard)
-			return new ImportContext("", true);
-		if (functionImported)
-			return new ImportContext("", tensorSpecImported);
+			return new ImportContext("", true, true, Collections.emptySet());
+		if (namedImports.contains("function"))
+			return new ImportContext("", namedImports.contains("TensorSpec"), false, namedImports);
 
 		// not found.
 		return null;

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
@@ -2,7 +2,9 @@ package edu.cuny.hunter.hybridize.core.analysis;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
@@ -57,12 +59,37 @@ public record InputSignature(List<TensorType> parameterTypes) {
 				shape = shapeDims.toString();
 			}
 
-			// `Locale.ROOT` so dtype identifiers stay ASCII regardless of the JVM default (Turkish locale lower-cases `I` to a
-			// non-ASCII dotless-i, which would corrupt `INT32` → `ınt32`, `STRING` → `strıng`).
-			String dtype = tfPrefix + t.getDType().name().toLowerCase(Locale.ROOT);
+			String dtype = tfPrefix + dtypeName(t);
 			specs.add(tfPrefix + "TensorSpec(shape=" + shape + ", dtype=" + dtype + ")");
 		}
 
 		return specs.toString();
+	}
+
+	/**
+	 * The set of dtype constant names this signature references (e.g., {@code "float32"}, {@code "int32"}), as the bare Python identifiers
+	 * emitted by {@link #toTensorSpecList(String)} (without any module prefix). The source-write uses this to verify each required dtype
+	 * constant is reachable under the chosen import prefix before emitting an unqualified signature: on the
+	 * {@code from tensorflow import ...} named-import path, {@code TensorSpec} being in scope does not imply the dtype constants are too,
+	 * so an unguarded emission would produce a {@code NameError}-raising decorator.
+	 *
+	 * @return The referenced dtype constant names.
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/585">Issue 585</a>
+	 */
+	public Set<String> requiredDTypeNames() {
+		return parameterTypes.stream().map(InputSignature::dtypeName).collect(Collectors.toUnmodifiableSet());
+	}
+
+	/**
+	 * The bare Python dtype constant identifier for a {@link TensorType} (e.g., {@code "float32"}), without any module prefix.
+	 * <p>
+	 * {@code Locale.ROOT} so dtype identifiers stay ASCII regardless of the JVM default (Turkish locale lower-cases {@code I} to a
+	 * non-ASCII dotless-i, which would corrupt {@code INT32} → {@code ınt32}, {@code STRING} → {@code strıng}).
+	 *
+	 * @param t The tensor type whose dtype constant name to render.
+	 * @return The lower-cased dtype constant identifier.
+	 */
+	private static String dtypeName(TensorType t) {
+		return t.getDType().name().toLowerCase(Locale.ROOT);
 	}
 }

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionNamedImportMissingDType/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionNamedImportMissingDType/in/A.py
@@ -1,0 +1,14 @@
+# Named-import variant where `TensorSpec` is in scope but the dtype constant is not. `from tensorflow import function,
+# TensorSpec, constant` makes `function` and `TensorSpec` reachable, but NOT `float32`. Even though analysis classifies `x`
+# as a tensor and `inferInputSignature` would produce `[TensorSpec(shape=(), dtype=float32)]`, the source-write must skip
+# emission because the `float32` dtype constant is not in scope under this import shape; emitting it unqualified would raise
+# `NameError` at runtime. The generated decorator is a bare `@function`.
+from tensorflow import function, TensorSpec, constant
+
+
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionNamedImportMissingDType/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionNamedImportMissingDType/out/A.py
@@ -1,0 +1,15 @@
+# Named-import variant where `TensorSpec` is in scope but the dtype constant is not. `from tensorflow import function,
+# TensorSpec, constant` makes `function` and `TensorSpec` reachable, but NOT `float32`. Even though analysis classifies `x`
+# as a tensor and `inferInputSignature` would produce `[TensorSpec(shape=(), dtype=float32)]`, the source-write must skip
+# emission because the `float32` dtype constant is not in scope under this import shape; emitting it unqualified would raise
+# `NameError` at runtime. The generated decorator is a bare `@function`.
+from tensorflow import function, TensorSpec, constant
+
+
+@function
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1346,6 +1346,22 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Named-import variant where {@code TensorSpec} is in scope but the dtype constant is not (#585). With
+	 * {@code from tensorflow import function, TensorSpec, constant}, both {@code function} and {@code TensorSpec} are reachable, so the
+	 * {@code tensorSpecReachable} gate passes—but {@code inferInputSignature} produces {@code [TensorSpec(shape=(), dtype=float32)]} and
+	 * {@code float32} is not in scope. The source-write must skip emission rather than emit an unqualified {@code dtype=float32} that would
+	 * raise {@code NameError} at runtime, producing a bare {@code @function}. Exercises the dtype-reachability gate in
+	 * {@code computeInputSignatureKeyword}, distinct from the {@code TensorSpec}-not-reachable gate of
+	 * {@link #testInferInputSignatureEmissionNamedImport()}.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/585">Issue 585</a>
+	 */
+	@Test
+	public void testInferInputSignatureEmissionNamedImportMissingDType() throws Exception {
+		helperAssertInputSignatureEmission();
+	}
+
+	/**
 	 * Runs the refactoring on the current test's fixture and asserts the produced source matches the expected {@code out/A.py}. The single
 	 * fixture function must be eager pre-refactoring, select {@link Transformation#CONVERT_TO_HYBRID}, and carry the harness-enabled
 	 * {@code inferInputSignatures} flag. Shared by the input-signature emission tests, which differ only in their import-shape fixture.


### PR DESCRIPTION
Closes #585.

Follow-up from #578/#586. With the full-pass `getImportContext`, a named `from tensorflow import function, TensorSpec` makes the source-write emit an *unqualified* signature. But the emitted `dtype=<name>` constant (e.g. `float32`, `int32`) must also be importable unqualified — and `getImportContext` marked `tensorSpecReachable` from the presence of `TensorSpec` alone, blind to the inferred dtype (only known later, in `computeInputSignatureKeyword`). A file importing `function` and `TensorSpec` but not the specific dtype constant emitted a `NameError`-raising decorator.

This bit only the named-`from`-import path: the qualified path (`import tensorflow as tf` qualifies `tf.float32` too) and the wildcard path (brings every dtype constant) were already correct.

## Fix

- `getImportContext` now collects the full set of names a `from tensorflow import ...` brings into scope, threaded into `ImportContext` alongside an `allNamesReachable` flag (true for qualified and wildcard shapes).
- `InputSignature.requiredDTypeNames` exposes the dtype constants a signature references.
- The emission gate in `computeInputSignatureKeyword` skips when any required dtype constant is out of scope. The named-import shape has no module prefix to qualify with, so skipping is the only safe option; qualified and wildcard shapes are unaffected.

## Testing

New `testInferInputSignatureEmissionNamedImportMissingDType`: `from tensorflow import function, TensorSpec, constant` (no `float32`) now emits a bare `@function` instead of a `NameError`-raising decorator. The full `HybridizeFunctionRefactoringTest` class (501) and `InputSignatureTest` (10) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)