### PR TITLE
Emit `RaggedTensorSpec` for ragged tensor parameters

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1980,8 +1980,9 @@ public class Function {
 	 * <li><b>Rank consensus or shape-⊤.</b> If any context has {@code dims == null} (unknown rank) or the ranks disagree across contexts,
 	 * emit a coarse {@code TensorType(dtype, null)} (shape-⊤). This is a valid, runtime-accepted signature.
 	 * <li><b>Per-position consensus or wildcard.</b> For each dimension position, if all contexts agree on a concrete value, keep it;
-	 * otherwise emit a {@link SymbolicDim}({@code "?"}) wildcard. Any non-{@link NumericDim} context dim also yields a wildcard at that
-	 * position.
+	 * otherwise emit a {@link SymbolicDim}({@code "?"}) wildcard. A consensus {@link RaggedDim} is preserved (it drives
+	 * {@link InputSignature#toTensorSpecList} to emit a {@code RaggedTensorSpec}); any other non-{@link NumericDim} context dim yields a
+	 * wildcard at that position.
 	 * </ol>
 	 *
 	 * @param contexts The non-empty set of {@link TensorType}s Ariadne associated with the parameter across call contexts.
@@ -2044,9 +2045,10 @@ public class Function {
 			else if (consensus instanceof DynamicDim)
 				shape.add(new SymbolicDim("?"));
 			else if (consensus instanceof RaggedDim)
-				// TODO(https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/524): once `RaggedTensorSpec` emission lands,
-				// route ragged dims there instead of collapsing.
-				shape.add(new SymbolicDim("?"));
+				// Preserve the ragged marker so the emission can produce a `RaggedTensorSpec` rather than a dense `TensorSpec` (#524). The
+				// position renders as `None` on the spec surface either way; the marker drives the spec-type choice in
+				// `InputSignature.toTensorSpecList`.
+				shape.add(consensus);
 			else
 				shape.add(new SymbolicDim("?"));
 		}
@@ -2446,14 +2448,15 @@ public class Function {
 	/**
 	 * Returns the {@code input_signature=[tfPrefix + "TensorSpec(...)", ...]} keyword argument when the flag is on and the inference
 	 * produces a signature whose names are all reachable under the import context. Returns {@link Optional#empty} otherwise (flag off, no
-	 * signature, {@code TensorSpec} not reachable, or a required dtype constant not reachable). The keyword text only; callers handle the
-	 * surrounding syntax (parenthesization via {@link #addInputSignature(ImportContext)}, or a leading {@code ", "} when injecting into an
-	 * existing arg list).
+	 * signature, a required spec-type constructor not reachable, or a required dtype constant not reachable). The keyword text only;
+	 * callers handle the surrounding syntax (parenthesization via {@link #addInputSignature(ImportContext)}, or a leading {@code ", "} when
+	 * injecting into an existing arg list).
 	 * <p>
-	 * The dtype-reachability check guards the {@code from tensorflow import ...} named-import path: {@code TensorSpec} being in scope does
-	 * not imply the signature's dtype constants (e.g. {@code float32}) are too, so emitting unconditionally would produce a
-	 * {@code NameError}-raising decorator. When any required dtype constant is out of scope, emission is skipped rather than qualified—the
-	 * named-import shape has no module prefix to qualify with.
+	 * The reachability checks guard the {@code from tensorflow import ...} named-import path: {@code TensorSpec} being in scope does not
+	 * imply the signature's dtype constants (e.g. {@code float32}) are too, nor that {@code RaggedTensorSpec} is in scope for a ragged
+	 * parameter ({@link InputSignature#requiredSpecTypeNames}), so emitting unconditionally would produce a {@code NameError}-raising
+	 * decorator. When any required name is out of scope, emission is skipped rather than qualified—the named-import shape has no module
+	 * prefix to qualify with.
 	 *
 	 * @param ctx The import context for the containing file.
 	 * @return The {@code input_signature=...} keyword argument, or empty.
@@ -2462,7 +2465,8 @@ public class Function {
 	private Optional<String> computeInputSignatureKeyword(ImportContext ctx) {
 		if (!this.getInferInputSignatures() || !ctx.tensorSpecReachable())
 			return Optional.empty();
-		return this.inferInputSignature().signature().filter(sig -> sig.requiredDTypeNames().stream().allMatch(ctx::nameReachable))
+		return this.inferInputSignature().signature().filter(sig -> sig.requiredSpecTypeNames().stream().allMatch(ctx::nameReachable))
+				.filter(sig -> sig.requiredDTypeNames().stream().allMatch(ctx::nameReachable))
 				.map(sig -> "input_signature=" + sig.toTensorSpecList(ctx.prefix()));
 	}
 

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -2282,7 +2282,7 @@ public class Function {
 			// Emission is reachable iff this function's required names are among those the injected line brought into scope; the
 			// `computeInputSignatureKeyword` gate enforces that, so a later function needing a dtype the first did not inject is
 			// safely skipped rather than emitting a `NameError`-raising decorator.
-			ctx = new ImportContext("", injectedNames.contains("TensorSpec"), false, injectedNames);
+			ctx = new ImportContext("", false, injectedNames);
 		}
 
 		// Compose the whole decorator into one InsertEdit rather than three same-offset ones, so correctness doesn't depend on Eclipse
@@ -2422,15 +2422,13 @@ public class Function {
 	 * the explicitly listed names.
 	 *
 	 * @param prefix The TensorFlow module prefix (e.g., {@code "tf."}, {@code "tensorflow."}, or {@code ""}).
-	 * @param tensorSpecReachable True iff {@code TensorSpec} can be referenced from the file using the {@code prefix}, without an
-	 *        additional import.
 	 * @param allNamesReachable True iff every TensorFlow name (including all dtype constants) is reachable under the {@code prefix} without
 	 *        an additional import—the case for qualified ({@code import tensorflow [as X]}) and wildcard ({@code from tensorflow import *})
 	 *        shapes. False for the named-import shape, where only {@code namedImports} are in scope.
 	 * @param namedImports The bare names brought into scope by a {@code from tensorflow import ...} statement; consulted only when
 	 *        {@code allNamesReachable} is false.
 	 */
-	private record ImportContext(String prefix, boolean tensorSpecReachable, boolean allNamesReachable, Set<String> namedImports) {
+	private record ImportContext(String prefix, boolean allNamesReachable, Set<String> namedImports) {
 
 		/**
 		 * Whether the bare TensorFlow name {@code name} (e.g., a dtype constant like {@code "float32"}) can be referenced as
@@ -2463,8 +2461,11 @@ public class Function {
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/585">Issue 585</a>
 	 */
 	private Optional<String> computeInputSignatureKeyword(ImportContext ctx) {
-		if (!this.getInferInputSignatures() || !ctx.tensorSpecReachable())
+		if (!this.getInferInputSignatures())
 			return Optional.empty();
+		// The signature's own spec-type names (`TensorSpec` and/or `RaggedTensorSpec`) are authoritative for reachability. A separate
+		// upfront `TensorSpec`-reachable gate would be redundant for a dense signature and would wrongly block a ragged-only signature
+		// when `RaggedTensorSpec` is imported but `TensorSpec` is not.
 		return this.inferInputSignature().signature().filter(sig -> sig.requiredSpecTypeNames().stream().allMatch(ctx::nameReachable))
 				.filter(sig -> sig.requiredDTypeNames().stream().allMatch(ctx::nameReachable))
 				.map(sig -> "input_signature=" + sig.toTensorSpecList(ctx.prefix()));
@@ -2544,11 +2545,11 @@ public class Function {
 		// unqualified. Otherwise a named `from tensorflow import ...` makes `function` reachable unqualified, and `TensorSpec` and the
 		// dtype constants only if they too were named.
 		if (qualifiedPrefix != null)
-			return new ImportContext(qualifiedPrefix, true, true, Collections.emptySet());
+			return new ImportContext(qualifiedPrefix, true, Collections.emptySet());
 		if (wildcard)
-			return new ImportContext("", true, true, Collections.emptySet());
+			return new ImportContext("", true, Collections.emptySet());
 		if (namedImports.contains("function"))
-			return new ImportContext("", namedImports.contains("TensorSpec"), false, namedImports);
+			return new ImportContext("", false, namedImports);
 
 		// not found.
 		return null;

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -2045,9 +2045,11 @@ public class Function {
 			else if (consensus instanceof DynamicDim)
 				shape.add(new SymbolicDim("?"));
 			else if (consensus instanceof RaggedDim)
-				// Preserve the ragged marker so the emission can produce a `RaggedTensorSpec` rather than a dense `TensorSpec` (#524). The
-				// position renders as `None` on the spec surface either way; the marker drives the spec-type choice in
-				// `InputSignature.toTensorSpecList`.
+				/*
+				 * Preserve the ragged marker so the emission can produce a `RaggedTensorSpec` rather than a dense `TensorSpec` (#524). The
+				 * position renders as `None` on the spec surface either way; the marker drives the spec-type choice in
+				 * `InputSignature.toTensorSpecList`.
+				 */
 				shape.add(consensus);
 			else
 				shape.add(new SymbolicDim("?"));
@@ -2463,9 +2465,11 @@ public class Function {
 	private Optional<String> computeInputSignatureKeyword(ImportContext ctx) {
 		if (!this.getInferInputSignatures())
 			return Optional.empty();
-		// The signature's own spec-type names (`TensorSpec` and/or `RaggedTensorSpec`) are authoritative for reachability. A separate
-		// upfront `TensorSpec`-reachable gate would be redundant for a dense signature and would wrongly block a ragged-only signature
-		// when `RaggedTensorSpec` is imported but `TensorSpec` is not.
+		/*
+		 * The signature's own spec-type names (`TensorSpec` and/or `RaggedTensorSpec`) are authoritative for reachability. A separate
+		 * upfront `TensorSpec`-reachable gate would be redundant for a dense signature and would wrongly block a ragged-only signature when
+		 * `RaggedTensorSpec` is imported but `TensorSpec` is not.
+		 */
 		return this.inferInputSignature().signature().filter(sig -> sig.requiredSpecTypeNames().stream().allMatch(ctx::nameReachable))
 				.filter(sig -> sig.requiredDTypeNames().stream().allMatch(ctx::nameReachable))
 				.map(sig -> "input_signature=" + sig.toTensorSpecList(ctx.prefix()));

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
@@ -22,6 +22,12 @@ import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
  */
 public record InputSignature(List<TensorType> parameterTypes) {
 
+	/** The {@code tf.TensorSpec} constructor name, emitted for a dense tensor parameter. */
+	private static final String TENSOR_SPEC = "TensorSpec";
+
+	/** The {@code tf.RaggedTensorSpec} constructor name, emitted for a ragged tensor parameter (#524). */
+	private static final String RAGGED_TENSOR_SPEC = "RaggedTensorSpec";
+
 	/**
 	 * Format this signature as a Python source-code expression suitable for the {@code input_signature=} keyword argument of
 	 * {@code @tf.function(...)}. Each parameter's {@link TensorType} renders as {@code tfPrefix + "<SpecType>(shape=(...), dtype=" +
@@ -80,7 +86,7 @@ public record InputSignature(List<TensorType> parameterTypes) {
 	private static String specTypeName(TensorType t) {
 		List<Dimension<?>> dims = t.getDims();
 		boolean ragged = dims != null && dims.stream().anyMatch(RaggedDim.class::isInstance);
-		return ragged ? "RaggedTensorSpec" : "TensorSpec";
+		return ragged ? RAGGED_TENSOR_SPEC : TENSOR_SPEC;
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
@@ -10,6 +10,7 @@ import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.Dimension;
 import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 
 /**
  * The inferred input signature of a hybridizable function: an ordered tuple of {@link TensorType}s in declaration order, one per
@@ -23,10 +24,11 @@ public record InputSignature(List<TensorType> parameterTypes) {
 
 	/**
 	 * Format this signature as a Python source-code expression suitable for the {@code input_signature=} keyword argument of
-	 * {@code @tf.function(...)}. Each parameter's {@link TensorType} renders as {@code tfPrefix + "TensorSpec(shape=(...), dtype=" +
-	 * tfPrefix + "<dtype>)"}; shape dims render as concrete integers for {@link NumericDim} and {@code None} for every other
-	 * {@link Dimension} subtype (dynamic, ragged, symbolic—all encoded the same way on the {@code TensorSpec} surface). The whole thing is
-	 * wrapped in {@code [...]} so it can drop straight into {@code @tf.function(input_signature=...)}.
+	 * {@code @tf.function(...)}. Each parameter's {@link TensorType} renders as {@code tfPrefix + "<SpecType>(shape=(...), dtype=" +
+	 * tfPrefix + "<dtype>)"}, where {@code <SpecType>} is {@code RaggedTensorSpec} for a parameter with a ragged dimension and
+	 * {@code TensorSpec} otherwise ({@link #specTypeName}); shape dims render as concrete integers for {@link NumericDim} and {@code None}
+	 * for every other {@link Dimension} subtype (dynamic, ragged, symbolic—all encoded the same way on the spec surface). The whole thing
+	 * is wrapped in {@code [...]} so it can drop straight into {@code @tf.function(input_signature=...)}.
 	 * <p>
 	 * Examples (with {@code tfPrefix = "tf."}):
 	 * <ul>
@@ -61,10 +63,38 @@ public record InputSignature(List<TensorType> parameterTypes) {
 			}
 
 			String dtype = tfPrefix + dtypeName(t);
-			specs.add(tfPrefix + "TensorSpec(shape=" + shape + ", dtype=" + dtype + ")");
+			specs.add(tfPrefix + specTypeName(t) + "(shape=" + shape + ", dtype=" + dtype + ")");
 		}
 
 		return specs.toString();
+	}
+
+	/**
+	 * The TensorFlow spec-type constructor for a parameter: {@code RaggedTensorSpec} when the parameter has a ragged dimension (it is a
+	 * {@code tf.RaggedTensor}), otherwise {@code TensorSpec}. The bare name without any module prefix.
+	 *
+	 * @param t The parameter's {@link TensorType}.
+	 * @return {@code "RaggedTensorSpec"} or {@code "TensorSpec"}.
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/524">Issue 524</a>
+	 */
+	private static String specTypeName(TensorType t) {
+		List<Dimension<?>> dims = t.getDims();
+		boolean ragged = dims != null && dims.stream().anyMatch(RaggedDim.class::isInstance);
+		return ragged ? "RaggedTensorSpec" : "TensorSpec";
+	}
+
+	/**
+	 * The set of spec-type constructor names this signature references (e.g., {@code "TensorSpec"}, {@code "RaggedTensorSpec"}), as the
+	 * bare Python identifiers emitted by {@link #toTensorSpecList(String)} (without any module prefix). The source-write verifies each is
+	 * reachable under the chosen import prefix before emitting an unqualified signature: on the {@code from tensorflow import ...}
+	 * named-import path a signature with a ragged parameter needs {@code RaggedTensorSpec} in scope, which {@code TensorSpec} being
+	 * imported does not imply, so an unguarded emission would produce a {@code NameError}-raising decorator.
+	 *
+	 * @return The referenced spec-type constructor names.
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/524">Issue 524</a>
+	 */
+	public Set<String> requiredSpecTypeNames() {
+		return parameterTypes.stream().map(InputSignature::specTypeName).collect(Collectors.toUnmodifiableSet());
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferRaggedTensorSpec/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testInferRaggedTensorSpec/in/A.py
@@ -1,0 +1,9 @@
+import tensorflow as tf
+
+
+@tf.function
+def f(t):
+    return t
+
+
+f(tf.ragged.constant([[1, 2, 3], [4, 5]]))

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8835,9 +8835,11 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function function = functions.iterator().next();
 		assertTrue("Parameter receiving a `tf.RaggedTensor` should be classified as tensor-typed.", function.getHasTensorParameter());
 
-		// Regression pin for the raw Ariadne type (the probe finding underpinning #524): Ariadne types the `tf.RaggedTensor` parameter
-		// with a `RaggedDim` at the ragged axis. If a future Ariadne version stops emitting `RaggedDim` here, `RaggedTensorSpec` emission
-		// would silently regress to a dense `TensorSpec`.
+		/*
+		 * Regression pin for the raw Ariadne type (the probe finding underpinning #524): Ariadne types the `tf.RaggedTensor` parameter with
+		 * a `RaggedDim` at the ragged axis. If a future Ariadne version stops emitting `RaggedDim` here, `RaggedTensorSpec` emission would
+		 * silently regress to a dense `TensorSpec`.
+		 */
 		Parameter t = function.getParameters().get(0);
 		assertEquals("Ariadne should type the `tf.RaggedTensor` parameter as `(INT32, [NumericDim(2), RaggedDim])`.",
 				Set.of(new TensorType(INT32, List.of(new NumericDim(2), RaggedDim.INSTANCE))), t.getTensorTypes());

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8835,6 +8835,13 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		Function function = functions.iterator().next();
 		assertTrue("Parameter receiving a `tf.RaggedTensor` should be classified as tensor-typed.", function.getHasTensorParameter());
 
+		// Regression pin for the raw Ariadne type (the probe finding underpinning #524): Ariadne types the `tf.RaggedTensor` parameter
+		// with a `RaggedDim` at the ragged axis. If a future Ariadne version stops emitting `RaggedDim` here, `RaggedTensorSpec` emission
+		// would silently regress to a dense `TensorSpec`.
+		Parameter t = function.getParameters().get(0);
+		assertEquals("Ariadne should type the `tf.RaggedTensor` parameter as `(INT32, [NumericDim(2), RaggedDim])`.",
+				Set.of(new TensorType(INT32, List.of(new NumericDim(2), RaggedDim.INSTANCE))), t.getTensorTypes());
+
 		InputSignature signature = function.inferInputSignature().signature()
 				.orElseThrow(() -> new AssertionError("Expected an inferred signature for the ragged parameter."));
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3868,8 +3868,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter59() throws Exception {
 		TensorType expectedParameterTensorType = new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
-		TensorType expectedSignatureTensorType = new TensorType(INT32,
-				List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?")));
+		TensorType expectedSignatureTensorType = new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE));
 		testHasLikelyTensorParameterHelper(expectedParameterTensorType, expectedSignatureTensorType);
 	}
 
@@ -3879,7 +3878,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter60() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -3888,7 +3887,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter61() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -3897,7 +3896,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter62() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -3906,7 +3905,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter63() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -3915,7 +3914,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter64() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -3924,7 +3923,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter65() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -3933,7 +3932,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter66() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE, RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -3943,7 +3942,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter67() throws Exception {
 		testHasLikelyTensorParameterHelper(
 				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
-				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3953,7 +3952,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter68() throws Exception {
 		testHasLikelyTensorParameterHelper(
 				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
-				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3963,7 +3962,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter69() throws Exception {
 		testHasLikelyTensorParameterHelper(
 				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
-				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3973,7 +3972,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter70() throws Exception {
 		testHasLikelyTensorParameterHelper(
 				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
-				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, new SymbolicDim("?"))));
 	}
 
 	/**
@@ -3982,7 +3981,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter71() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -3991,7 +3990,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter72() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -4000,7 +3999,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter73() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -4009,7 +4008,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter74() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -4018,7 +4017,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter75() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -4027,7 +4026,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter76() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -4036,7 +4035,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter77() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -4045,7 +4044,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter78() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -4054,7 +4053,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter79() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(5), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(5), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -4063,7 +4062,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter80() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(4), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(4), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(4), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -4072,7 +4071,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter81() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(4), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(4), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(4), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -4081,7 +4080,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter82() throws Exception {
 		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(4), RaggedDim.INSTANCE)),
-				new TensorType(INT32, List.of(new NumericDim(4), new SymbolicDim("?"))));
+				new TensorType(INT32, List.of(new NumericDim(4), RaggedDim.INSTANCE)));
 	}
 
 	/**
@@ -4400,7 +4399,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter118() throws Exception {
 		testHasLikelyTensorParameterHelper(
 				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
-				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4410,7 +4409,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter119() throws Exception {
 		testHasLikelyTensorParameterHelper(
 				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
-				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4420,7 +4419,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter120() throws Exception {
 		testHasLikelyTensorParameterHelper(
 				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
-				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4430,7 +4429,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter121() throws Exception {
 		testHasLikelyTensorParameterHelper(
 				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
-				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, new SymbolicDim("?"))));
 	}
 
 	/**
@@ -4440,7 +4439,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	public void testHasLikelyTensorParameter122() throws Exception {
 		testHasLikelyTensorParameterHelper(
 				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, DynamicDim.INSTANCE)),
-				new TensorType(STRING, List.of(new NumericDim(4), new SymbolicDim("?"), new SymbolicDim("?"), new SymbolicDim("?"))));
+				new TensorType(STRING, List.of(new NumericDim(4), RaggedDim.INSTANCE, RaggedDim.INSTANCE, new SymbolicDim("?"))));
 	}
 
 	/**
@@ -8820,6 +8819,31 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 
 		assertNotEquals("A `*Spec` type hint must NOT classify the parameter as tensor-typed.", TRUE, t.isTensor());
 		assertFalse("With no tensor classification, `getHasTensorParameter()` is FALSE.", function.getHasTensorParameter());
+	}
+
+	/**
+	 * A parameter receiving a {@code tf.RaggedTensor} (here via {@code tf.ragged.constant}) is typed by Ariadne with a {@code RaggedDim} at
+	 * the ragged position. Inference preserves that marker rather than collapsing it to a symbolic wildcard, and the emission produces a
+	 * {@code tf.RaggedTensorSpec} rather than a dense {@code tf.TensorSpec} (#524).
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/524">Issue 524</a>
+	 */
+	@Test
+	public void testInferRaggedTensorSpec() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function function = functions.iterator().next();
+		assertTrue("Parameter receiving a `tf.RaggedTensor` should be classified as tensor-typed.", function.getHasTensorParameter());
+
+		InputSignature signature = function.inferInputSignature().signature()
+				.orElseThrow(() -> new AssertionError("Expected an inferred signature for the ragged parameter."));
+
+		// The ragged marker survives reduction (not collapsed to a symbolic wildcard).
+		List<TensorType.Dimension<?>> dims = signature.parameterTypes().get(0).getDims();
+		assertTrue("Inference should preserve the `RaggedDim` marker.", dims.get(dims.size() - 1) instanceof TensorType.RaggedDim);
+
+		// ...and the emission is a `RaggedTensorSpec`, with the ragged position rendered as `None`.
+		assertEquals("[tf.RaggedTensorSpec(shape=(2, None), dtype=tf.int32)]", signature.toTensorSpecList("tf."));
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -68,14 +69,29 @@ public class InputSignatureTest {
 	}
 
 	/**
-	 * {@link SymbolicDim} and {@link RaggedDim} render as {@code None}, the same as {@link DynamicDim}. The {@code TensorSpec} surface
-	 * cannot encode raggedness; the {@code RaggedTensorSpec} flip is tracked separately at #524.
+	 * {@link SymbolicDim}, {@link RaggedDim}, and {@link DynamicDim} all render as {@code None} on the shape surface. A {@link RaggedDim}
+	 * additionally selects {@code RaggedTensorSpec} over {@code TensorSpec}, since a ragged dimension marks the parameter as a
+	 * {@code tf.RaggedTensor} (#524).
 	 */
 	@Test
 	public void testSymbolicAndRaggedDimsCollapseToNone() {
 		InputSignature sig = new InputSignature(
 				List.of(new TensorType(INT32, List.of(new NumericDim(3), new SymbolicDim("?"), RaggedDim.INSTANCE, DynamicDim.INSTANCE))));
-		assertEquals("[tf.TensorSpec(shape=(3, None, None, None), dtype=tf.int32)]", sig.toTensorSpecList("tf."));
+		assertEquals("[tf.RaggedTensorSpec(shape=(3, None, None, None), dtype=tf.int32)]", sig.toTensorSpecList("tf."));
+	}
+
+	/**
+	 * {@link InputSignature#requiredSpecTypeNames} reports {@code TensorSpec} for a dense parameter, {@code RaggedTensorSpec} for a
+	 * parameter with a ragged dimension, and both for a mixed signature. The source-write gates emission on these being reachable (#524).
+	 */
+	@Test
+	public void testRequiredSpecTypeNames() {
+		TensorType dense = new TensorType(INT32, List.of(new NumericDim(3)));
+		TensorType ragged = new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE));
+
+		assertEquals(Set.of("TensorSpec"), new InputSignature(List.of(dense)).requiredSpecTypeNames());
+		assertEquals(Set.of("RaggedTensorSpec"), new InputSignature(List.of(ragged)).requiredSpecTypeNames());
+		assertEquals(Set.of("TensorSpec", "RaggedTensorSpec"), new InputSignature(List.of(dense, ragged)).requiredSpecTypeNames());
 	}
 
 	/**


### PR DESCRIPTION
Input-signature inference collapsed a parameter's ragged dimension (Ariadne's `RaggedDim`) to a symbolic wildcard and emitted a dense `tf.TensorSpec`, discarding the raggedness. Now:

- `inferSpec` preserves a consensus `RaggedDim` through its per-dim reduction instead of collapsing it.
- `InputSignature.toTensorSpecList` emits `tf.RaggedTensorSpec` for a parameter with a ragged dimension (the ragged positions still render as `None` in the shape).
- `InputSignature.requiredSpecTypeNames` reports the spec-type constructors a signature needs (`TensorSpec`/`RaggedTensorSpec`), and `computeInputSignatureKeyword` gates emission on them being reachable—so a ragged signature under a named import that lacks `RaggedTensorSpec` is skipped rather than emitting a `NameError`-raising decorator, matching the existing dtype-reachability guard (#585).

Confirmed empirically that Ariadne 0.47.0 types a `tf.RaggedTensor` parameter with a `RaggedDim` (new test `testInferRaggedTensorSpec`: `tf.ragged.constant([[1,2,3],[4,5]])` → `[tf.RaggedTensorSpec(shape=(2, None), dtype=tf.int32)]`).

The 29 precision-audit corpus pins and one formatter unit pin that asserted the old symbolic-wildcard collapse are updated to expect the preserved `RaggedDim`/`RaggedTensorSpec` (their param-layer already pinned `RaggedDim`; only the inferred-layer expectation moved). Full suite green (558).

Follow-up: auto-injecting `RaggedTensorSpec` into an import-less file (so ragged emits there too, rather than safely skipping)—analogous to the `TensorSpec` auto-inject (#574).

Stacked on #483 → #588 → #612 → #608.

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)
