### PR TITLE
Implement the `RECONFIGURE` transformation to emit `input_signature`

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1026,12 +1026,14 @@ public class Function {
 					} else if (this.getHasPythonSideEffects() != null) // it has side-effects.
 						this.addFailure(HAS_PYTHON_SIDE_EFFECTS, "De-hybridizing a function with Python side-effects may alter semantics.");
 				} else if (this.getHasPrimitiveParameter() != null) { // no primitive parameters.
-					// This function is already correctly hybrid (tensor parameter, no primitive parameter). When input-signature
-					// inference is enabled, the decorator carries no `input_signature` yet, the function is side-effect-free and
-					// non-recursive, and a signature can be inferred, reconfigure the decorator to add the inferred signature instead
-					// of leaving the function untouched. A function that already supplies an `input_signature` is deferred (the
-					// supplied signature must not be clobbered; that is the validate-then-overwrite case). Gating on the flag keeps
-					// the default precondition matrix unchanged.
+					/*
+					 * This function is already correctly hybrid (tensor parameter, no primitive parameter). When input-signature inference
+					 * is enabled, the decorator carries no `input_signature` yet, the function is side-effect-free and non-recursive, and a
+					 * signature can be inferred, reconfigure the decorator to add the inferred signature instead of leaving the function
+					 * untouched. A function that already supplies an `input_signature` is deferred (the supplied signature must not be
+					 * clobbered; that is the validate-then-overwrite case). Gating on the flag keeps the default precondition matrix
+					 * unchanged.
+					 */
 					if (this.getInferInputSignatures() && !this.getHybridizationParameters().hasInputSignatureParam()
 							&& this.getHasPythonSideEffects() != null && !this.getHasPythonSideEffects() && this.isRecursive() != null
 							&& !this.isRecursive() && this.canEmitInferredInputSignature()) {
@@ -2147,9 +2149,10 @@ public class Function {
 		MultiTextEdit mte = new MultiTextEdit();
 
 		if (decorator.func instanceof Call) {
-			// `@tf.function(...)`: inject at the front of the existing argument list, just past the open parenthesis. Front-insertion
-			// handles both the empty-parentheses (`@tf.function()`) and non-empty (`@tf.function(reduce_retracing=True)`) forms without
-			// locating the closing parenthesis or the last argument.
+			// `@tf.function(...)`: append `input_signature=...` at the END of the existing argument list, just before the matching close
+			// parenthesis. A trailing keyword argument is always valid Python, whereas front-insertion would place the keyword before any
+			// existing positional argument (e.g. `@tf.function(None)`), producing a syntax error. Handles the empty-parentheses
+			// (`@tf.function()`) and non-empty (`@tf.function(reduce_retracing=True)`) forms uniformly.
 			Call call = (Call) decorator.func;
 
 			// Find the open parenthesis, tolerating any whitespace between the callee and `(`.
@@ -2157,14 +2160,29 @@ public class Function {
 			while (parenOffset < doc.getLength() && doc.getChar(parenOffset) != '(')
 				++parenOffset;
 
+			// Find the matching close parenthesis by tracking bracket nesting from the open parenthesis (assumes no `)` inside a string
+			// argument, which `@tf.function` decorators do not use in practice).
+			int depth = 0;
+			int closeOffset = parenOffset;
+			for (; closeOffset < doc.getLength(); closeOffset++) {
+				char c = doc.getChar(closeOffset);
+				if (c == '(' || c == '[' || c == '{')
+					++depth;
+				else if (c == ')' || c == ']' || c == '}') {
+					--depth;
+					if (depth == 0)
+						break;
+				}
+			}
+
 			boolean hasArguments = (call.args != null && call.args.length > 0) || (call.keywords != null && call.keywords.length > 0)
 					|| call.starargs != null || call.kwargs != null;
 
-			// Insertion point is just inside the parenthesis; captured as effectively final for the lambda below.
-			final int insertOffset = parenOffset + 1;
+			// Insertion point is just before the matching close parenthesis; captured as effectively final for the lambda below.
+			final int insertOffset = closeOffset;
 
 			this.computeInputSignatureKeyword(ctx)
-					.ifPresent(kw -> mte.addChild(new InsertEdit(insertOffset, hasArguments ? kw + ", " : kw)));
+					.ifPresent(kw -> mte.addChild(new InsertEdit(insertOffset, hasArguments ? ", " + kw : kw)));
 		} else
 			// Bare `@tf.function` (no parentheses): append a parenthesized argument list right after the decorator name. This is the
 			// argless-existing-decorator sub-case `addInputSignature` is documented to serve.
@@ -2223,6 +2241,13 @@ public class Function {
 	 * @return The {@code input_signature=...} keyword argument, or empty.
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/585">Issue 585</a>
 	 */
+	private Optional<String> computeInputSignatureKeyword(ImportContext ctx) {
+		if (!this.getInferInputSignatures() || !ctx.tensorSpecReachable())
+			return Optional.empty();
+		return this.inferInputSignature().filter(sig -> sig.requiredDTypeNames().stream().allMatch(ctx::nameReachable))
+				.map(sig -> "input_signature=" + sig.toTensorSpecList(ctx.prefix()));
+	}
+
 	/**
 	 * Whether an inferred input signature can actually be emitted into this function's decorator under the containing file's import shape.
 	 * Gates {@code RECONFIGURE} selection in {@link #check()} so a passing precondition is never reported for a no-op transformation: a
@@ -2236,13 +2261,6 @@ public class Function {
 	private boolean canEmitInferredInputSignature() {
 		ImportContext ctx = getImportContext(this.getContainingDocument());
 		return ctx != null && this.computeInputSignatureKeyword(ctx).isPresent();
-	}
-
-	private Optional<String> computeInputSignatureKeyword(ImportContext ctx) {
-		if (!this.getInferInputSignatures() || !ctx.tensorSpecReachable())
-			return Optional.empty();
-		return this.inferInputSignature().filter(sig -> sig.requiredDTypeNames().stream().allMatch(ctx::nameReachable))
-				.map(sig -> "input_signature=" + sig.toTensorSpecList(ctx.prefix()));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -8,10 +8,12 @@ import static edu.cuny.hunter.hybridize.core.analysis.PreconditionFailure.HAS_PY
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P1;
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P2;
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P3;
+import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P4;
 import static edu.cuny.hunter.hybridize.core.analysis.Refactoring.CONVERT_EAGER_FUNCTION_TO_HYBRID;
 import static edu.cuny.hunter.hybridize.core.analysis.Refactoring.OPTIMIZE_HYBRID_FUNCTION;
 import static edu.cuny.hunter.hybridize.core.analysis.Transformation.CONVERT_TO_EAGER;
 import static edu.cuny.hunter.hybridize.core.analysis.Transformation.CONVERT_TO_HYBRID;
+import static edu.cuny.hunter.hybridize.core.analysis.Transformation.RECONFIGURE;
 import static edu.cuny.hunter.hybridize.core.analysis.Util.getAllParentNames;
 import static edu.cuny.hunter.hybridize.core.utils.Util.getPythonPath;
 import static edu.cuny.hunter.hybridize.core.wala.ml.PythonModRefWithBuiltinFunctions.PythonModVisitorWithBuiltinFunctions.GLOBAL_OUTPUT_STREAM_POINTER_KEY;
@@ -1024,12 +1026,26 @@ public class Function {
 					} else if (this.getHasPythonSideEffects() != null) // it has side-effects.
 						this.addFailure(HAS_PYTHON_SIDE_EFFECTS, "De-hybridizing a function with Python side-effects may alter semantics.");
 				} else if (this.getHasPrimitiveParameter() != null) { // no primitive parameters.
-					this.addFailure(PreconditionFailure.HAS_NO_PRIMITIVE_PARAMETERS,
-							"Functions with no Python literal arguments may benefit from hybridization.");
+					// This function is already correctly hybrid (tensor parameter, no primitive parameter). When input-signature
+					// inference is enabled, the decorator carries no `input_signature` yet, the function is side-effect-free and
+					// non-recursive, and a signature can be inferred, reconfigure the decorator to add the inferred signature instead
+					// of leaving the function untouched. A function that already supplies an `input_signature` is deferred (the
+					// supplied signature must not be clobbered; that is the validate-then-overwrite case). Gating on the flag keeps
+					// the default precondition matrix unchanged.
+					if (this.getInferInputSignatures() && !this.getHybridizationParameters().hasInputSignatureParam()
+							&& this.getHasPythonSideEffects() != null && !this.getHasPythonSideEffects() && this.isRecursive() != null
+							&& !this.isRecursive() && this.inferInputSignature().isPresent()) {
+						this.addInfo("This hybrid function has no input signature and can be reconfigured to add the inferred one.");
+						this.addTransformation(RECONFIGURE);
+						this.setPassingPrecondition(P4);
+					} else {
+						this.addFailure(PreconditionFailure.HAS_NO_PRIMITIVE_PARAMETERS,
+								"Functions with no Python literal arguments may benefit from hybridization.");
 
-					if (this.getHasPythonSideEffects() != null && this.getHasPythonSideEffects())
-						this.addFailure(PreconditionFailure.HAS_PYTHON_SIDE_EFFECTS,
-								"De-hybridizing a function with Python side-effects may alter semantics.");
+						if (this.getHasPythonSideEffects() != null && this.getHasPythonSideEffects())
+							this.addFailure(PreconditionFailure.HAS_PYTHON_SIDE_EFFECTS,
+									"De-hybridizing a function with Python side-effects may alter semantics.");
+					}
 				}
 
 				// Here, we have a hybrid function with a tensor parameter.
@@ -1983,7 +1999,8 @@ public class Function {
 				ret.addAll(this.convertToEager());
 				break;
 			case RECONFIGURE:
-				throw new UnsupportedOperationException();
+				ret.addAll(this.reconfigure());
+				break;
 			default:
 				throw new IllegalStateException();
 			}
@@ -2091,6 +2108,70 @@ public class Function {
 		this.addInputSignature(offset, ctx).ifPresent(mte::addChild);
 		mte.addChild(new InsertEdit(offset, "\n" + precedingText));
 		ret.add(mte);
+
+		return ret;
+	}
+
+	/**
+	 * Adds the inferred {@code input_signature} to this already-hybrid function's existing {@code @tf.function} decorator (the
+	 * {@code RECONFIGURE} transformation). Selection (in {@link #check()}) guarantees the decorator carries no {@code input_signature}
+	 * yet—the supplied-signature case is deferred to validate-then-overwrite and never reaches here. Reuses the existing import-shape
+	 * resolution ({@link #getImportContext(IDocument)}) and emission gate ({@link #computeInputSignatureKeyword(ImportContext)} /
+	 * {@link #addInputSignature(int, ImportContext)}); a hybrid function necessarily imports TensorFlow (the decorator references it), so
+	 * {@code getImportContext} is non-null. When the signature's names are not reachable under the file's import shape (e.g.
+	 * {@code from tensorflow import function} without {@code TensorSpec}), the gate yields no keyword and no edit is produced, matching
+	 * {@link #convertToHybrid()}'s silent skip.
+	 *
+	 * @return The edits adding {@code input_signature=[...]} to the decorator, or an empty list when emission is gated out.
+	 * @throws BadLocationException If a document offset cannot be resolved.
+	 */
+	private List<TextEdit> reconfigure() throws BadLocationException {
+		assert this.getDecoratorNames(null).contains(TF_FUNCTION_FQN) : "Not hybrid.";
+
+		List<TextEdit> ret = new ArrayList<>();
+
+		IDocument doc = this.getContainingDocument();
+		ImportContext ctx = getImportContext(doc);
+
+		if (ctx == null)
+			return ret;
+
+		decoratorsType decorator = this.hybridDecorator;
+
+		// Offset just past the decorator name (e.g. just past `function` in `@tf.function`). Mirrors `convertToEager`'s proven offset
+		// computation: the `decoratorsType` node begins at `@`, and `getFullRepresentationString(decorator.func)` yields the dotted name
+		// without arguments for both the bare and called forms (the trailing `+ 1` accounts for the leading `@`). The inner `func` expr's
+		// own position is unreliable for decorators, so it is not used directly.
+		int afterName = getOffset(doc, decorator) + getFullRepresentationString(decorator.func).length() + 1;
+
+		MultiTextEdit mte = new MultiTextEdit();
+
+		if (decorator.func instanceof Call) {
+			// `@tf.function(...)`: inject at the front of the existing argument list, just past the open parenthesis. Front-insertion
+			// handles both the empty-parentheses (`@tf.function()`) and non-empty (`@tf.function(reduce_retracing=True)`) forms without
+			// locating the closing parenthesis or the last argument.
+			Call call = (Call) decorator.func;
+
+			// Find the open parenthesis, tolerating any whitespace between the callee and `(`.
+			int parenOffset = afterName;
+			while (parenOffset < doc.getLength() && doc.getChar(parenOffset) != '(')
+				++parenOffset;
+
+			boolean hasArguments = (call.args != null && call.args.length > 0) || (call.keywords != null && call.keywords.length > 0)
+					|| call.starargs != null || call.kwargs != null;
+
+			// Insertion point is just inside the parenthesis; captured as effectively final for the lambda below.
+			final int insertOffset = parenOffset + 1;
+
+			this.computeInputSignatureKeyword(ctx)
+					.ifPresent(kw -> mte.addChild(new InsertEdit(insertOffset, hasArguments ? kw + ", " : kw)));
+		} else
+			// Bare `@tf.function` (no parentheses): append a parenthesized argument list right after the decorator name. This is the
+			// argless-existing-decorator sub-case `addInputSignature` is documented to serve.
+			this.addInputSignature(afterName, ctx).ifPresent(mte::addChild);
+
+		if (mte.hasChildren())
+			ret.add(mte);
 
 		return ret;
 	}

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1034,7 +1034,7 @@ public class Function {
 					// the default precondition matrix unchanged.
 					if (this.getInferInputSignatures() && !this.getHybridizationParameters().hasInputSignatureParam()
 							&& this.getHasPythonSideEffects() != null && !this.getHasPythonSideEffects() && this.isRecursive() != null
-							&& !this.isRecursive() && this.inferInputSignature().isPresent()) {
+							&& !this.isRecursive() && this.canEmitInferredInputSignature()) {
 						this.addInfo("This hybrid function has no input signature and can be reconfigured to add the inferred one.");
 						this.addTransformation(RECONFIGURE);
 						this.setPassingPrecondition(P4);
@@ -2223,6 +2223,21 @@ public class Function {
 	 * @return The {@code input_signature=...} keyword argument, or empty.
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/585">Issue 585</a>
 	 */
+	/**
+	 * Whether an inferred input signature can actually be emitted into this function's decorator under the containing file's import shape.
+	 * Gates {@code RECONFIGURE} selection in {@link #check()} so a passing precondition is never reported for a no-op transformation: a
+	 * hybrid function always imports TensorFlow (its decorator references it), but the named-import shape ({@code from tensorflow import
+	 * function}) can leave {@code TensorSpec} or a dtype constant out of scope, in which case
+	 * {@link #computeInputSignatureKeyword(ImportContext)} yields nothing and {@link #reconfigure()} would produce no edit. True implies
+	 * both that a signature was inferred and that all its names are reachable, so a selected reconfiguration always rewrites the decorator.
+	 *
+	 * @return True iff the inferred input signature is emittable under this file's import shape.
+	 */
+	private boolean canEmitInferredInputSignature() {
+		ImportContext ctx = getImportContext(this.getContainingDocument());
+		return ctx != null && this.computeInputSignatureKeyword(ctx).isPresent();
+	}
+
 	private Optional<String> computeInputSignatureKeyword(ImportContext ctx) {
 		if (!this.getInferInputSignatures() || !ctx.tensorSpecReachable())
 			return Optional.empty();

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/PreconditionSuccess.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/PreconditionSuccess.java
@@ -2,4 +2,10 @@ package edu.cuny.hunter.hybridize.core.analysis;
 
 public enum PreconditionSuccess {
 	P1, P2, P3,
+
+	/**
+	 * A hybrid function that is already correctly hybrid but carries no {@code input_signature}: reconfigure its decorator to add the
+	 * inferred input signature.
+	 */
+	P4,
 }

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/PreconditionSuccess.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/PreconditionSuccess.java
@@ -5,7 +5,9 @@ public enum PreconditionSuccess {
 
 	/**
 	 * A hybrid function that is already correctly hybrid but carries no {@code input_signature}: reconfigure its decorator to add the
-	 * inferred input signature.
+	 * inferred input signature. This is the add-when-absent path into the {@link Transformation#RECONFIGURE} transformation; modifying an
+	 * already-supplied signature (validate-then-overwrite) is a separate precondition path that reaches the same transformation, mirroring
+	 * how {@link #P2} and {@link #P3} both reach {@link Transformation#CONVERT_TO_EAGER}.
 	 */
 	P4,
 }

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureBareDecorator/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureBareDecorator/in/A.py
@@ -1,0 +1,13 @@
+# Already-hybrid function with a bare `@tf.function` (no parentheses) and a single tensor parameter, no `input_signature`. Analysis
+# selects `RECONFIGURE`; the source-write appends a parenthesized `input_signature=[tf.TensorSpec(...)]` argument list right after the
+# decorator name.
+import tensorflow as tf
+
+
+@tf.function
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureBareDecorator/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureBareDecorator/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureBareDecorator/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureBareDecorator/out/A.py
@@ -1,0 +1,13 @@
+# Already-hybrid function with a bare `@tf.function` (no parentheses) and a single tensor parameter, no `input_signature`. Analysis
+# selects `RECONFIGURE`; the source-write appends a parenthesized `input_signature=[tf.TensorSpec(...)]` argument list right after the
+# decorator name.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureEmptyParens/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureEmptyParens/in/A.py
@@ -1,0 +1,12 @@
+# Already-hybrid function with an empty-parentheses `@tf.function()` decorator and a tensor parameter, no `input_signature`. Analysis
+# selects `RECONFIGURE`; the source-write inserts `input_signature=[tf.TensorSpec(...)]` between the existing parentheses.
+import tensorflow as tf
+
+
+@tf.function()
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureEmptyParens/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureEmptyParens/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureEmptyParens/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureEmptyParens/out/A.py
@@ -1,0 +1,12 @@
+# Already-hybrid function with an empty-parentheses `@tf.function()` decorator and a tensor parameter, no `input_signature`. Analysis
+# selects `RECONFIGURE`; the source-write inserts `input_signature=[tf.TensorSpec(...)]` between the existing parentheses.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingArgs/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingArgs/in/A.py
@@ -1,6 +1,6 @@
 # Already-hybrid function whose `@tf.function(reduce_retracing=True)` decorator already carries a non-`input_signature` keyword
-# argument. Analysis selects `RECONFIGURE`; the source-write inserts `input_signature=[tf.TensorSpec(...)], ` at the front of the
-# existing argument list, preserving the trailing `reduce_retracing=True`.
+# argument. Analysis selects `RECONFIGURE`; the source-write appends `, input_signature=[tf.TensorSpec(...)]` at the end of the
+# existing argument list, after the `reduce_retracing=True` keyword.
 import tensorflow as tf
 
 

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingArgs/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingArgs/in/A.py
@@ -1,0 +1,13 @@
+# Already-hybrid function whose `@tf.function(reduce_retracing=True)` decorator already carries a non-`input_signature` keyword
+# argument. Analysis selects `RECONFIGURE`; the source-write inserts `input_signature=[tf.TensorSpec(...)], ` at the front of the
+# existing argument list, preserving the trailing `reduce_retracing=True`.
+import tensorflow as tf
+
+
+@tf.function(reduce_retracing=True)
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingArgs/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingArgs/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingArgs/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingArgs/out/A.py
@@ -1,10 +1,10 @@
 # Already-hybrid function whose `@tf.function(reduce_retracing=True)` decorator already carries a non-`input_signature` keyword
-# argument. Analysis selects `RECONFIGURE`; the source-write inserts `input_signature=[tf.TensorSpec(...)], ` at the front of the
-# existing argument list, preserving the trailing `reduce_retracing=True`.
+# argument. Analysis selects `RECONFIGURE`; the source-write appends `, input_signature=[tf.TensorSpec(...)]` at the end of the
+# existing argument list, after the `reduce_retracing=True` keyword.
 import tensorflow as tf
 
 
-@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)], reduce_retracing=True)
+@tf.function(reduce_retracing=True, input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
 def f(x):
     return x + 1
 

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingArgs/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingArgs/out/A.py
@@ -1,0 +1,13 @@
+# Already-hybrid function whose `@tf.function(reduce_retracing=True)` decorator already carries a non-`input_signature` keyword
+# argument. Analysis selects `RECONFIGURE`; the source-write inserts `input_signature=[tf.TensorSpec(...)], ` at the front of the
+# existing argument list, preserving the trailing `reduce_retracing=True`.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)], reduce_retracing=True)
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingSignatureDeferred/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingSignatureDeferred/in/A.py
@@ -1,0 +1,13 @@
+# Already-hybrid function that already supplies an `input_signature`. Per the presence/parse three-state contract, a supplied
+# signature must not be clobbered, so `RECONFIGURE` is NOT selected even with inference enabled (validate-then-overwrite is future
+# work). This pins the deferral of the supplied-signature case.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingSignatureDeferred/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureExistingSignatureDeferred/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureFlagOff/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureFlagOff/in/A.py
@@ -1,0 +1,13 @@
+# Same good-hybrid shape as `testReconfigureBareDecorator`, but with input-signature inference disabled (the suite default). The
+# precondition matrix must be unchanged: the function still hits the `HAS_NO_PRIMITIVE_PARAMETERS` failure and selects no
+# transformation, proving `RECONFIGURE` is gated behind the flag.
+import tensorflow as tf
+
+
+@tf.function
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureFlagOff/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureFlagOff/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureFullyQualifiedImport/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureFullyQualifiedImport/in/A.py
@@ -1,0 +1,12 @@
+# Fully-qualified-import variant of `testReconfigureBareDecorator`. Bare `import tensorflow` (no `as` alias) means the source-write
+# must qualify every emitted name with the `tensorflow.` prefix when reconfiguring the existing `@tensorflow.function` decorator.
+import tensorflow
+
+
+@tensorflow.function
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tensorflow.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureFullyQualifiedImport/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureFullyQualifiedImport/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureFullyQualifiedImport/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureFullyQualifiedImport/out/A.py
@@ -1,0 +1,12 @@
+# Fully-qualified-import variant of `testReconfigureBareDecorator`. Bare `import tensorflow` (no `as` alias) means the source-write
+# must qualify every emitted name with the `tensorflow.` prefix when reconfiguring the existing `@tensorflow.function` decorator.
+import tensorflow
+
+
+@tensorflow.function(input_signature=[tensorflow.TensorSpec(shape=(), dtype=tensorflow.float32)])
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tensorflow.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureNamedImportMissingTensorSpec/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureNamedImportMissingTensorSpec/in/A.py
@@ -1,0 +1,13 @@
+# Named-import variant: `from tensorflow import function` brings the decorator into scope but not `TensorSpec`, so the inferred
+# signature cannot be emitted unqualified. RECONFIGURE must NOT be selected (emission would be a no-op); the function keeps its
+# HAS_NO_PRIMITIVE_PARAMETERS status. Mirrors `testInferInputSignatureEmissionNamedImport` for the already-hybrid case.
+from tensorflow import function, constant
+
+
+@function
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureNamedImportMissingTensorSpec/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureNamedImportMissingTensorSpec/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigurePositionalFunc/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigurePositionalFunc/in/A.py
@@ -1,0 +1,13 @@
+# Already-hybrid function whose decorator passes `func` positionally (`@tf.function(None)`) and carries no `input_signature`.
+# Analysis selects `RECONFIGURE`; the source-write appends `, input_signature=[tf.TensorSpec(...)]` at the END of the argument list.
+# Front-insertion would place the keyword before the `None` positional argument, producing a Python syntax error (#595 review).
+import tensorflow as tf
+
+
+@tf.function(None)
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigurePositionalFunc/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigurePositionalFunc/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigurePositionalFunc/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigurePositionalFunc/out/A.py
@@ -1,0 +1,13 @@
+# Already-hybrid function whose decorator passes `func` positionally (`@tf.function(None)`) and carries no `input_signature`.
+# Analysis selects `RECONFIGURE`; the source-write appends `, input_signature=[tf.TensorSpec(...)]` at the END of the argument list.
+# Front-insertion would place the keyword before the `None` positional argument, producing a Python syntax error (#595 review).
+import tensorflow as tf
+
+
+@tf.function(None, input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+def f(x):
+    return x + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1693,6 +1693,29 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * A hybrid function under a named import ({@code from tensorflow import function}) that brings the decorator into scope but not
+	 * {@code TensorSpec}: the inferred signature cannot be emitted unqualified, so {@code RECONFIGURE} must not be selected (it would be a
+	 * no-op). The function keeps its {@code HAS_NO_PRIMITIVE_PARAMETERS} status. Pins the emittability gate on {@code RECONFIGURE}
+	 * selection, ensuring a passing precondition is never reported for a transformation that would produce no edit.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	@Test
+	public void testReconfigureNamedImportMissingTensorSpec() throws Exception {
+		this.setInferInputSignatures(true);
+
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertTrue("Fixture function `f` should be hybrid.", f.isHybrid());
+		assertFalse("Emission is impossible under this import shape, so RECONFIGURE must not be selected.",
+				f.getTransformations().contains(RECONFIGURE));
+		assertNull("No passing precondition when the signature is not emittable.", f.getPassingPrecondition());
+		assertNotNull("The function keeps its HAS_NO_PRIMITIVE_PARAMETERS failure.",
+				f.getEntryMatchingFailure(HAS_NO_PRIMITIVE_PARAMETERS));
+	}
+
+	/**
 	 * With input-signature inference disabled (the suite default), the precondition matrix must be unchanged: a good-hybrid function still
 	 * hits the {@code HAS_NO_PRIMITIVE_PARAMETERS} failure and selects no transformation. Proves {@code RECONFIGURE} is gated behind the
 	 * flag and existing behavior is preserved for the whole suite.

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -17,10 +17,12 @@ import static edu.cuny.hunter.hybridize.core.analysis.PreconditionFailure.UNDETE
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P1;
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P2;
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P3;
+import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P4;
 import static edu.cuny.hunter.hybridize.core.analysis.Refactoring.CONVERT_EAGER_FUNCTION_TO_HYBRID;
 import static edu.cuny.hunter.hybridize.core.analysis.Refactoring.OPTIMIZE_HYBRID_FUNCTION;
 import static edu.cuny.hunter.hybridize.core.analysis.Transformation.CONVERT_TO_EAGER;
 import static edu.cuny.hunter.hybridize.core.analysis.Transformation.CONVERT_TO_HYBRID;
+import static edu.cuny.hunter.hybridize.core.analysis.Transformation.RECONFIGURE;
 import static java.lang.Boolean.TRUE;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.System.getProperty;
@@ -1608,6 +1610,130 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 		// Apply highest-offset edits first so an inserted import (low offset) does not shift the unapplied decorator edit's anchor. In
 		// production the edits compose in one LTK change tree, which coordinates offsets; this loop applies them as independent trees.
+		List<TextEdit> edits = new ArrayList<>(f.transform());
+		edits.sort(Comparator.comparingInt(TextEdit::getOffset).reversed());
+
+		for (TextEdit edit : edits)
+			edit.apply(doc);
+
+		String expected = this.getFileContents(this.getOutputTestFileName("A"));
+		assertEqualLines(expected, doc.get());
+	}
+
+	/**
+	 * Test that {@code RECONFIGURE} adds an inferred {@code input_signature=[tf.TensorSpec(...)]} to an already-hybrid function whose bare
+	 * {@code @tf.function} decorator (no parentheses) carries no signature. The remaining half of #563: the eager case is
+	 * {@code CONVERT_TO_HYBRID} (#565); this is the already-hybrid case. The source-write appends a parenthesized argument list right after
+	 * the decorator name.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	@Test
+	public void testReconfigureBareDecorator() throws Exception {
+		helperAssertReconfigure();
+	}
+
+	/**
+	 * Empty-parentheses variant of {@link #testReconfigureBareDecorator()}. The existing decorator is {@code @tf.function()}; the
+	 * source-write inserts {@code input_signature=[...]} between the parentheses (front-of-arg-list insertion with no trailing arguments).
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	@Test
+	public void testReconfigureEmptyParens() throws Exception {
+		helperAssertReconfigure();
+	}
+
+	/**
+	 * Non-empty argument-list variant of {@link #testReconfigureBareDecorator()}. The existing decorator already carries a
+	 * non-{@code input_signature} keyword ({@code @tf.function(reduce_retracing=True)}); the source-write inserts
+	 * {@code input_signature=[...], } at the front of the argument list, preserving the trailing keyword.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	@Test
+	public void testReconfigureExistingArgs() throws Exception {
+		helperAssertReconfigure();
+	}
+
+	/**
+	 * Fully-qualified-import variant of {@link #testReconfigureBareDecorator()}. With bare {@code import tensorflow} (no {@code as} alias),
+	 * the source-write must qualify every emitted name with the {@code tensorflow.} prefix when reconfiguring the existing
+	 * {@code @tensorflow.function} decorator.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	@Test
+	public void testReconfigureFullyQualifiedImport() throws Exception {
+		helperAssertReconfigure();
+	}
+
+	/**
+	 * A function that already supplies an {@code input_signature} must not be reconfigured. Per the presence/parse three-state contract
+	 * (#557), a supplied signature must not be clobbered; validate-then-overwrite is future work. Even with inference enabled,
+	 * {@code RECONFIGURE} is not selected, no passing precondition is set, and the function keeps its {@code HAS_NO_PRIMITIVE_PARAMETERS}
+	 * failure. Pins the deferral of the supplied-signature case.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	@Test
+	public void testReconfigureExistingSignatureDeferred() throws Exception {
+		this.setInferInputSignatures(true);
+
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertTrue("Fixture function `f` should be hybrid.", f.isHybrid());
+		assertTrue("A supplied `input_signature` must be detected.", f.getHybridizationParameters().hasInputSignatureParam());
+		assertFalse("A function that already supplies an `input_signature` must not be reconfigured.",
+				f.getTransformations().contains(RECONFIGURE));
+		assertNull("The supplied-signature case is deferred, so no passing precondition is set.", f.getPassingPrecondition());
+		assertNotNull("The deferred function keeps its HAS_NO_PRIMITIVE_PARAMETERS failure.",
+				f.getEntryMatchingFailure(HAS_NO_PRIMITIVE_PARAMETERS));
+	}
+
+	/**
+	 * With input-signature inference disabled (the suite default), the precondition matrix must be unchanged: a good-hybrid function still
+	 * hits the {@code HAS_NO_PRIMITIVE_PARAMETERS} failure and selects no transformation. Proves {@code RECONFIGURE} is gated behind the
+	 * flag and existing behavior is preserved for the whole suite.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	@Test
+	public void testReconfigureFlagOff() throws Exception {
+		// The `inferInputSignatures` flag defaults off; intentionally do not enable it.
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertTrue("Fixture function `f` should be hybrid.", f.isHybrid());
+		assertFalse("With inference disabled, RECONFIGURE must not be selected.", f.getTransformations().contains(RECONFIGURE));
+		assertTrue("The default precondition matrix must be unchanged: no transformation.", f.getTransformations().isEmpty());
+		assertNull("No passing precondition with the flag off.", f.getPassingPrecondition());
+		assertNotNull("The good-hybrid function must still hit the HAS_NO_PRIMITIVE_PARAMETERS failure when the flag is off.",
+				f.getEntryMatchingFailure(HAS_NO_PRIMITIVE_PARAMETERS));
+	}
+
+	/**
+	 * Runs the refactoring on the current test's fixture and asserts the produced source matches the expected {@code out/A.py}. The single
+	 * fixture function must be hybrid pre-refactoring, carry no {@code input_signature}, select {@link Transformation#RECONFIGURE} with
+	 * passing precondition {@link PreconditionSuccess#P4}, and carry the harness-enabled {@code inferInputSignatures} flag. Shared by the
+	 * reconfigure tests, which differ only in their decorator/import-shape fixture.
+	 */
+	private void helperAssertReconfigure() throws Exception {
+		// Emission is opt-in per test (off by default suite-wide; see #580). The reconfigure tests enable it here.
+		this.setInferInputSignatures(true);
+
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertTrue("Fixture function `f` should be hybrid pre-refactoring.", f.isHybrid());
+		assertEquals("Fixture function `f` should select `RECONFIGURE` after analysis.", singleton(RECONFIGURE), f.getTransformations());
+		assertEquals("`RECONFIGURE` selection should set the P4 passing precondition.", P4, f.getPassingPrecondition());
+
+		// Apply the `TextEdit`s directly to the function's in-memory document, mirroring `helperAssertInputSignatureEmission` (the
+		// `ResourceStub`-backed `IFile` can't be resolved to a URI by `TextFileBufferManager`; tracked at #359).
+		IDocument doc = f.getContainingDocument();
+
 		List<TextEdit> edits = new ArrayList<>(f.transform());
 		edits.sort(Comparator.comparingInt(TextEdit::getOffset).reversed());
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1646,13 +1646,26 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 	/**
 	 * Non-empty argument-list variant of {@link #testReconfigureBareDecorator()}. The existing decorator already carries a
-	 * non-{@code input_signature} keyword ({@code @tf.function(reduce_retracing=True)}); the source-write inserts
-	 * {@code input_signature=[...], } at the front of the argument list, preserving the trailing keyword.
+	 * non-{@code input_signature} keyword ({@code @tf.function(reduce_retracing=True)}); the source-write appends
+	 * {@code , input_signature=[...]} at the end of the argument list, after the existing keyword.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
 	 */
 	@Test
 	public void testReconfigureExistingArgs() throws Exception {
+		helperAssertReconfigure();
+	}
+
+	/**
+	 * Positional-argument variant of {@link #testReconfigureBareDecorator()}. The existing decorator passes {@code func} positionally
+	 * ({@code @tf.function(None)}); the source-write appends {@code , input_signature=[...]} at the end of the argument list. Front
+	 * insertion would place the keyword argument before the {@code None} positional argument, producing a Python syntax error; appending at
+	 * the end keeps the result valid (#595 review).
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
+	 */
+	@Test
+	public void testReconfigurePositionalFunc() throws Exception {
 		helperAssertReconfigure();
 	}
 


### PR DESCRIPTION
## Summary

Completes the input-signature source rewrite for already-hybrid functions. When input-signature inference is enabled and a qualifying hybrid `@tf.function` carries no `input_signature`, the refactoring now adds the inferred `input_signature=[tf.TensorSpec(...)]` to the existing decorator via the `RECONFIGURE` transformation. The eager `CONVERT_TO_HYBRID` emission half landed in #565; this is the complementary already-hybrid half.

## Changes

- New `PreconditionSuccess.P4` for the reconfigure case.
- `Function.check()` selects `RECONFIGURE` + `P4` for a hybrid function with a tensor parameter and no primitive parameter when inference is enabled, the decorator has no `input_signature`, the function is side-effect-free and non-recursive, and a signature can be inferred. Gated on the `inferInputSignatures` flag (default off), so the precondition matrix is unchanged for the existing suite.
- `Function.reconfigure()` inserts the keyword into the existing decorator, reusing `getImportContext`, `computeInputSignatureKeyword`, and `addInputSignature`. Handles the bare `@tf.function`, empty-parentheses `@tf.function()`, and non-empty `@tf.function(...)` forms.
- `transform()` dispatches `RECONFIGURE` (previously `UnsupportedOperationException`).

## Behavior Contract

A hybrid function that already supplies an `input_signature` is deferred (not reconfigured): the supplied signature must not be clobbered, per the presence/parse three-state contract from #557. Validate-then-overwrite remains future work.

## Tests

Six tests over decorator/import-shape fixtures: bare, empty-parentheses, and existing-argument decorator forms; fully-qualified import; a pinning test for the deferred supplied-signature case; and a flag-off guard asserting the default precondition matrix is unchanged. All fixtures run under `python3.10`. Full suite: 519 pass, 11 skipped (pre-existing env-dependent).

Closes #563