### PR TITLE
Tidy the `inferInputSignatures` test harness field

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -591,6 +591,16 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		return this.inferInputSignatures;
 	}
 
+	/**
+	 * Sets whether inferred input signatures should be emitted into the refactored source. The input-signature emission tests call this to
+	 * opt in (the flag is off by default suite-wide, #580).
+	 *
+	 * @param inferInputSignatures Whether inferred input signatures should be emitted.
+	 */
+	public void setInferInputSignatures(boolean inferInputSignatures) {
+		this.inferInputSignatures = inferInputSignatures;
+	}
+
 	@Override
 	public void genericafter() throws Exception {
 		// Do nothing.
@@ -1398,7 +1408,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	private void helperAssertInputSignatureEmission() throws Exception {
 		// Emission is opt-in per test (off by default suite-wide; see #580). The input-signature emission tests enable it here.
-		this.inferInputSignatures = true;
+		this.setInferInputSignatures(true);
 
 		Set<Function> functions = this.getFunctions();
 		assertEquals(1, functions.size());

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -533,7 +533,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 * suite's compare-output fixtures are unaffected by emission; the input-signature emission tests opt in through
 	 * {@link #helperAssertInputSignatureEmission()}. Production gating is tracked at #481.
 	 */
-	protected boolean inferInputSignatures = false;
+	protected boolean inferInputSignatures;
 
 	private Entry<SimpleNode, IDocument> createPythonNodeFromTestFile(String fileNameWithoutExtension)
 			throws IOException, MisconfigurationException {


### PR DESCRIPTION
Post-merge review follow-ups on #590.

- Drop the redundant `= false` initializer — instance `boolean` fields default to `false`.
- Add a `setInferInputSignatures` mutator and call it from `helperAssertInputSignatureEmission`, rather than assigning the `protected` field directly.

Test-harness only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)