### PR TITLE
Parse the keyword-form `input_signature` argument of `@tf.function`

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -392,11 +392,11 @@ public class Function {
 		 * or tuple of {@code tf.TensorSpec(...)} calls; each element is reduced to a {@link TensorType} via {@link #parseTensorSpec}. The
 		 * parse is all-or-nothing: if any element cannot be fully modeled (an unsupported subtype, a non-{@code TensorSpec} call, or
 		 * malformed content), the whole signature is dropped to {@link Optional#empty} rather than producing a partial signature that
-		 * downstream validate-then-overwrite logic could not trust.
+		 * downstream validate-then-overwrite logic could not trust. A well-formed empty list/tuple ({@code input_signature=[]}, a no-arg
+		 * function) is itself fully modeled and parses to a present, empty {@link InputSignature}.
 		 *
 		 * @param value The expression bound to the {@code input_signature} keyword.
-		 * @return The parsed signature, or {@link Optional#empty} if the value is not a non-empty list/tuple of fully modeled
-		 *         {@code TensorSpec}s.
+		 * @return The parsed signature, or {@link Optional#empty} if the value is not a list/tuple of fully modeled {@code TensorSpec}s.
 		 */
 		private static Optional<InputSignature> parseSuppliedInputSignature(exprType value) {
 			exprType[] elements;
@@ -407,16 +407,16 @@ public class Function {
 			else
 				return Optional.empty();
 
-			if (elements == null || elements.length == 0)
-				return Optional.empty();
-
-			List<TensorType> parameterTypes = new ArrayList<>(elements.length);
-			for (exprType element : elements) {
-				Optional<TensorType> tensorType = parseTensorSpec(element);
-				if (tensorType.isEmpty())
-					return Optional.empty();
-				parameterTypes.add(tensorType.get());
-			}
+			// A well-formed empty list/tuple is `input_signature=[]` (a no-arg function); it parses to an empty—but present—signature
+			// rather than dropping to empty, which the contract reserves for a supplied signature that cannot be modeled.
+			List<TensorType> parameterTypes = new ArrayList<>(elements == null ? 0 : elements.length);
+			if (elements != null)
+				for (exprType element : elements) {
+					Optional<TensorType> tensorType = parseTensorSpec(element);
+					if (tensorType.isEmpty())
+						return Optional.empty();
+					parameterTypes.add(tensorType.get());
+				}
 
 			return Optional.of(new InputSignature(parameterTypes));
 		}

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -73,7 +74,10 @@ import org.python.pydev.parser.jython.SimpleNode;
 import org.python.pydev.parser.jython.ast.Call;
 import org.python.pydev.parser.jython.ast.ClassDef;
 import org.python.pydev.parser.jython.ast.FunctionDef;
+import org.python.pydev.parser.jython.ast.Name;
 import org.python.pydev.parser.jython.ast.NameTok;
+import org.python.pydev.parser.jython.ast.Num;
+import org.python.pydev.parser.jython.ast.Tuple;
 import org.python.pydev.parser.jython.ast.argumentsType;
 import org.python.pydev.parser.jython.ast.decoratorsType;
 import org.python.pydev.parser.jython.ast.exprType;
@@ -204,6 +208,13 @@ public class Function {
 		private boolean inputSignatureParam;
 
 		/**
+		 * The {@link InputSignature} parsed from a keyword-form {@code input_signature=[tf.TensorSpec(...)]} argument supplied to this
+		 * {@link Function}'s {@code @tf.function} decorator, or {@link Optional#empty} when none was supplied or its content could not be
+		 * fully modeled. See {@link #getSuppliedInputSignature()} for the presence/parse contract.
+		 */
+		private Optional<InputSignature> suppliedInputSignature = Optional.empty();
+
+		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter jit_compile.
 		 */
 		private boolean jitCompileParam;
@@ -246,6 +257,11 @@ public class Function {
 					if (keyword.arg instanceof NameTok) {
 						NameTok name = (NameTok) keyword.arg;
 						this.markParam(name.id);
+
+						// Parse the content of a keyword-form `input_signature=[tf.TensorSpec(...)]`. Positional binding (#573) is not
+						// handled here; only the keyword form contributes a parsed signature in this pass.
+						if (INPUT_SIGNATURE.equals(name.id))
+							this.suppliedInputSignature = parseSuppliedInputSignature(keyword.value);
 					}
 			} // else, tf.function is used without parameters.
 		}
@@ -328,6 +344,32 @@ public class Function {
 		}
 
 		/**
+		 * The {@link InputSignature} parsed from a keyword-form {@code input_signature=[tf.TensorSpec(...)]} argument supplied to this
+		 * {@link Function}'s {@code @tf.function} decorator.
+		 * <p>
+		 * This getter and {@link #hasInputSignatureParam()} together carry a three-state contract that downstream reconfiguration must
+		 * honor to avoid clobbering a user's signature:
+		 * <ul>
+		 * <li>{@code hasInputSignatureParam() == false}: no {@code input_signature} was supplied. Inference may synthesize one and write
+		 * it.
+		 * <li>{@code hasInputSignatureParam() == true} and the result is <em>present</em>: a signature was supplied <em>and</em> fully
+		 * modeled. A validate-then-overwrite decision can compare it against the inferred signature.
+		 * <li>{@code hasInputSignatureParam() == true} and the result is <em>empty</em>: a signature was supplied but could not be fully
+		 * modeled (an unsupported {@code TensorSpec} subtype such as {@code RaggedTensorSpec}/{@code SparseTensorSpec}—tracked by #524 and
+		 * #533—or malformed content). It must be left as-is, never overwritten.
+		 * </ul>
+		 * An empty result therefore does <em>not</em> mean "no signature supplied"; callers must consult {@link #hasInputSignatureParam()}
+		 * for that distinction. Only the keyword form is parsed; positional binding is tracked by #573.
+		 *
+		 * @return The parsed supplied input signature, or {@link Optional#empty} when none was supplied or its content could not be fully
+		 *         modeled.
+		 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/557">Issue 557</a>
+		 */
+		public Optional<InputSignature> getSuppliedInputSignature() {
+			return this.suppliedInputSignature;
+		}
+
+		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter jit_compile.
 		 *
 		 * @return True iff this {@link decoratorsType} has parameter jit_compile.
@@ -343,6 +385,156 @@ public class Function {
 		 */
 		public boolean hasReduceRetracingParam() {
 			return this.reduceRetracingParam;
+		}
+
+		/**
+		 * Parse the value of a keyword-form {@code input_signature=...} argument into an {@link InputSignature}. The value must be a list
+		 * or tuple of {@code tf.TensorSpec(...)} calls; each element is reduced to a {@link TensorType} via {@link #parseTensorSpec}. The
+		 * parse is all-or-nothing: if any element cannot be fully modeled (an unsupported subtype, a non-{@code TensorSpec} call, or
+		 * malformed content), the whole signature is dropped to {@link Optional#empty} rather than producing a partial signature that
+		 * downstream validate-then-overwrite logic could not trust.
+		 *
+		 * @param value The expression bound to the {@code input_signature} keyword.
+		 * @return The parsed signature, or {@link Optional#empty} if the value is not a non-empty list/tuple of fully modeled
+		 *         {@code TensorSpec}s.
+		 */
+		private static Optional<InputSignature> parseSuppliedInputSignature(exprType value) {
+			exprType[] elements;
+			if (value instanceof org.python.pydev.parser.jython.ast.List)
+				elements = ((org.python.pydev.parser.jython.ast.List) value).elts;
+			else if (value instanceof Tuple)
+				elements = ((Tuple) value).elts;
+			else
+				return Optional.empty();
+
+			if (elements == null || elements.length == 0)
+				return Optional.empty();
+
+			List<TensorType> parameterTypes = new ArrayList<>(elements.length);
+			for (exprType element : elements) {
+				Optional<TensorType> tensorType = parseTensorSpec(element);
+				if (tensorType.isEmpty())
+					return Optional.empty();
+				parameterTypes.add(tensorType.get());
+			}
+
+			return Optional.of(new InputSignature(parameterTypes));
+		}
+
+		/**
+		 * Parse a single {@code tf.TensorSpec(shape, dtype)} call into a {@link TensorType}. The call's callee must name {@code TensorSpec}
+		 * exactly; {@code RaggedTensorSpec}/{@code SparseTensorSpec} and any other callee return {@link Optional#empty} because the current
+		 * {@link InputSignature} model cannot represent them (tracked by #524 and #533). Both the positional form
+		 * {@code TensorSpec(shape, dtype)} and the keyword form {@code TensorSpec(shape=..., dtype=...)} are accepted.
+		 *
+		 * @param element A candidate {@code TensorSpec} expression from the supplied list/tuple.
+		 * @return The reduced {@link TensorType}, or {@link Optional#empty} if {@code element} is not a fully modeled {@code TensorSpec}
+		 *         call.
+		 */
+		private static Optional<TensorType> parseTensorSpec(exprType element) {
+			if (!(element instanceof Call))
+				return Optional.empty();
+
+			Call call = (Call) element;
+			// `getRepresentationString` returns the trailing attribute, so `tf.TensorSpec` and a bare `TensorSpec` both yield
+			// "TensorSpec"; `RaggedTensorSpec`/`SparseTensorSpec` yield their own names and are rejected below.
+			if (!"TensorSpec".equals(NodeUtils.getRepresentationString(call.func)))
+				return Optional.empty();
+
+			exprType shapeExpr = argumentValue(call, 0, "shape");
+			exprType dtypeExpr = argumentValue(call, 1, "dtype");
+			if (shapeExpr == null || dtypeExpr == null)
+				return Optional.empty();
+
+			Optional<DType> dtype = parseDType(dtypeExpr);
+			if (dtype.isEmpty())
+				return Optional.empty();
+
+			return parseShape(shapeExpr).map(shape -> new TensorType(dtype.get(), shape.orElse(null)));
+		}
+
+		/**
+		 * Resolve a {@code TensorSpec} argument by either positional index or keyword name. Positional arguments take precedence, matching
+		 * Python's binding rules; if no positional argument occupies {@code position}, the keyword arguments are searched for {@code name}.
+		 *
+		 * @param call The {@code TensorSpec} call.
+		 * @param position The positional index of the argument.
+		 * @param name The keyword name of the argument.
+		 * @return The bound expression, or {@code null} when neither form supplies the argument.
+		 */
+		private static exprType argumentValue(Call call, int position, String name) {
+			if (call.args != null && position < call.args.length)
+				return call.args[position];
+
+			if (call.keywords != null)
+				for (keywordType keyword : call.keywords)
+					if (keyword.arg instanceof NameTok && name.equals(((NameTok) keyword.arg).id))
+						return keyword.value;
+
+			return null;
+		}
+
+		/**
+		 * Parse a {@code TensorSpec} shape expression into a dimension list. A list/tuple yields one {@link Dimension} per element:
+		 * {@code None} becomes {@link DynamicDim#INSTANCE} and an integer literal becomes a {@link NumericDim}; any other element fails the
+		 * parse. A bare {@code None} (i.e., {@code shape=None}) yields {@link Optional#empty} dims, the shape-&#8868; encoding
+		 * {@link Function#inferSpec} and {@link InputSignature#toTensorSpecList} already use for unknown rank.
+		 *
+		 * @param shapeExpr The expression bound to the {@code shape} argument.
+		 * @return An {@link Optional} holding the dimension list (empty inner {@link Optional} for {@code shape=None}), or
+		 *         {@link Optional#empty} (outer) when the shape cannot be modeled.
+		 */
+		private static Optional<Optional<List<Dimension<?>>>> parseShape(exprType shapeExpr) {
+			if (shapeExpr instanceof Name && "None".equals(((Name) shapeExpr).id))
+				// Shape-⊤: unknown rank. Represented as null dims downstream.
+				return Optional.of(Optional.empty());
+
+			exprType[] elements;
+			if (shapeExpr instanceof org.python.pydev.parser.jython.ast.List)
+				elements = ((org.python.pydev.parser.jython.ast.List) shapeExpr).elts;
+			else if (shapeExpr instanceof Tuple)
+				elements = ((Tuple) shapeExpr).elts;
+			else
+				return Optional.empty();
+
+			List<Dimension<?>> dimensions = new ArrayList<>(elements == null ? 0 : elements.length);
+			if (elements != null)
+				for (exprType element : elements) {
+					if (element instanceof Name && "None".equals(((Name) element).id)) {
+						dimensions.add(DynamicDim.INSTANCE);
+						continue;
+					}
+					if (element instanceof Num) {
+						try {
+							dimensions.add(new NumericDim(Integer.valueOf(((Num) element).num.trim())));
+							continue;
+						} catch (NumberFormatException _) {
+							return Optional.empty();
+						}
+					}
+					return Optional.empty();
+				}
+
+			return Optional.of(Optional.of(dimensions));
+		}
+
+		/**
+		 * Parse a {@code TensorSpec} dtype expression (e.g., {@code tf.float32} or a bare {@code float32}) into a {@link DType}. The
+		 * trailing attribute name is upper-cased and resolved against {@link DType#valueOf}; this inverts {@link InputSignature}'s
+		 * lower-casing of {@link DType#name()}. An unrecognized name yields {@link Optional#empty}.
+		 *
+		 * @param dtypeExpr The expression bound to the {@code dtype} argument.
+		 * @return The resolved {@link DType}, or {@link Optional#empty} when the name is not a modeled dtype.
+		 */
+		private static Optional<DType> parseDType(exprType dtypeExpr) {
+			String name = NodeUtils.getRepresentationString(dtypeExpr);
+			if (name == null)
+				return Optional.empty();
+			try {
+				return Optional.of(DType.valueOf(name.toUpperCase(Locale.ROOT)));
+			} catch (IllegalArgumentException _) {
+				return Optional.empty();
+			}
 		}
 	}
 

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureAbsent/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureAbsent/in/A.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+
+
+@tf.function
+def func(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    func(tf.ones([2, 2]))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureAbsent/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureAbsent/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureConcrete/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureConcrete/in/A.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec([2, 2], tf.float32)])
+def func(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    func(tf.ones([2, 2]))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureConcrete/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureConcrete/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureDynamicDim/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureDynamicDim/in/A.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=[None, 32], dtype=tf.float32)])
+def func(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    func(tf.ones([4, 32]))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureDynamicDim/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureDynamicDim/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureEmptyList/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureEmptyList/in/A.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+
+
+@tf.function(input_signature=[])
+def func():
+    return tf.constant(1)
+
+
+if __name__ == "__main__":
+    func()

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureEmptyList/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureEmptyList/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureKeywordForm/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureKeywordForm/in/A.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(5,), dtype=tf.int32)])
+def func(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    func(tf.ones([5], dtype=tf.int32))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureKeywordForm/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureKeywordForm/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureMultipleParameters/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureMultipleParameters/in/A.py
@@ -1,0 +1,12 @@
+import tensorflow as tf
+
+
+@tf.function(
+    input_signature=[tf.TensorSpec((2, 3), tf.float32), tf.TensorSpec((5,), tf.int32)]
+)
+def func(a, b):
+    return a, b
+
+
+if __name__ == "__main__":
+    func(tf.ones([2, 3]), tf.ones([5], dtype=tf.int32))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureMultipleParameters/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureMultipleParameters/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureRaggedSpec/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureRaggedSpec/in/A.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+
+@tf.function(
+    input_signature=[
+        tf.RaggedTensorSpec(shape=[2, None], dtype=tf.int32, ragged_rank=1)
+    ]
+)
+def func(t):
+    return t
+
+
+if __name__ == "__main__":
+    func(tf.ragged.constant([[1, 2], [3]]))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureRaggedSpec/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureRaggedSpec/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureScalar/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureScalar/in/A.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.int32)])
+def func(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    func(tf.constant(3))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureScalar/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureScalar/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureShapeNone/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureShapeNone/in/A.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=None, dtype=tf.float32)])
+def func(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    func(tf.ones([2, 2]))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureShapeNone/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureShapeNone/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureUnmodeledDType/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureUnmodeledDType/in/A.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(2,), dtype=tf.complex64)])
+def func(t):
+    return t
+
+
+if __name__ == "__main__":
+    func(tf.constant([1 + 2j, 3 + 4j], dtype=tf.complex64))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureUnmodeledDType/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testSuppliedInputSignatureUnmodeledDType/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -991,6 +991,21 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Test for #557. A well-formed empty {@code input_signature=[]} (a no-arg function) is itself fully modeled: it parses to a present,
+	 * empty {@link InputSignature}, distinct from the presence-true/parse-empty "unmodelable" state.
+	 */
+	@Test
+	public void testSuppliedInputSignatureEmptyList() throws Exception {
+		Function.HybridizationParameters args = this.getSingleHybridizationParameters();
+
+		assertTrue(args.hasInputSignatureParam());
+
+		Optional<InputSignature> signature = args.getSuppliedInputSignature();
+		assertTrue(signature.isPresent());
+		assertEquals(List.of(), signature.get().parameterTypes());
+	}
+
+	/**
 	 * Test for #557. A {@code None} entry in a {@code TensorSpec} shape parses to {@link DynamicDim#INSTANCE}, mixed with a concrete
 	 * {@link NumericDim}.
 	 */

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -927,6 +927,157 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Returns the {@code Function.HybridizationParameters} of the single hybrid {@link Function} in the test file A.py.
+	 *
+	 * @return The hybridization parameters of the sole analyzed {@link Function}.
+	 */
+	private Function.HybridizationParameters getSingleHybridizationParameters() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertNotNull(functions);
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+		assertNotNull(function);
+		assertTrue(function.isHybrid());
+		Function.HybridizationParameters args = function.getHybridizationParameters();
+		assertNotNull(args);
+		return args;
+	}
+
+	/**
+	 * Test for #557. A concrete, fully modeled keyword-form {@code input_signature=[tf.TensorSpec([2, 2], tf.float32)]} parses into a
+	 * single rank-2 {@code float32} {@link TensorType}. The shape and dtype are supplied positionally <em>within</em> the
+	 * {@code TensorSpec} call.
+	 */
+	@Test
+	public void testSuppliedInputSignatureConcrete() throws Exception {
+		Function.HybridizationParameters args = this.getSingleHybridizationParameters();
+
+		assertTrue(args.hasInputSignatureParam());
+
+		Optional<InputSignature> signature = args.getSuppliedInputSignature();
+		assertTrue(signature.isPresent());
+		assertEquals(List.of(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2)))), signature.get().parameterTypes());
+	}
+
+	/**
+	 * Test for #557. The keyword form {@code tf.TensorSpec(shape=(5,), dtype=tf.int32)} binds shape and dtype by name rather than by
+	 * position; both forms must resolve to the same {@link TensorType}.
+	 */
+	@Test
+	public void testSuppliedInputSignatureKeywordForm() throws Exception {
+		Function.HybridizationParameters args = this.getSingleHybridizationParameters();
+
+		assertTrue(args.hasInputSignatureParam());
+
+		Optional<InputSignature> signature = args.getSuppliedInputSignature();
+		assertTrue(signature.isPresent());
+		assertEquals(List.of(new TensorType(INT32, List.of(new NumericDim(5)))), signature.get().parameterTypes());
+	}
+
+	/**
+	 * Test for #557. A two-element {@code input_signature} list with differing dtypes parses into two {@link TensorType}s in declaration
+	 * order.
+	 */
+	@Test
+	public void testSuppliedInputSignatureMultipleParameters() throws Exception {
+		Function.HybridizationParameters args = this.getSingleHybridizationParameters();
+
+		assertTrue(args.hasInputSignatureParam());
+
+		Optional<InputSignature> signature = args.getSuppliedInputSignature();
+		assertTrue(signature.isPresent());
+		assertEquals(List.of(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))),
+				new TensorType(INT32, List.of(new NumericDim(5)))), signature.get().parameterTypes());
+	}
+
+	/**
+	 * Test for #557. A {@code None} entry in a {@code TensorSpec} shape parses to {@link DynamicDim#INSTANCE}, mixed with a concrete
+	 * {@link NumericDim}.
+	 */
+	@Test
+	public void testSuppliedInputSignatureDynamicDim() throws Exception {
+		Function.HybridizationParameters args = this.getSingleHybridizationParameters();
+
+		assertTrue(args.hasInputSignatureParam());
+
+		Optional<InputSignature> signature = args.getSuppliedInputSignature();
+		assertTrue(signature.isPresent());
+		assertEquals(List.of(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(32)))), signature.get().parameterTypes());
+	}
+
+	/**
+	 * Test for #557. A scalar (rank-0) {@code TensorSpec} with an empty shape tuple parses to a {@link TensorType} with an empty dimension
+	 * list.
+	 */
+	@Test
+	public void testSuppliedInputSignatureScalar() throws Exception {
+		Function.HybridizationParameters args = this.getSingleHybridizationParameters();
+
+		assertTrue(args.hasInputSignatureParam());
+
+		Optional<InputSignature> signature = args.getSuppliedInputSignature();
+		assertTrue(signature.isPresent());
+		assertEquals(List.of(new TensorType(INT32, List.of())), signature.get().parameterTypes());
+	}
+
+	/**
+	 * Test for #557. A bare {@code shape=None} (unknown rank) parses to a {@link TensorType} with {@code null} dimensions, the shape-⊤
+	 * encoding used elsewhere in the tool.
+	 */
+	@Test
+	public void testSuppliedInputSignatureShapeNone() throws Exception {
+		Function.HybridizationParameters args = this.getSingleHybridizationParameters();
+
+		assertTrue(args.hasInputSignatureParam());
+
+		Optional<InputSignature> signature = args.getSuppliedInputSignature();
+		assertTrue(signature.isPresent());
+		assertEquals(1, signature.get().parameterTypes().size());
+		TensorType tensorType = signature.get().parameterTypes().get(0);
+		assertEquals(FLOAT32, tensorType.getDType());
+		assertNull(tensorType.getDims());
+	}
+
+	/**
+	 * Test for #557. A {@code RaggedTensorSpec} element is supplied (so {@code hasInputSignatureParam()} is true), but the current
+	 * {@link InputSignature} model cannot represent raggedness, so the parse drops to {@link Optional#empty}. This pins the
+	 * presence-true/parse-empty state of the contract: a supplied-but-unmodelable signature must be left as-is, not overwritten. Ragged
+	 * emission is tracked separately at #524.
+	 */
+	@Test
+	public void testSuppliedInputSignatureRaggedSpec() throws Exception {
+		Function.HybridizationParameters args = this.getSingleHybridizationParameters();
+
+		assertTrue(args.hasInputSignatureParam());
+		assertFalse(args.getSuppliedInputSignature().isPresent());
+	}
+
+	/**
+	 * Test for #557. A valid TensorFlow dtype the tool does not model ({@code tf.complex64}) is supplied; the parse drops the whole
+	 * signature to {@link Optional#empty} while {@code hasInputSignatureParam()} stays true (the presence-true/parse-empty contract state).
+	 */
+	@Test
+	public void testSuppliedInputSignatureUnmodeledDType() throws Exception {
+		Function.HybridizationParameters args = this.getSingleHybridizationParameters();
+
+		assertTrue(args.hasInputSignatureParam());
+		assertFalse(args.getSuppliedInputSignature().isPresent());
+	}
+
+	/**
+	 * Test for #557. A bare {@code @tf.function} with no {@code input_signature} argument: presence is false and the parsed signature is
+	 * {@link Optional#empty}. This pins the presence-false state of the contract, distinguishing "no signature supplied" (safe to infer and
+	 * write) from "supplied but unmodelable" (leave as-is).
+	 */
+	@Test
+	public void testSuppliedInputSignatureAbsent() throws Exception {
+		Function.HybridizationParameters args = this.getSingleHybridizationParameters();
+
+		assertFalse(args.hasInputSignatureParam());
+		assertFalse(args.getSuppliedInputSignature().isPresent());
+	}
+
+	/**
 	 * Test for #108. Positional `input_signature` argument: `@tf.function(None, (tf.TensorSpec(...),))` passes `func=None` and
 	 * `input_signature=(...)` positionally. We expect both `hasFuncParam` and `hasInputSignatureParam` to be true (the position-0 `func`
 	 * slot is occupied even though its value is `None`; presence of the positional slot is what's detected, not its value).


### PR DESCRIPTION
Reads the content of a keyword-form `input_signature=[tf.TensorSpec(...)]` decorator argument into an `InputSignature` (an ordered tuple of `TensorType`s) and exposes it via `HybridizationParameters.getSuppliedInputSignature()`. Until now only the argument's presence was detected (`hasInputSignatureParam()`); its content was never parsed, so the inference path ignored a signature the user had already declared.

## Behavior

Both the positional form `TensorSpec(shape, dtype)` and the keyword form `TensorSpec(shape=..., dtype=...)` are accepted within each spec. Shape lists/tuples map per element: integer literals become `NumericDim`, `None` becomes `DynamicDim`; a bare `shape=None` becomes unknown rank (null dims). Dtypes (`tf.float32`, bare `float32`) resolve against the modeled `DType` set.

The parse is all-or-nothing: any element that cannot be fully modeled drops the whole signature to empty. That covers unsupported `TensorSpec` subtypes (`RaggedTensorSpec`/`SparseTensorSpec`), a non-`TensorSpec` callee, an unmodeled dtype, or malformed content.

## Presence/Parse Contract

The new getter and `hasInputSignatureParam()` together carry three states, documented on the getter so downstream reconfiguration does not clobber a user's signature:

- presence false: no `input_signature` supplied — safe to infer and write.
- presence true, parse present: supplied and fully modeled — eligible for validate-then-overwrite.
- presence true, parse empty: supplied but not representable — leave as-is, never overwrite.

## Scope

Keyword form only, parse plus expose. No inference behavior changes.

Closes #557

Positional binding is tracked by #573, wiring the parsed content into inference by #563, and ragged/sparse spec representation by #524 and #533.