### PR TITLE
Recognize `tf.Tensor` subtypes in the type-hint check

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -80,6 +80,19 @@ public final class Parameter {
 	private static final String TF_TENSOR_FQN = "tensorflow.python.framework.ops.Tensor";
 
 	/**
+	 * Fully-qualified names of the TensorFlow types recognized as tensor-typed in a type hint: {@link #TF_TENSOR_FQN} and its
+	 * tensor-equivalent subtypes ({@code RaggedTensor}, {@code SparseTensor}, {@code Variable}, {@code IndexedSlices}). The {@code *Spec}
+	 * descriptors ({@code TensorSpec}, {@code RaggedTensorSpec}, …) are deliberately excluded: they describe tensors but are not tensors
+	 * themselves. See <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/434">#434</a>.
+	 */
+	private static final Set<String> TF_TENSOR_TYPE_HINT_FQNS = Set.of( //
+			TF_TENSOR_FQN, //
+			"tensorflow.python.ops.ragged.ragged_tensor.RaggedTensor", //
+			"tensorflow.python.framework.sparse_tensor.SparseTensor", //
+			"tensorflow.python.ops.variables.Variable", //
+			"tensorflow.python.framework.indexed_slices.IndexedSlices");
+
+	/**
 	 * Parent Jython AST node carrying every positional name expression (in {@link argumentsType#args}) and per-position annotation (in
 	 * {@link argumentsType#annotation}) of the owning function. Shared across all {@link Parameter}s of the same function.
 	 */
@@ -269,7 +282,7 @@ public final class Parameter {
 
 			LOG.info("Found FQN: " + fqn + ".");
 
-			if (fqn.equals(TF_TENSOR_FQN)) { // TODO: Also check for subtypes (RaggedTensor, SparseTensor, Variable, IndexedSlices) (#434).
+			if (TF_TENSOR_TYPE_HINT_FQNS.contains(fqn)) {
 				subMonitor.done();
 				return true;
 			}

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -80,17 +80,33 @@ public final class Parameter {
 	private static final String TF_TENSOR_FQN = "tensorflow.python.framework.ops.Tensor";
 
 	/**
+	 * Fully-qualified name of TensorFlow's {@code RaggedTensor} type, a tensor-equivalent subtype recognized in type hints.
+	 */
+	private static final String TF_RAGGED_TENSOR_FQN = "tensorflow.python.ops.ragged.ragged_tensor.RaggedTensor";
+
+	/**
+	 * Fully-qualified name of TensorFlow's {@code SparseTensor} type, a tensor-equivalent subtype recognized in type hints.
+	 */
+	private static final String TF_SPARSE_TENSOR_FQN = "tensorflow.python.framework.sparse_tensor.SparseTensor";
+
+	/**
+	 * Fully-qualified name of TensorFlow's {@code Variable} type, a tensor-equivalent subtype recognized in type hints.
+	 */
+	private static final String TF_VARIABLE_FQN = "tensorflow.python.ops.variables.Variable";
+
+	/**
+	 * Fully-qualified name of TensorFlow's {@code IndexedSlices} type, a tensor-equivalent subtype recognized in type hints.
+	 */
+	private static final String TF_INDEXED_SLICES_FQN = "tensorflow.python.framework.indexed_slices.IndexedSlices";
+
+	/**
 	 * Fully-qualified names of the TensorFlow types recognized as tensor-typed in a type hint: {@link #TF_TENSOR_FQN} and its
 	 * tensor-equivalent subtypes ({@code RaggedTensor}, {@code SparseTensor}, {@code Variable}, {@code IndexedSlices}). The {@code *Spec}
 	 * descriptors ({@code TensorSpec}, {@code RaggedTensorSpec}, …) are deliberately excluded: they describe tensors but are not tensors
 	 * themselves. See <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/434">#434</a>.
 	 */
-	private static final Set<String> TF_TENSOR_TYPE_HINT_FQNS = Set.of( //
-			TF_TENSOR_FQN, //
-			"tensorflow.python.ops.ragged.ragged_tensor.RaggedTensor", //
-			"tensorflow.python.framework.sparse_tensor.SparseTensor", //
-			"tensorflow.python.ops.variables.Variable", //
-			"tensorflow.python.framework.indexed_slices.IndexedSlices");
+	private static final Set<String> TF_TENSOR_TYPE_HINT_FQNS = Set.of(TF_TENSOR_FQN, TF_RAGGED_TENSOR_FQN, TF_SPARSE_TENSOR_FQN,
+			TF_VARIABLE_FQN, TF_INDEXED_SLICES_FQN);
 
 	/**
 	 * Parent Jython AST node carrying every positional name expression (in {@link argumentsType#args}) and per-position annotation (in

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterRagged/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterRagged/in/A.py
@@ -1,0 +1,13 @@
+# Test for #434. A `tf.RaggedTensor` type hint must classify the parameter as tensor-typed via the Phase 1 type-hint path (honored
+# here by the harness's global ALWAYS_FOLLOW_TYPE_HINTS), since a RaggedTensor is a tensor for refactoring purposes. The argument is a
+# non-tensor so the only classifying signal is the type hint.
+import tensorflow as tf
+
+
+@tf.function
+def f(t: tf.RaggedTensor):
+    pass
+
+
+if __name__ == "__main__":
+    f(5)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterRagged/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterRagged/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterRaggedSpec/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterRaggedSpec/in/A.py
@@ -1,0 +1,13 @@
+# Negative test for #434. A `tf.RaggedTensorSpec` type hint must NOT classify the parameter as tensor-typed: a *Spec descriptor
+# describes a tensor but is not itself a tensor, so its FQN is excluded from the recognized set. The argument is a non-tensor, so
+# with the type hint rejected there is no classifying signal.
+import tensorflow as tf
+
+
+@tf.function
+def f(t: tf.RaggedTensorSpec):
+    pass
+
+
+if __name__ == "__main__":
+    f(5)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterRaggedSpec/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterRaggedSpec/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterSparse/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterSparse/in/A.py
@@ -1,0 +1,12 @@
+# Test for #434. A `tf.SparseTensor` type hint must classify the parameter as tensor-typed via the Phase 1 type-hint path. The
+# argument is a non-tensor so the only classifying signal is the type hint.
+import tensorflow as tf
+
+
+@tf.function
+def f(t: tf.SparseTensor):
+    pass
+
+
+if __name__ == "__main__":
+    f(5)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterSparse/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterSparse/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterVariable/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterVariable/in/A.py
@@ -1,0 +1,12 @@
+# Test for #434. A `tf.Variable` type hint must classify the parameter as tensor-typed via the Phase 1 type-hint path; a Variable is
+# treated as tensor-equivalent for hybridization purposes. The argument is a non-tensor so the only classifying signal is the hint.
+import tensorflow as tf
+
+
+@tf.function
+def f(t: tf.Variable):
+    pass
+
+
+if __name__ == "__main__":
+    f(5)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterVariable/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testHasLikelyTensorParameterVariable/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8414,6 +8414,82 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Test for #434. A {@code tf.RaggedTensor} type hint classifies the parameter as tensor-typed via the Phase 1 type-hint path: a
+	 * {@code RaggedTensor} is a tensor for refactoring purposes, so its FQN is among those recognized by {@code hasTensorTypeHint}. The
+	 * argument is a non-tensor, isolating the type-hint signal.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/434">Issue 434</a>
+	 */
+	@Test
+	public void testHasLikelyTensorParameterRagged() throws Exception {
+		assertTensorTypeHintClassifies();
+	}
+
+	/**
+	 * Test for #434. A {@code tf.SparseTensor} type hint classifies the parameter as tensor-typed via the Phase 1 type-hint path.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/434">Issue 434</a>
+	 */
+	@Test
+	public void testHasLikelyTensorParameterSparse() throws Exception {
+		assertTensorTypeHintClassifies();
+	}
+
+	/**
+	 * Test for #434. A {@code tf.Variable} type hint classifies the parameter as tensor-typed via the Phase 1 type-hint path; a
+	 * {@code Variable} is treated as tensor-equivalent for hybridization purposes.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/434">Issue 434</a>
+	 */
+	@Test
+	public void testHasLikelyTensorParameterVariable() throws Exception {
+		assertTensorTypeHintClassifies();
+	}
+
+	/**
+	 * Negative test for #434. A {@code tf.RaggedTensorSpec} type hint must NOT classify the parameter as tensor-typed: a {@code *Spec}
+	 * descriptor describes a tensor but is not itself one, so its FQN is excluded from the recognized set. With the type hint rejected and
+	 * a non-tensor argument, the parameter has no classifying signal.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/434">Issue 434</a>
+	 */
+	@Test
+	public void testHasLikelyTensorParameterRaggedSpec() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+		assertTrue("Fixture function is decorated with `@tf.function`.", function.isHybrid());
+
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(1, parameters.size());
+		Parameter t = parameters.get(0);
+		assertEquals("t", t.getName());
+
+		assertNotEquals("A `*Spec` type hint must NOT classify the parameter as tensor-typed.", TRUE, t.isTensor());
+		assertFalse("With no tensor classification, `getHasTensorParameter()` is FALSE.", function.getHasTensorParameter());
+	}
+
+	/**
+	 * Shared assertion for the positive #434 type-hint tests: the current fixture's single {@code @tf.function} parameter {@code t} is
+	 * classified as tensor-typed via the Phase 1 type-hint path (honored by the harness's global {@code ALWAYS_FOLLOW_TYPE_HINTS}), and the
+	 * function reflects that at {@link Function#getHasTensorParameter()}.
+	 */
+	private void assertTensorTypeHintClassifies() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+		assertTrue("Fixture function is decorated with `@tf.function`.", function.isHybrid());
+
+		List<Parameter> parameters = function.getParameters();
+		assertEquals(1, parameters.size());
+		Parameter t = parameters.get(0);
+		assertEquals("t", t.getName());
+
+		assertTrue("A TF tensor subtype type hint must classify the parameter as tensor-typed (#434).", t.isTensor());
+		assertTrue("A type-hint-classified parameter implies `getHasTensorParameter() == TRUE`.", function.getHasTensorParameter());
+	}
+
+	/**
 	 * Regression test for #486 (shape-⊤). A tensor-typed parameter whose shape Ariadne cannot resolve must surface the shape-⊤ marker (a
 	 * {@link TensorType} with {@code null} {@linkplain TensorType#getDims() dims}) so downstream code can distinguish it from a concrete
 	 * shape. The marker is visible at the {@link Parameter#getTensorTypes()} level because the {@code TensorTypeAnalysis} iterator emits


### PR DESCRIPTION
## Summary

`Parameter.hasTensorTypeHint` matched only the exact `tf.Tensor` FQN, so a parameter annotated with a tensor-equivalent subtype was never classified as tensor-typed via the Phase 1 type-hint path — e.g. `def f(t: tf.RaggedTensor)` was missed entirely. Recognize the subtype FQNs via a `TF_TENSOR_TYPE_HINT_FQNS` set: `tf.RaggedTensor`, `tf.SparseTensor`, `tf.Variable`, `tf.IndexedSlices` (plus `tf.Tensor`).

The `*Spec` descriptors (`TensorSpec`, `RaggedTensorSpec`, …) are deliberately excluded — they describe tensors but are not tensors themselves.

## Scope

This fixes **classification** only. A ragged/sparse parameter is now recognized and its function becomes a hybridization candidate, but emitting a faithful `input_signature` for it still requires `RaggedTensorSpec`/`SparseTensorSpec` support (#524/#533); dense `TensorSpec` can't represent those. Classification and signature emission are separate concerns.

## Tests

Positive tests for `tf.RaggedTensor`, `tf.SparseTensor`, `tf.Variable` (each classifies via the type hint under the harness's global `ALWAYS_FOLLOW_TYPE_HINTS`), plus a negative test pinning that `tf.RaggedTensorSpec` is not classified. All fixtures run under `python3.10`.

Closes #434