### PR TITLE
Bump Ariadne to 0.48.0

### DIFF
--- a/hybridize.target
+++ b/hybridize.target
@@ -57,7 +57,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.47.0</version>
+					<version>0.48.0</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
Bumps `com.ibm.wala.cast.python.ml` (fat) in `hybridize.target` from 0.47.0 to 0.48.0, picking up the configurable selective k-CFA depth (ponder-lab/ML#371).

**Draft — blocked.** 0.48.0 regresses two tests that pass on 0.47.0 (identical Hybridize code; only the Ariadne version changes), so CI here is expected red until upstream is resolved:

- `testNeuralNetwork` errors with an uncaught `NonBroadcastableShapesException` (shapes `[D:Constant,256]` and `[D:Constant,10000]` in `tf.equal`) thrown out of `TensorGenerator` — wala/ML#583.
- `testExtractPatches` loses its tensor-parameter classification (`getHasTensorParameter()` is now `false`) — wala/ML#584.

Both are new since ponder-lab/ML#371. This PR stays in draft until the upstream issues are fixed (or one is confirmed an intended change warranting a fixture update).

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)