### PR TITLE
Bump Ariadne to 0.49.1

### DIFF
--- a/hybridize.target
+++ b/hybridize.target
@@ -57,7 +57,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.49.0</version>
+					<version>0.49.1</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>

--- a/hybridize.target
+++ b/hybridize.target
@@ -57,7 +57,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.47.0</version>
+					<version>0.49.0</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
Closes #603.

Bumps the Ariadne (`com.ibm.wala.cast.python.ml`) target-platform dependency to **0.49.1**.

0.49.1 carries the fixes needed to move past 0.47.0:
- **wala/ML#583** — `tf.equal`/element-wise ops no longer throw `NonBroadcastableShapesException` and abort the analysis on collapsed per-context shapes.
- **wala/ML#584** — a comprehension-built `images` argument no longer drops the `tf.image.extract_patches` result's tensor classification. This is the `testExtractPatches` corpus case that failed under 0.49.0 (the 0.49.0 bump surfaced it; 0.49.1 fixes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)