### PR TITLE
Auto-inject `TensorSpec` and `dtype` constants for signature emission

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -28,8 +28,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -351,9 +353,13 @@ public class Function {
 	public static final String PLUGIN_ID = FrameworkUtil.getBundle(Function.class).getSymbolicName();
 
 	/**
-	 * Containing {@link File}s that have had import statements added to them during transformation.
+	 * Containing {@link File}s that have had an import statement auto-injected during transformation, mapped to the bare TensorFlow names
+	 * that injection brought into scope (always {@code function}, plus {@code TensorSpec} and the inferred signature's dtype constants when
+	 * input-signature emission applies). The first hybridizable function in a file to need an injected import fixes the injected line;
+	 * later functions in the same file reuse the recorded name set, so their emission gate ({@link #computeInputSignatureKeyword}) sees
+	 * exactly what is in scope.
 	 */
-	private static Set<File> filesWithAddedImport = new HashSet<>();
+	private static Map<File, Set<String>> autoInjectedImportNames = new HashMap<>();
 
 	private static final String TF_FUNCTION_FQN = "tensorflow.python.eager.def_function.function";
 
@@ -463,7 +469,7 @@ public class Function {
 	public static void clearCaches() {
 		creationsCache.clear();
 		Parameter.clearCaches();
-		filesWithAddedImport.clear();
+		autoInjectedImportNames.clear();
 	}
 
 	/**
@@ -1846,23 +1852,39 @@ public class Function {
 		ImportContext ctx = getImportContext(doc);
 
 		if (ctx == null) {
-			// need to add an import if it doesn't already exist.
+			// No TensorFlow import in scope: auto-inject one. The first hybridizable function in the file fixes the injected line and
+			// records which names it brings into scope; later functions in the same file reuse that record (#574).
 			File file = this.getContainingFile();
+			Set<String> injectedNames = autoInjectedImportNames.get(file);
 
-			if (!filesWithAddedImport.contains(file)) {
+			if (injectedNames == null) {
+				// `function` is always needed for the decorator. When input-signature emission applies, also bring `TensorSpec` and the
+				// signature's dtype constants into scope so the emission proceeds unqualified rather than being skipped. The dtype
+				// constants are sorted for deterministic emission; `function` and `TensorSpec` lead to match the conventional spelling.
+				Set<String> names = new LinkedHashSet<>();
+				names.add("function");
+
+				if (this.getInferInputSignatures())
+					this.inferInputSignature().ifPresent(sig -> {
+						names.add("TensorSpec");
+						sig.requiredDTypeNames().stream().sorted().forEach(names::add);
+					});
+
 				int line = getLineToInsertImport(doc);
 				int lineOffset = doc.getLineOffset(line);
 
-				TextEdit edit = new InsertEdit(lineOffset, "from tensorflow import function\n");
+				TextEdit edit = new InsertEdit(lineOffset, "from tensorflow import " + String.join(", ", names) + "\n");
 				MultiTextEdit mte = new MultiTextEdit();
 				mte.addChild(edit);
 				ret.add(mte);
-				filesWithAddedImport.add(file);
+				autoInjectedImportNames.put(file, names);
+				injectedNames = names;
 			}
 
-			// The auto-injected `from tensorflow import function` makes only `function` reachable; `TensorSpec` is not. Extending
-			// the auto-inject to cover the signature's required symbols is tracked separately.
-			ctx = new ImportContext("", false, false, Collections.emptySet());
+			// Emission is reachable iff this function's required names are among those the injected line brought into scope; the
+			// `computeInputSignatureKeyword` gate enforces that, so a later function needing a dtype the first did not inject is
+			// safely skipped rather than emitting a `NameError`-raising decorator.
+			ctx = new ImportContext("", injectedNames.contains("TensorSpec"), false, injectedNames);
 		}
 
 		MultiTextEdit mte = new MultiTextEdit();

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionAutoInjectImport/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionAutoInjectImport/in/A.py
@@ -1,0 +1,13 @@
+# Auto-inject variant (#574): the file has no TensorFlow import at all, but `x` is typed as a tensor via `np.ones` (Ariadne
+# types `np.ones`/`np.zeros` as tensors). The source-write injects `from tensorflow import function, TensorSpec, <dtype>` so
+# the inferred `input_signature` can be emitted unqualified, rather than injecting a bare `from tensorflow import function`
+# and skipping emission for lack of `TensorSpec`/dtype scope.
+import numpy as np
+
+
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(np.ones((2, 3)))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionAutoInjectImport/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferInputSignatureEmissionAutoInjectImport/out/A.py
@@ -1,0 +1,15 @@
+# Auto-inject variant (#574): the file has no TensorFlow import at all, but `x` is typed as a tensor via `np.ones` (Ariadne
+# types `np.ones`/`np.zeros` as tensors). The source-write injects `from tensorflow import function, TensorSpec, <dtype>` so
+# the inferred `input_signature` can be emitted unqualified, rather than injecting a bare `from tensorflow import function`
+# and skipping emission for lack of `TensorSpec`/dtype scope.
+import numpy as np
+from tensorflow import function, TensorSpec, float64
+
+
+@function(input_signature=[TensorSpec(shape=(2, 3), dtype=float64)])
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(np.ones((2, 3)))

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1362,6 +1363,19 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Auto-inject variant (#574). The fixture has no TensorFlow import at all, but {@code x} is tensor-typed via {@code np.ones}. The
+	 * source-write must inject a {@code from tensorflow import ...} line carrying {@code function}, {@code TensorSpec}, and the inferred
+	 * signature's dtype constant, then emit the unqualified {@code input_signature}—rather than injecting a bare
+	 * {@code from tensorflow import function} and skipping emission for lack of {@code TensorSpec}/dtype scope.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/574">Issue 574</a>
+	 */
+	@Test
+	public void testInferInputSignatureEmissionAutoInjectImport() throws Exception {
+		helperAssertInputSignatureEmission();
+	}
+
+	/**
 	 * Runs the refactoring on the current test's fixture and asserts the produced source matches the expected {@code out/A.py}. The single
 	 * fixture function must be eager pre-refactoring, select {@link Transformation#CONVERT_TO_HYBRID}, and carry the harness-enabled
 	 * {@code inferInputSignatures} flag. Shared by the input-signature emission tests, which differ only in their import-shape fixture.
@@ -1381,7 +1395,12 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		// `TextFileBufferManager`. Tracked at #359. When that lands, these tests can collapse to setting `compareOutputTestFile`.
 		IDocument doc = f.getContainingDocument();
 
-		for (TextEdit edit : f.transform())
+		// Apply highest-offset edits first so an inserted import (low offset) does not shift the unapplied decorator edit's anchor. In
+		// production the edits compose in one LTK change tree, which coordinates offsets; this loop applies them as independent trees.
+		List<TextEdit> edits = new ArrayList<>(f.transform());
+		edits.sort(Comparator.comparingInt(TextEdit::getOffset).reversed());
+
+		for (TextEdit edit : edits)
 			edit.apply(doc);
 
 		String expected = this.getFileContents(this.getOutputTestFileName("A"));


### PR DESCRIPTION
Closes #574.

When `Function.convertToHybrid` finds no TensorFlow import in the source file, it auto-injects one and proceeds. It previously injected a bare `from tensorflow import function`, leaving `TensorSpec` and the dtype constants out of scope, so the input-signature gate skipped emission. Users running the refactoring on files with no prior TensorFlow import (a small but real population) got no inferred `input_signature`, unlike the `import tensorflow as tf` and `from tensorflow import *` shapes.

## Fix

- Extend the auto-inject to bring the signature's required symbols into scope: `from tensorflow import function, TensorSpec, <dtypes>` (dtype constants sorted for deterministic emission).
- Replace the per-file `Set<File>` injection guard with a `Map<File, Set<String>>` recording which names each file's injection brought into scope, and build the `ImportContext` from that record. A later function in the same file emits when its dtypes are covered and is safely skipped by the #585 reachability gate otherwise — never a `NameError`-raising decorator.
- Injecting the union of all functions' dtypes per file (so divergent-dtype functions all emit) is left to #588.

A pre-existing emission-test-helper limitation surfaced: it applied the transform's `TextEdit`s as independent trees, so an injected import (low offset) shifted the unapplied decorator edit's anchor, corrupting output. The helper now applies edits highest-offset-first; production composes them in one LTK change tree, which coordinates offsets.

## Testing

New `testInferInputSignatureEmissionAutoInjectImport`: a file with no TensorFlow import and an `np.ones`-typed parameter now injects `from tensorflow import function, TensorSpec, float64` and emits `@function(input_signature=[TensorSpec(shape=(2, 3), dtype=float64)])`. Verified runtime-correct under python3.10 — the output imports resolve and tf.function accepts `np.ones((2, 3))` against the emitted signature. Full `HybridizeFunctionRefactoringTest` (502) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)