### PR TITLE
Harden Coveralls CI step against reporter-binary flakes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -73,4 +73,8 @@ jobs:
     - name: Test with Maven
       run: ./mvnw -U -s .travis.settings.xml -Dgithub.username=${{ github.actor }} -Dgithub.password=${{ secrets.GITHUB_TOKEN }} -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties -DtrimStackTrace=true -Dtycho.showEclipseLog=false -B verify -Pjacoco coveralls:report
     - name: Coveralls GitHub Action
-      uses: coverallsapp/github-action@v2.3.6
+      uses: coverallsapp/github-action@v2.3.7
+      with:
+        # Don't fail the build when the Coveralls reporter binary download/checksum or upload flakes (#601); coverage reporting is
+        # best-effort. v2.3.7 honors `fail-on-error` for binary download/verification failures, which v2.3.6 did not.
+        fail-on-error: false


### PR DESCRIPTION
## Summary

Bumps `coverallsapp/github-action` from v2.3.6 to v2.3.7 and sets `fail-on-error: false` on the Coveralls step in `maven.yml`.

## Why

The Coveralls reporter-binary download intermittently fails checksum verification on the runners. Under v2.3.6 that fails the `build` job (a required check), which blocked merges and the merge queue. v2.3.7 honors `fail-on-error` for binary download/verification failures (it didn't in v2.3.6), so with `fail-on-error: false` a Coveralls outage degrades to best-effort coverage reporting rather than failing the build.

This complements de-requiring the `coverage/coveralls (push)` status check (which addressed the separate failure mode where the build succeeds but Coveralls never posts its status).

Toward #601.