### PR TITLE
Emit inferred `input_signature` and supplied-vs-inferred relation in the evaluator

### DIFF
--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -515,11 +515,13 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasJitCompileParam());
 		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasReduceRetracingParam());
 
-		// The inferred signature the refactoring computed for this function, how it relates to an explicitly supplied one, and—when no
-		// signature was inferred—why. All read the memoized inference result without recomputing, so they leave the status untouched. When
-		// the refactoring did not run inference on a function, all three are blank. When it did, exactly one of the inferred-content and
-		// absence-reason columns is populated: the content when a signature was inferred, the reason when inference was blocked. (The
-		// inferred-content column is thus blank both when inference never ran and when it ran but was blocked.)
+		/*
+		 * The inferred signature the refactoring computed for this function, how it relates to an explicitly supplied one, and—when no
+		 * signature was inferred—why. All read the memoized inference result without recomputing, so they leave the status untouched. When
+		 * the refactoring did not run inference on a function, all three are blank. When it did, exactly one of the inferred-content and
+		 * absence-reason columns is populated: the content when a signature was inferred, the reason when inference was blocked. (The
+		 * inferred-content column is thus blank both when inference never ran and when it ran but was blocked.)
+		 */
 		printer.print(function.getInferredInputSignature().map(s -> s.toTensorSpecList("tf.")).orElse(null));
 		printer.print(hybridizationParameters == null ? null
 				: hybridizationParameters.getSuppliedInputSignature()

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -492,7 +492,8 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 		return buildAttributeColumnNames("method reference", "type reference", "method", "parameters", "tensor parameter",
 				"primitive parameter", "hybrid", "side-effects", "recursive", "autograph", "experimental_autograph_options",
 				"experimental_follow_type_hints", "experimental_implements", "func", "input_signature", "jit_compile", "reduce_retracing",
-				"inferred input_signature", "input_signature relation", "refactoring", "passing precondition", "status");
+				"inferred input_signature", "input_signature relation", "input_signature absence reason", "refactoring",
+				"passing precondition", "status");
 	}
 
 	private static void printFunction(CSVPrinter printer, Function function) throws IOException, CoreException {
@@ -514,13 +515,15 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasJitCompileParam());
 		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasReduceRetracingParam());
 
-		// The inferred signature the refactoring computed for this function, and how it relates to an explicitly supplied one. Both read
-		// the memoized inference result without recomputing, so they leave the status untouched: they are blank for functions where the
-		// refactoring never ran inference.
+		// The inferred signature the refactoring computed for this function, how it relates to an explicitly supplied one, and—when no
+		// signature was inferred—why. All read the memoized inference result without recomputing, so they leave the status untouched: they
+		// are blank for functions where the refactoring never ran inference. For a function inference ran on, exactly one of the inferred
+		// content and the absence reason is populated.
 		printer.print(function.getInferredInputSignature().map(s -> s.toTensorSpecList("tf.")).orElse(null));
 		printer.print(hybridizationParameters == null ? null
 				: hybridizationParameters.getSuppliedInputSignature()
 						.flatMap(supplied -> function.getInferredInputSignature().map(supplied::relate)).orElse(null));
+		printer.print(function.getInferredInputSignatureAbsenceReason().orElse(null));
 
 		printer.print(function.getRefactoring());
 		printer.print(function.getPassingPrecondition());

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -516,9 +516,10 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasReduceRetracingParam());
 
 		// The inferred signature the refactoring computed for this function, how it relates to an explicitly supplied one, and—when no
-		// signature was inferred—why. All read the memoized inference result without recomputing, so they leave the status untouched: they
-		// are blank for functions where the refactoring never ran inference. For a function inference ran on, exactly one of the inferred
-		// content and the absence reason is populated.
+		// signature was inferred—why. All read the memoized inference result without recomputing, so they leave the status untouched. When
+		// the refactoring did not run inference on a function, all three are blank. When it did, exactly one of the inferred-content and
+		// absence-reason columns is populated: the content when a signature was inferred, the reason when inference was blocked. (The
+		// inferred-content column is thus blank both when inference never ran and when it ran but was blocked.)
 		printer.print(function.getInferredInputSignature().map(s -> s.toTensorSpecList("tf.")).orElse(null));
 		printer.print(hybridizationParameters == null ? null
 				: hybridizationParameters.getSuppliedInputSignature()

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -492,7 +492,7 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 		return buildAttributeColumnNames("method reference", "type reference", "method", "parameters", "tensor parameter",
 				"primitive parameter", "hybrid", "side-effects", "recursive", "autograph", "experimental_autograph_options",
 				"experimental_follow_type_hints", "experimental_implements", "func", "input_signature", "jit_compile", "reduce_retracing",
-				"refactoring", "passing precondition", "status");
+				"inferred input_signature", "input_signature relation", "refactoring", "passing precondition", "status");
 	}
 
 	private static void printFunction(CSVPrinter printer, Function function) throws IOException, CoreException {
@@ -513,6 +513,14 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasInputSignatureParam());
 		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasJitCompileParam());
 		printer.print(hybridizationParameters == null ? null : hybridizationParameters.hasReduceRetracingParam());
+
+		// The inferred signature the refactoring computed for this function, and how it relates to an explicitly supplied one. Both read
+		// the memoized inference result without recomputing, so they leave the status untouched: they are blank for functions where the
+		// refactoring never ran inference.
+		printer.print(function.getInferredInputSignature().map(s -> s.toTensorSpecList("tf.")).orElse(null));
+		printer.print(hybridizationParameters == null ? null
+				: hybridizationParameters.getSuppliedInputSignature()
+						.flatMap(supplied -> function.getInferredInputSignature().map(supplied::relate)).orElse(null));
 
 		printer.print(function.getRefactoring());
 		printer.print(function.getPassingPrecondition());


### PR DESCRIPTION
Adds three per-function CSV columns to the evaluator, together characterizing each function's input-signature inference outcome across the corpus:

- `inferred input_signature`—the signature the refactoring computed, as a `tf.TensorSpec(...)` list.
- `input_signature relation`—when both an explicit and an inferred signature exist, how they relate under the per-parameter, per-axis order (agreement, supplied tighter, supplied broader, incomparable).
- `input_signature absence reason`—when inference ran but was blocked, why (non-tensor parameter, no shape/dtype evidence, heterogeneous dtype, dtype-⊤).

For a function the refactoring ran inference on, exactly one of the inferred content and the absence reason is populated. All three read the memoized inference result via the side-effect-free getters (`getInferredInputSignature()`, `getInferredInputSignatureAbsenceReason()`), so they leave the existing `status` column untouched and are blank for functions where the refactoring never ran inference. The relation column reuses the lattice comparison from #608; the absence reason reuses the typed result from #483.

Stacked on #483 → #588 → #612 → #608. The `supplied input_signature` content column (#610, off `main`) is independent; when both land they touch adjacent entries in the column lists and merge trivially.

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)
