### PR TITLE
Bump Ariadne to 0.50.0 for `MODEL_FORWARD_CFA_DEPTH`

### DIFF
--- a/hybridize.target
+++ b/hybridize.target
@@ -57,7 +57,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.49.1</version>
+					<version>0.50.0</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
Bumps the Ariadne (`com.ibm.wala.cast.python.ml`) target-platform dependency to **0.50.0**.

0.50.0 adds `MODEL_FORWARD_CFA_DEPTH` (wala/ML#587, ponder-lab/ML#394) — the recommended targeted k-CFA depth for the model-forward archetype (chained-layer `tf.keras.Model` forward passes), with Javadoc documenting the cost/scoping model and the deepen-when symptom. This unblocks #600, which forwards a named, documented depth to the Ariadne engine for per-context input-signature precision instead of hardcoding a literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
