### PR TITLE
Overwrite a disagreeing `input_signature` (RECONFIGURE modify path)

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -9,6 +9,7 @@ import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P1;
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P2;
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P3;
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P4;
+import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P5;
 import static edu.cuny.hunter.hybridize.core.analysis.Refactoring.CONVERT_EAGER_FUNCTION_TO_HYBRID;
 import static edu.cuny.hunter.hybridize.core.analysis.Refactoring.OPTIMIZE_HYBRID_FUNCTION;
 import static edu.cuny.hunter.hybridize.core.analysis.Transformation.CONVERT_TO_EAGER;
@@ -61,6 +62,7 @@ import org.eclipse.text.edits.DeleteEdit;
 import org.eclipse.text.edits.InsertEdit;
 import org.eclipse.text.edits.MalformedTreeException;
 import org.eclipse.text.edits.MultiTextEdit;
+import org.eclipse.text.edits.ReplaceEdit;
 import org.eclipse.text.edits.TextEdit;
 import org.osgi.framework.FrameworkUtil;
 import org.python.pydev.ast.refactoring.AbstractPyRefactoring;
@@ -217,6 +219,13 @@ public class Function {
 		private Optional<InputSignature> suppliedInputSignature = Optional.empty();
 
 		/**
+		 * The AST expression node of the supplied {@code input_signature} argument's value (the {@code [tf.TensorSpec(...)]} list/tuple),
+		 * whether supplied by keyword or by position, or {@code null} when none was supplied. Retained so {@link #reconfigure()} can locate
+		 * the existing value's source span to overwrite it. See {@link #getSuppliedInputSignatureNode()}.
+		 */
+		private exprType suppliedInputSignatureNode;
+
+		/**
 		 * True iff this {@link Function}'s {@link decoratorsType} has parameter jit_compile.
 		 */
 		private boolean jitCompileParam;
@@ -253,8 +262,10 @@ public class Function {
 						// Parse the content of a positionally supplied `input_signature` (e.g. `@tf.function(None, [tf.TensorSpec(...)])`,
 						// where index 1 binds to `input_signature`). Python forbids passing the same parameter both positionally and by
 						// keyword, so this and the keyword branch below cannot both set the field for a well-formed decorator.
-						if (INPUT_SIGNATURE.equals(TF_FUNCTION_POSITIONAL_PARAMS[i]))
+						if (INPUT_SIGNATURE.equals(TF_FUNCTION_POSITIONAL_PARAMS[i])) {
+							this.suppliedInputSignatureNode = positionalArgs[i];
 							this.suppliedInputSignature = parseSuppliedInputSignature(positionalArgs[i]);
+						}
 					}
 				}
 
@@ -268,8 +279,10 @@ public class Function {
 						this.markParam(name.id);
 
 						// Parse the content of a keyword-form `input_signature=[tf.TensorSpec(...)]`.
-						if (INPUT_SIGNATURE.equals(name.id))
+						if (INPUT_SIGNATURE.equals(name.id)) {
+							this.suppliedInputSignatureNode = keyword.value;
 							this.suppliedInputSignature = parseSuppliedInputSignature(keyword.value);
+						}
 					}
 			} // else, tf.function is used without parameters.
 		}
@@ -376,6 +389,16 @@ public class Function {
 		 */
 		public Optional<InputSignature> getSuppliedInputSignature() {
 			return this.suppliedInputSignature;
+		}
+
+		/**
+		 * The AST expression node of the supplied {@code input_signature} value (the {@code [tf.TensorSpec(...)]} list/tuple), or
+		 * {@code null} when none was supplied. {@link #reconfigure()} uses it to locate the existing value's source span when overwriting.
+		 *
+		 * @return The supplied {@code input_signature} value node, or {@code null}.
+		 */
+		public exprType getSuppliedInputSignatureNode() {
+			return this.suppliedInputSignatureNode;
 		}
 
 		/**
@@ -1034,18 +1057,49 @@ public class Function {
 				} else if (this.getHasPrimitiveParameter() != null) { // no primitive parameters.
 					/*
 					 * This function is already correctly hybrid (tensor parameter, no primitive parameter). When input-signature inference
-					 * is enabled, the decorator carries no `input_signature` yet, the function is side-effect-free and non-recursive, and a
-					 * signature can be inferred, reconfigure the decorator to add the inferred signature instead of leaving the function
-					 * untouched. A function that already supplies an `input_signature` is deferred (the supplied signature must not be
-					 * clobbered; that is the validate-then-overwrite case). Gating on the flag keeps the default precondition matrix
-					 * unchanged.
+					 * is enabled, the function is side-effect-free and non-recursive, and a signature can be inferred and emitted, the
+					 * decorator is reconfigured: if it carries no `input_signature` yet, add the inferred one (the add path); if it carries
+					 * one that is more specific than, or incomparable with, the inferred one, overwrite it; if it carries one broader than
+					 * the inferred one, preserve it (the broader signature may be intentional); if they agree, do nothing. A supplied
+					 * signature whose content could not be modeled is left untouched. Gating on the flag keeps the default precondition
+					 * matrix unchanged.
 					 */
-					if (this.getInferInputSignatures() && !this.getHybridizationParameters().hasInputSignatureParam()
-							&& this.getHasPythonSideEffects() != null && !this.getHasPythonSideEffects() && this.isRecursive() != null
-							&& !this.isRecursive() && this.canEmitInferredInputSignature()) {
+					boolean canReconfigure = this.getInferInputSignatures() && this.getHasPythonSideEffects() != null
+							&& !this.getHasPythonSideEffects() && this.isRecursive() != null && !this.isRecursive()
+							&& this.canEmitInferredInputSignature();
+
+					if (canReconfigure && !this.getHybridizationParameters().hasInputSignatureParam()) {
+						// Add path: no existing `input_signature`.
 						this.addInfo("This hybrid function has no input signature and can be reconfigured to add the inferred one.");
 						this.addTransformation(RECONFIGURE);
 						this.setPassingPrecondition(P4);
+					} else if (canReconfigure && this.getHybridizationParameters().getSuppliedInputSignature().isPresent()) {
+						// Modify path: an existing, fully-modeled `input_signature` is present. Compare it against the inferred one.
+						InputSignature supplied = this.getHybridizationParameters().getSuppliedInputSignature().get();
+						InputSignature inferred = this.inferInputSignature().get();
+
+						switch (supplied.relate(inferred)) {
+						case SUPPLIED_TIGHTER -> {
+							this.addInfo("This hybrid function's input signature is narrower than its call sites require; "
+									+ "it can be reconfigured to admit the observed inputs.");
+							this.addTransformation(RECONFIGURE);
+							this.setPassingPrecondition(P5);
+						}
+						case INCOMPARABLE -> {
+							this.addWarning("This hybrid function's input signature disagrees with its call sites; "
+									+ "reconfiguring it will change the inputs the function accepts.");
+							this.addTransformation(RECONFIGURE);
+							this.setPassingPrecondition(P5);
+						}
+						case SUPPLIED_BROADER -> {
+							this.addInfo("This hybrid function's input signature is broader than its call sites require; "
+									+ "it is left unchanged in case the broader signature is intentional.");
+							this.addFailure(PreconditionFailure.HAS_NO_PRIMITIVE_PARAMETERS,
+									"Functions with no Python literal arguments may benefit from hybridization.");
+						}
+						case AGREEMENT -> this.addFailure(PreconditionFailure.HAS_NO_PRIMITIVE_PARAMETERS,
+								"Functions with no Python literal arguments may benefit from hybridization.");
+						}
 					} else {
 						this.addFailure(PreconditionFailure.HAS_NO_PRIMITIVE_PARAMETERS,
 								"Functions with no Python literal arguments may benefit from hybridization.");
@@ -2124,16 +2178,16 @@ public class Function {
 	}
 
 	/**
-	 * Adds the inferred {@code input_signature} to this already-hybrid function's existing {@code @tf.function} decorator (the
-	 * {@code RECONFIGURE} transformation). Selection (in {@link #check()}) guarantees the decorator carries no {@code input_signature}
-	 * yet—the supplied-signature case is deferred to validate-then-overwrite and never reaches here. Reuses the existing import-shape
-	 * resolution ({@link #getImportContext(IDocument)}) and emission gate ({@link #computeInputSignatureKeyword(ImportContext)} /
-	 * {@link #addInputSignature(ImportContext)}); a hybrid function necessarily imports TensorFlow (the decorator references it), so
-	 * {@code getImportContext} is non-null. When the signature's names are not reachable under the file's import shape (e.g.
-	 * {@code from tensorflow import function} without {@code TensorSpec}), the gate yields no keyword and no edit is produced, matching
-	 * {@link #convertToHybrid()}'s silent skip.
+	 * Reconfigures this already-hybrid function's {@code @tf.function} decorator to carry the inferred {@code input_signature} (the
+	 * {@code RECONFIGURE} transformation). When the decorator has no {@code input_signature}, the inferred one is added; when it already
+	 * has one that {@link #check()} determined should be overwritten, the existing value is replaced in place. Reuses the existing
+	 * import-shape resolution ({@link #getImportContext(IDocument)}) and emission gate
+	 * ({@link #computeInputSignatureKeyword(ImportContext)} / {@link #addInputSignature(ImportContext)}); a hybrid function necessarily
+	 * imports TensorFlow (the decorator references it), so {@code getImportContext} is non-null. When the signature's names are not
+	 * reachable under the file's import shape (e.g. {@code from tensorflow import function} without {@code TensorSpec}), the gate yields no
+	 * keyword and no edit is produced, matching {@link #convertToHybrid()}'s silent skip.
 	 *
-	 * @return The edits adding {@code input_signature=[...]} to the decorator, or an empty list when emission is gated out.
+	 * @return The edits adding or replacing {@code input_signature=[...]} on the decorator, or an empty list when emission is gated out.
 	 * @throws BadLocationException If a document offset cannot be resolved.
 	 */
 	private List<TextEdit> reconfigure() throws BadLocationException {
@@ -2148,6 +2202,43 @@ public class Function {
 			return ret;
 
 		decoratorsType decorator = this.hybridDecorator;
+
+		// Overwrite path: an existing `input_signature` value is present (its node was retained during parameter parsing). Replace its
+		// bracketed list/tuple in place with the inferred one. `check()` selects this only when the inferred signature is emittable, so
+		// `inferInputSignature` is present here.
+		exprType existingValue = this.getHybridizationParameters() == null ? null
+				: this.getHybridizationParameters().getSuppliedInputSignatureNode();
+
+		if (existingValue != null) {
+			// Span the existing value's bracketed list/tuple: from its first opening bracket to the matching close, tracking nesting.
+			int bracket = getOffset(doc, existingValue);
+			while (bracket < doc.getLength() && doc.getChar(bracket) != '[' && doc.getChar(bracket) != '(')
+				++bracket;
+
+			int depth = 0;
+			int end = bracket;
+			for (; end < doc.getLength(); end++) {
+				char c = doc.getChar(end);
+				if (c == '(' || c == '[' || c == '{')
+					++depth;
+				else if (c == ')' || c == ']' || c == '}') {
+					--depth;
+					if (depth == 0)
+						break;
+				}
+			}
+
+			final int valueOffset = bracket;
+			final int valueLength = end - bracket + 1;
+			MultiTextEdit replacement = new MultiTextEdit();
+			this.inferInputSignature()
+					.ifPresent(sig -> replacement.addChild(new ReplaceEdit(valueOffset, valueLength, sig.toTensorSpecList(ctx.prefix()))));
+
+			if (replacement.hasChildren())
+				ret.add(replacement);
+
+			return ret;
+		}
 
 		// Offset just past the decorator name (e.g. just past `function` in `@tf.function`). Mirrors `convertToEager`'s proven offset
 		// computation: the `decoratorsType` node begins at `@`, and `getFullRepresentationString(decorator.func)` yields the dotted name

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
+import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
@@ -78,6 +79,157 @@ public record InputSignature(List<TensorType> parameterTypes) {
 	 */
 	public Set<String> requiredDTypeNames() {
 		return parameterTypes.stream().map(InputSignature::dtypeName).collect(Collectors.toUnmodifiableSet());
+	}
+
+	/**
+	 * How a supplied (developer-written) signature relates to an inferred one under the per-parameter, per-axis partial order on the
+	 * tensor-type lattice. On each axis, a wildcard ({@code None}/dynamic/symbolic dimension, an unknown-rank shape, or an {@code UNKNOWN}
+	 * dtype) is the most general value; a concrete value (a fixed dimension, a known-rank shape, or a concrete dtype) is more specific; two
+	 * distinct concrete values (and two shapes of different rank) are incomparable. A signature is at least as specific as another iff it
+	 * is at least as specific on every parameter and axis.
+	 */
+	public enum Relation {
+		/** The supplied and inferred signatures are identical. */
+		AGREEMENT,
+
+		/**
+		 * The supplied signature is strictly more specific than the inferred one (it would reject inputs the call-site evidence shows the
+		 * function receives). The inferred signature should replace it.
+		 */
+		SUPPLIED_TIGHTER,
+
+		/**
+		 * The supplied signature is strictly more general than the inferred one (it admits more inputs than the evidence requires). The
+		 * supplied signature should be preserved, as the broader contract may be intentional and invisible to the static analysis.
+		 */
+		SUPPLIED_BROADER,
+
+		/**
+		 * The supplied and inferred signatures are incomparable—each is more specific than the other on some axis (or they differ in shape
+		 * rank, parameter count, or concrete dtype). The inferred signature should replace it.
+		 */
+		INCOMPARABLE
+	}
+
+	/**
+	 * Relates this signature, taken as the developer-supplied one, to {@code inferred}, the signature derived from call-site evidence by
+	 * {@link Function#inferInputSignature}. See {@link Relation} for the partial order. Used by {@link Function#check()} to decide whether
+	 * an existing {@code input_signature} should be overwritten ({@link Relation#SUPPLIED_TIGHTER}, {@link Relation#INCOMPARABLE}),
+	 * preserved ({@link Relation#SUPPLIED_BROADER}), or left untouched ({@link Relation#AGREEMENT}).
+	 *
+	 * @param inferred The signature inferred from call-site evidence.
+	 * @return How this (supplied) signature relates to {@code inferred}.
+	 */
+	public Relation relate(InputSignature inferred) {
+		List<TensorType> supplied = this.parameterTypes();
+		List<TensorType> evidence = inferred.parameterTypes();
+
+		// A parameter-count mismatch has no meaningful per-parameter order; treat it as incomparable so the inferred signature wins.
+		if (supplied.size() != evidence.size())
+			return Relation.INCOMPARABLE;
+
+		Relation result = Relation.AGREEMENT;
+		for (int i = 0; i < supplied.size(); i++)
+			result = combine(result, relate(supplied.get(i), evidence.get(i)));
+
+		return result;
+	}
+
+	/**
+	 * Combines two axis/parameter relations into the relation of the whole. {@link Relation#AGREEMENT} is the identity (a fully-agreeing
+	 * part imposes nothing); {@link Relation#INCOMPARABLE} is absorbing; and a part where the supplied side is tighter combined with one
+	 * where it is broader is itself incomparable (neither side is uniformly at least as specific).
+	 *
+	 * @param a One relation.
+	 * @param b The other relation.
+	 * @return Their combination.
+	 */
+	private static Relation combine(Relation a, Relation b) {
+		if (a == b)
+			return a;
+		if (a == Relation.AGREEMENT)
+			return b;
+		if (b == Relation.AGREEMENT)
+			return a;
+		// a and b are two different non-AGREEMENT relations: any pairing of {TIGHTER, BROADER, INCOMPARABLE} that isn't equal is
+		// incomparable overall.
+		return Relation.INCOMPARABLE;
+	}
+
+	/**
+	 * Relates a supplied {@link TensorType} to an inferred one by combining the dtype-axis and shape-axis relations.
+	 *
+	 * @param supplied The developer-supplied tensor type.
+	 * @param inferred The inferred tensor type.
+	 * @return How the supplied tensor type relates to the inferred one.
+	 */
+	private static Relation relate(TensorType supplied, TensorType inferred) {
+		return combine(relateDType(supplied.getDType(), inferred.getDType()), relateShape(supplied.getDims(), inferred.getDims()));
+	}
+
+	/**
+	 * Relates a supplied dtype to an inferred one. {@code UNKNOWN} is the lattice top (most general); two distinct concrete dtypes are
+	 * incomparable.
+	 *
+	 * @param supplied The supplied dtype.
+	 * @param inferred The inferred dtype.
+	 * @return How the supplied dtype relates to the inferred one.
+	 */
+	private static Relation relateDType(DType supplied, DType inferred) {
+		if (supplied == inferred)
+			return Relation.AGREEMENT;
+		if (supplied == DType.UNKNOWN)
+			return Relation.SUPPLIED_BROADER;
+		if (inferred == DType.UNKNOWN)
+			return Relation.SUPPLIED_TIGHTER;
+		return Relation.INCOMPARABLE; // two distinct concrete dtypes.
+	}
+
+	/**
+	 * Relates a supplied shape to an inferred one. A {@code null} dimension list is unknown rank, the lattice top (most general). Two
+	 * shapes of different rank are incomparable; otherwise the relation is the combination of the per-dimension relations.
+	 *
+	 * @param supplied The supplied dimension list, or {@code null} for unknown rank.
+	 * @param inferred The inferred dimension list, or {@code null} for unknown rank.
+	 * @return How the supplied shape relates to the inferred one.
+	 */
+	private static Relation relateShape(List<Dimension<?>> supplied, List<Dimension<?>> inferred) {
+		if (supplied == null && inferred == null)
+			return Relation.AGREEMENT;
+		if (supplied == null)
+			return Relation.SUPPLIED_BROADER; // unknown rank is more general than any known rank.
+		if (inferred == null)
+			return Relation.SUPPLIED_TIGHTER;
+		if (supplied.size() != inferred.size())
+			return Relation.INCOMPARABLE; // different ranks.
+
+		Relation result = Relation.AGREEMENT;
+		for (int i = 0; i < supplied.size(); i++)
+			result = combine(result, relateDim(supplied.get(i), inferred.get(i)));
+
+		return result;
+	}
+
+	/**
+	 * Relates a supplied dimension to an inferred one. Any non-{@link NumericDim} (dynamic {@code None}, symbolic {@code ?}, ragged) is a
+	 * wildcard—the most general dimension—so all wildcards relate as equal; a concrete {@link NumericDim} is more specific than a wildcard;
+	 * two distinct concrete dimensions are incomparable.
+	 *
+	 * @param supplied The supplied dimension.
+	 * @param inferred The inferred dimension.
+	 * @return How the supplied dimension relates to the inferred one.
+	 */
+	private static Relation relateDim(Dimension<?> supplied, Dimension<?> inferred) {
+		boolean suppliedConcrete = supplied instanceof NumericDim;
+		boolean inferredConcrete = inferred instanceof NumericDim;
+
+		if (!suppliedConcrete && !inferredConcrete)
+			return Relation.AGREEMENT; // both wildcards.
+		if (suppliedConcrete && !inferredConcrete)
+			return Relation.SUPPLIED_TIGHTER;
+		if (!suppliedConcrete && inferredConcrete)
+			return Relation.SUPPLIED_BROADER;
+		return supplied.value().equals(inferred.value()) ? Relation.AGREEMENT : Relation.INCOMPARABLE;
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/PreconditionSuccess.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/PreconditionSuccess.java
@@ -5,9 +5,18 @@ public enum PreconditionSuccess {
 
 	/**
 	 * A hybrid function that is already correctly hybrid but carries no {@code input_signature}: reconfigure its decorator to add the
-	 * inferred input signature. This is the add-when-absent path into the {@link Transformation#RECONFIGURE} transformation; modifying an
-	 * already-supplied signature (validate-then-overwrite) is a separate precondition path that reaches the same transformation, mirroring
-	 * how {@link #P2} and {@link #P3} both reach {@link Transformation#CONVERT_TO_EAGER}.
+	 * inferred input signature. This is the add-when-absent path into the {@link Transformation#RECONFIGURE} transformation; overwriting an
+	 * already-supplied signature ({@link #P5}) is a separate precondition path that reaches the same transformation, mirroring how
+	 * {@link #P2} and {@link #P3} both reach {@link Transformation#CONVERT_TO_EAGER}.
 	 */
 	P4,
+
+	/**
+	 * A hybrid function whose existing {@code input_signature} disagrees with the inferred one in a way that warrants an overwrite—the
+	 * supplied signature is strictly tighter than the inferred one (the call-site evidence admits inputs the supplied signature would
+	 * reject), or the two are incomparable: reconfigure its decorator to replace the existing signature with the inferred one. This is the
+	 * overwrite path into {@link Transformation#RECONFIGURE}; adding a signature when none is supplied is {@link #P4}. A supplied signature
+	 * that is strictly broader than the inferred one is preserved (no transformation), and an agreeing signature is a no-op.
+	 */
+	P5,
 }

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureAgreement/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureAgreement/in/A.py
@@ -1,0 +1,11 @@
+# Modify path (#596), agreement case. The supplied signature matches the inferred one exactly, so the refactoring is a no-op.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+def f(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureAgreement/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureAgreement/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureModifyFlagOff/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureModifyFlagOff/in/A.py
@@ -1,0 +1,12 @@
+# Modify path (#596), flag-off guard. With input-signature inference disabled (the suite default), an existing signature is never
+# compared or overwritten; the precondition matrix is unchanged.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+def f(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureModifyFlagOff/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureModifyFlagOff/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteIncomparable/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteIncomparable/in/A.py
@@ -1,0 +1,13 @@
+# Modify path (#596), incomparable case. The decorator pins a float32 dtype, but the call site passes an int32 tensor, so the
+# supplied and inferred dtypes are incomparable. The supplied signature is overwritten with a warning (it changes the inputs accepted
+# at runtime). The supplied signature intentionally disagrees with the call site, so this fixture is analyzed statically.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+def f(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteIncomparable/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteIncomparable/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteIncomparable/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteIncomparable/out/A.py
@@ -1,0 +1,13 @@
+# Modify path (#596), incomparable case. The decorator pins a float32 dtype, but the call site passes an int32 tensor, so the
+# supplied and inferred dtypes are incomparable. The supplied signature is overwritten with a warning (it changes the inputs accepted
+# at runtime). The supplied signature intentionally disagrees with the call site, so this fixture is analyzed statically.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.int32)])
+def f(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteTighter/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteTighter/in/A.py
@@ -1,0 +1,15 @@
+# Modify path (#596), supplied-tighter case. The decorator pins a concrete rank-1 shape, but the call sites pass tensors of
+# differing rank (scalar and rank-1), so inference degrades the shape to unknown rank (shape=None). The supplied signature is strictly
+# tighter than the evidence, so it is overwritten (informational). The supplied signature intentionally disagrees with the call sites,
+# so this fixture is analyzed statically rather than executed.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=(2,), dtype=tf.float32)])
+def f(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))
+    f(tf.ones([2]))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteTighter/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteTighter/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteTighter/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigureOverwriteTighter/out/A.py
@@ -1,0 +1,15 @@
+# Modify path (#596), supplied-tighter case. The decorator pins a concrete rank-1 shape, but the call sites pass tensors of
+# differing rank (scalar and rank-1), so inference degrades the shape to unknown rank (shape=None). The supplied signature is strictly
+# tighter than the evidence, so it is overwritten (informational). The supplied signature intentionally disagrees with the call sites,
+# so this fixture is analyzed statically rather than executed.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=None, dtype=tf.float32)])
+def f(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))
+    f(tf.ones([2]))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigurePreserveBroader/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigurePreserveBroader/in/A.py
@@ -1,0 +1,12 @@
+# Modify path (#596), supplied-broader case. The decorator's shape=None admits any shape, broader than the concrete scalar the call
+# site requires. The broader signature may be intentional, so it is preserved (informational), not overwritten.
+import tensorflow as tf
+
+
+@tf.function(input_signature=[tf.TensorSpec(shape=None, dtype=tf.float32)])
+def f(t):
+    return t + 1
+
+
+if __name__ == "__main__":
+    f(tf.constant(2.0))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigurePreserveBroader/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testReconfigurePreserveBroader/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -18,6 +18,7 @@ import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P1;
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P2;
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P3;
 import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P4;
+import static edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess.P5;
 import static edu.cuny.hunter.hybridize.core.analysis.Refactoring.CONVERT_EAGER_FUNCTION_TO_HYBRID;
 import static edu.cuny.hunter.hybridize.core.analysis.Refactoring.OPTIMIZE_HYBRID_FUNCTION;
 import static edu.cuny.hunter.hybridize.core.analysis.Transformation.CONVERT_TO_EAGER;
@@ -1778,6 +1779,114 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 		String expected = this.getFileContents(this.getOutputTestFileName("A"));
 		assertEqualLines(expected, doc.get());
+	}
+
+	/**
+	 * Modify path (#596), supplied-tighter: the existing {@code input_signature} is more specific than the call-site evidence (a concrete
+	 * rank-1 shape against call sites of differing rank, which infer an unknown-rank shape), so it is overwritten with the inferred one and
+	 * reported informationally.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/596">Issue 596</a>
+	 */
+	@Test
+	public void testReconfigureOverwriteTighter() throws Exception {
+		helperAssertReconfigureOverwrite(false, "narrower than its call sites require");
+	}
+
+	/**
+	 * Modify path (#596), incomparable: the existing {@code input_signature} is incomparable with the inferred one (a float32 dtype against
+	 * an int32 call site), so it is overwritten with a warning.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/596">Issue 596</a>
+	 */
+	@Test
+	public void testReconfigureOverwriteIncomparable() throws Exception {
+		helperAssertReconfigureOverwrite(true, "disagrees with its call sites");
+	}
+
+	/**
+	 * Shared assertion for the modify-path overwrite tests: the single hybrid fixture function selects {@link Transformation#RECONFIGURE}
+	 * with passing precondition {@link PreconditionSuccess#P5}, emits a status of the expected severity (warning for an incomparable
+	 * signature, informational otherwise) containing {@code messageFragment}, and rewrites the decorator to match {@code out/A.py}.
+	 *
+	 * @param expectWarning True iff the per-category status should be a warning (the incomparable case).
+	 * @param messageFragment A fragment the per-category status message must contain.
+	 */
+	private void helperAssertReconfigureOverwrite(boolean expectWarning, String messageFragment) throws Exception {
+		this.setInferInputSignatures(true);
+
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertTrue("Fixture function `f` should be hybrid.", f.isHybrid());
+		assertEquals("A modify-path overwrite should select `RECONFIGURE`.", singleton(RECONFIGURE), f.getTransformations());
+		assertEquals("A modify-path overwrite should set the P5 passing precondition.", P5, f.getPassingPrecondition());
+
+		boolean found = Arrays.stream(f.getStatus().getEntries())
+				.anyMatch(e -> (expectWarning ? e.isWarning() : e.isInfo()) && e.getMessage().contains(messageFragment));
+		assertTrue("Expected a " + (expectWarning ? "warning" : "informational") + " status containing: " + messageFragment, found);
+
+		IDocument doc = f.getContainingDocument();
+		List<TextEdit> edits = new ArrayList<>(f.transform());
+		edits.sort(Comparator.comparingInt(TextEdit::getOffset).reversed());
+
+		for (TextEdit edit : edits)
+			edit.apply(doc);
+
+		assertEqualLines(this.getFileContents(this.getOutputTestFileName("A")), doc.get());
+	}
+
+	/**
+	 * Modify path (#596), supplied-broader: the existing {@code input_signature} (an unknown-rank shape) is broader than the call sites
+	 * require, so it is preserved (not overwritten) and the divergence is reported informationally.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/596">Issue 596</a>
+	 */
+	@Test
+	public void testReconfigurePreserveBroader() throws Exception {
+		this.setInferInputSignatures(true);
+
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertTrue("Fixture function `f` should be hybrid.", f.isHybrid());
+		assertFalse("A broader supplied signature must not be overwritten.", f.getTransformations().contains(RECONFIGURE));
+		assertTrue("Expected an informational status about preserving the broader signature.", Arrays.stream(f.getStatus().getEntries())
+				.anyMatch(e -> e.isInfo() && e.getMessage().contains("broader than its call sites require")));
+	}
+
+	/**
+	 * Modify path (#596), agreement: the supplied {@code input_signature} matches the inferred one, so the refactoring is a no-op (no
+	 * transformation selected).
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/596">Issue 596</a>
+	 */
+	@Test
+	public void testReconfigureAgreement() throws Exception {
+		this.setInferInputSignatures(true);
+
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertTrue("Fixture function `f` should be hybrid.", f.isHybrid());
+		assertFalse("An agreeing signature must not be reconfigured.", f.getTransformations().contains(RECONFIGURE));
+	}
+
+	/**
+	 * Modify path (#596), flag-off guard: with input-signature inference disabled (the suite default), an existing signature is never
+	 * compared or overwritten, so the default precondition matrix is unchanged.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/596">Issue 596</a>
+	 */
+	@Test
+	public void testReconfigureModifyFlagOff() throws Exception {
+		// The `inferInputSignatures` flag defaults off; intentionally do not enable it.
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertTrue("Fixture function `f` should be hybrid.", f.isHybrid());
+		assertFalse("With inference disabled, an existing signature must not be overwritten.",
+				f.getTransformations().contains(RECONFIGURE));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
@@ -4,6 +4,7 @@ import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.BOOL;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.INT32;
 import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.STRING;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.UNKNOWN;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -18,6 +19,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 
 import edu.cuny.hunter.hybridize.core.analysis.InputSignature;
+import edu.cuny.hunter.hybridize.core.analysis.InputSignature.Relation;
 
 /**
  * Tests for {@link InputSignature#toTensorSpecList(String)}.
@@ -132,5 +134,135 @@ public class InputSignatureTest {
 		} finally {
 			Locale.setDefault(prior);
 		}
+	}
+
+	private static InputSignature sig(TensorType... types) {
+		return new InputSignature(List.of(types));
+	}
+
+	/**
+	 * Identical signatures agree.
+	 */
+	@Test
+	public void testRelateAgreement() {
+		InputSignature a = sig(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
+		InputSignature b = sig(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
+		assertEquals(Relation.AGREEMENT, a.relate(b));
+	}
+
+	/**
+	 * A concrete supplied dimension where the inferred one is a wildcard makes the supplied signature strictly tighter.
+	 */
+	@Test
+	public void testRelateSuppliedTighterByDim() {
+		InputSignature supplied = sig(new TensorType(FLOAT32, List.of(new NumericDim(32), new NumericDim(784))));
+		InputSignature inferred = sig(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(784))));
+		assertEquals(Relation.SUPPLIED_TIGHTER, supplied.relate(inferred));
+	}
+
+	/**
+	 * A known-rank supplied shape against an unknown-rank ({@code null} dims) inferred shape is strictly tighter.
+	 */
+	@Test
+	public void testRelateSuppliedTighterByShapeTop() {
+		InputSignature supplied = sig(new TensorType(FLOAT32, List.of(new NumericDim(2))));
+		InputSignature inferred = sig(new TensorType(FLOAT32, null));
+		assertEquals(Relation.SUPPLIED_TIGHTER, supplied.relate(inferred));
+	}
+
+	/**
+	 * A concrete supplied dtype against an {@code UNKNOWN} inferred dtype is strictly tighter (defensive: inference drops {@code UNKNOWN}
+	 * upstream, but the lattice still orders it as the top).
+	 */
+	@Test
+	public void testRelateSuppliedTighterByDtype() {
+		InputSignature supplied = sig(new TensorType(FLOAT32, List.of(new NumericDim(2))));
+		InputSignature inferred = sig(new TensorType(UNKNOWN, List.of(new NumericDim(2))));
+		assertEquals(Relation.SUPPLIED_TIGHTER, supplied.relate(inferred));
+	}
+
+	/**
+	 * A wildcard supplied dimension where the inferred one is concrete makes the supplied signature strictly broader.
+	 */
+	@Test
+	public void testRelateSuppliedBroaderByDim() {
+		InputSignature supplied = sig(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(784))));
+		InputSignature inferred = sig(new TensorType(FLOAT32, List.of(new NumericDim(32), new NumericDim(784))));
+		assertEquals(Relation.SUPPLIED_BROADER, supplied.relate(inferred));
+	}
+
+	/**
+	 * An unknown-rank ({@code null} dims) supplied shape against a known-rank inferred shape is strictly broader.
+	 */
+	@Test
+	public void testRelateSuppliedBroaderByShapeTop() {
+		InputSignature supplied = sig(new TensorType(FLOAT32, null));
+		InputSignature inferred = sig(new TensorType(FLOAT32, List.of(new NumericDim(2))));
+		assertEquals(Relation.SUPPLIED_BROADER, supplied.relate(inferred));
+	}
+
+	/**
+	 * Two distinct concrete dimensions at the same position are incomparable.
+	 */
+	@Test
+	public void testRelateIncomparableByDim() {
+		InputSignature supplied = sig(new TensorType(FLOAT32, List.of(new NumericDim(32), new NumericDim(784))));
+		InputSignature inferred = sig(new TensorType(FLOAT32, List.of(new NumericDim(16), new NumericDim(784))));
+		assertEquals(Relation.INCOMPARABLE, supplied.relate(inferred));
+	}
+
+	/**
+	 * Two distinct concrete dtypes are incomparable.
+	 */
+	@Test
+	public void testRelateIncomparableByDtype() {
+		InputSignature supplied = sig(new TensorType(FLOAT32, List.of(new NumericDim(2))));
+		InputSignature inferred = sig(new TensorType(INT32, List.of(new NumericDim(2))));
+		assertEquals(Relation.INCOMPARABLE, supplied.relate(inferred));
+	}
+
+	/**
+	 * Two shapes of different rank are incomparable.
+	 */
+	@Test
+	public void testRelateIncomparableByRank() {
+		InputSignature supplied = sig(new TensorType(FLOAT32, List.of(new NumericDim(2))));
+		InputSignature inferred = sig(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(2))));
+		assertEquals(Relation.INCOMPARABLE, supplied.relate(inferred));
+	}
+
+	/**
+	 * A signature that is tighter on one parameter and broader on another is incomparable overall (neither is uniformly at least as
+	 * specific).
+	 */
+	@Test
+	public void testRelateIncomparableMixedParameters() {
+		InputSignature supplied = sig(new TensorType(FLOAT32, List.of(new NumericDim(32))),
+				new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE)));
+		InputSignature inferred = sig(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE)),
+				new TensorType(FLOAT32, List.of(new NumericDim(32))));
+		assertEquals(Relation.INCOMPARABLE, supplied.relate(inferred));
+	}
+
+	/**
+	 * Different parameter counts are incomparable.
+	 */
+	@Test
+	public void testRelateIncomparableParameterCount() {
+		InputSignature supplied = sig(new TensorType(FLOAT32, List.of(new NumericDim(2))));
+		InputSignature inferred = sig(new TensorType(FLOAT32, List.of(new NumericDim(2))),
+				new TensorType(FLOAT32, List.of(new NumericDim(2))));
+		assertEquals(Relation.INCOMPARABLE, supplied.relate(inferred));
+	}
+
+	/**
+	 * All wildcard kinds ({@link DynamicDim}, {@link SymbolicDim}) are the lattice top and relate as equal, so a supplied {@code None}
+	 * agrees with an inferred symbolic wildcard.
+	 */
+	@Test
+	public void testRelateWildcardKindsAgree() {
+		InputSignature supplied = sig(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(784))));
+		InputSignature inferred = sig(new TensorType(FLOAT32, List.of(new SymbolicDim("?"), new NumericDim(784))));
+		assertEquals(Relation.AGREEMENT, supplied.relate(inferred));
 	}
 }


### PR DESCRIPTION
## Summary

Completes the `RECONFIGURE` transformation: when a hybrid `@tf.function` already supplies an `input_signature`, compare it against the inferred one and respond per the relation. The add-when-absent half landed earlier (#563); this is the modify half (#596).

The comparison is a per-parameter, per-axis partial order on the tensor-type lattice: a wildcard (`None`/dynamic/symbolic dimension, unknown-rank shape, or `UNKNOWN` dtype) is the most general value, a concrete value is more specific, and two distinct concrete values (or shapes of different rank) are incomparable.

| Relation | Action | Status |
|---|---|---|
| supplied strictly tighter than inferred | overwrite with inferred | informational |
| supplied strictly broader | preserve | informational |
| incomparable | overwrite with inferred | warning |
| agreement | no-op | — |

## Changes

- `PreconditionSuccess.P5` for the overwrite path. `check()` selects `RECONFIGURE`+`P5` for the overwrite relations, preserves for the broader relation, and no-ops on agreement — gated on the `inferInputSignatures` flag (default off), side-effect-free, non-recursive, and an emittable inferred signature, so the default precondition matrix is unchanged.
- `reconfigure()` extended from insertion to in-place replacement of the existing `input_signature` value (its AST node is retained during parameter parsing so its source span can be located).
- `InputSignature.Relation` + `relate()` implement the lattice comparison.

## Tests

`InputSignature.relate()` is unit-tested directly (deterministic, no analysis) across all relations and edge cases (rank/dtype/parameter-count mismatch, wildcard equivalence). Integration fixtures cover one example per relation — overwrite (tighter, informational), overwrite (incomparable, warning), preserve (broader), agreement (no-op) — plus a flag-off guard, asserting the emitted source and the status severity. The overwrite fixtures intentionally carry a signature the call sites violate, so they are analyzed statically rather than executed. Full suite: 531 pass, 11 known-skipped.

Closes #596