### PR TITLE
Consolidate Coveralls upload to the Maven plugin; drop the redundant GitHub Action

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: github-actions
-repo_token: 71wVjTUWdxts3DnxmkannlSruAfGsxN6d

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,4 +71,6 @@ jobs:
         git clone --depth=50 --branch=pydev_9_3 https://github.com/ponder-lab/Pydev.git
         popd
     - name: Test with Maven
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: ./mvnw -U -s .travis.settings.xml -Dgithub.username=${{ github.actor }} -Dgithub.password=${{ secrets.GITHUB_TOKEN }} -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties -DtrimStackTrace=true -Dtycho.showEclipseLog=false -B verify -Pjacoco coveralls:report

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,7 +71,7 @@ jobs:
         git clone --depth=50 --branch=pydev_9_3 https://github.com/ponder-lab/Pydev.git
         popd
     - name: Test with Maven
-      run: ./mvnw -U -s .travis.settings.xml -Dgithub.username=${{ github.actor }} -Dgithub.password=${{ secrets.GITHUB_TOKEN }} -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties -DtrimStackTrace=true -Dtycho.showEclipseLog=false -B verify -Pjacoco coveralls:report
+      run: ./mvnw -U -s .travis.settings.xml -Dgithub.username=${{ github.actor }} -Dgithub.password=${{ secrets.GITHUB_TOKEN }} -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties -DtrimStackTrace=true -Dtycho.showEclipseLog=false -B verify -Pjacoco
     - name: Coveralls GitHub Action
       uses: coverallsapp/github-action@v2.3.7
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,10 +71,4 @@ jobs:
         git clone --depth=50 --branch=pydev_9_3 https://github.com/ponder-lab/Pydev.git
         popd
     - name: Test with Maven
-      run: ./mvnw -U -s .travis.settings.xml -Dgithub.username=${{ github.actor }} -Dgithub.password=${{ secrets.GITHUB_TOKEN }} -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties -DtrimStackTrace=true -Dtycho.showEclipseLog=false -B verify -Pjacoco
-    - name: Coveralls GitHub Action
-      uses: coverallsapp/github-action@v2.3.7
-      with:
-        # Don't fail the build when the Coveralls reporter binary download/checksum or upload flakes (#601); coverage reporting is
-        # best-effort. v2.3.7 honors `fail-on-error` for binary download/verification failures, which v2.3.6 did not.
-        fail-on-error: false
+      run: ./mvnw -U -s .travis.settings.xml -Dgithub.username=${{ github.actor }} -Dgithub.password=${{ secrets.GITHUB_TOKEN }} -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties -DtrimStackTrace=true -Dtycho.showEclipseLog=false -B verify -Pjacoco coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,29 @@
         <activeByDefault>false</activeByDefault>
       </activation>
       <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.eluder.coveralls</groupId>
+              <artifactId>coveralls-maven-plugin</artifactId>
+              <version>4.3.0</version>
+              <configuration>
+                <jacocoReports>
+                  <jacocoReport>${project.basedir}/edu.cuny.hunter.hybridize.tests.report/target/site/jacoco-aggregate/jacoco.xml</jacocoReport>
+                </jacocoReports>
+                <repoToken>71wVjTUWdxts3DnxmkannlSruAfGsxN6d</repoToken>
+                <serviceName>travis-pro</serviceName>
+              </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>javax.xml.bind</groupId>
+                  <artifactId>jaxb-api</artifactId>
+                  <version>2.3.1</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
         <plugins>
           <plugin>
             <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
                 <jacocoReports>
                   <jacocoReport>${project.basedir}/edu.cuny.hunter.hybridize.tests.report/target/site/jacoco-aggregate/jacoco.xml</jacocoReport>
                 </jacocoReports>
-                <repoToken>71wVjTUWdxts3DnxmkannlSruAfGsxN6d</repoToken>
+                <repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
                 <serviceName>github</serviceName>
               </configuration>
               <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
                   <jacocoReport>${project.basedir}/edu.cuny.hunter.hybridize.tests.report/target/site/jacoco-aggregate/jacoco.xml</jacocoReport>
                 </jacocoReports>
                 <repoToken>71wVjTUWdxts3DnxmkannlSruAfGsxN6d</repoToken>
-                <serviceName>travis-pro</serviceName>
+                <serviceName>github</serviceName>
               </configuration>
               <dependencies>
                 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -352,29 +352,6 @@
         <activeByDefault>false</activeByDefault>
       </activation>
       <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.eluder.coveralls</groupId>
-              <artifactId>coveralls-maven-plugin</artifactId>
-              <version>4.3.0</version>
-              <configuration>
-                <jacocoReports>
-                  <jacocoReport>${project.basedir}/edu.cuny.hunter.hybridize.tests.report/target/site/jacoco-aggregate/jacoco.xml</jacocoReport>
-                </jacocoReports>
-                <repoToken>71wVjTUWdxts3DnxmkannlSruAfGsxN6d</repoToken>
-                <serviceName>travis-pro</serviceName>
-              </configuration>
-              <dependencies>
-                <dependency>
-                  <groupId>javax.xml.bind</groupId>
-                  <artifactId>jaxb-api</artifactId>
-                  <version>2.3.1</version>
-                </dependency>
-              </dependencies>
-            </plugin>
-          </plugins>
-        </pluginManagement>
         <plugins>
           <plugin>
             <groupId>org.jacoco</groupId>


### PR DESCRIPTION
Consolidates the duplicate Coveralls upload and modernizes its config. The build uploaded coverage twice per commit: via the Maven `coveralls:report` goal and via the `coverallsapp/github-action` step.

CI showed the **GitHub Action does not upload the jacoco aggregate on its own**. It was posting the `target/coveralls.json` produced by the Maven goal, so the Maven `coveralls:report` is the real, correctly-attributed uploader (its coveralls.io builds report `branch=main`, not a bare SHA). This PR keeps it and drops the redundant Action, which also removes the reporter-binary download that #601 hardened against, at its source.

Also:
- Set the `coveralls-maven-plugin` `serviceName` from the stale `travis-pro` to `github` (the canonical Coveralls identifier for GitHub Actions).
- Delete `.coveralls.yml`: it was only read by the removed Action's reporter; the Maven plugin takes `repoToken`/`serviceName` from the pom. (Removes a duplicated repo token too.)

The Coveralls GitHub App (installed while resolving #622) posts the commit statuses and PR comment from the Maven-uploaded build. This PR's own CI is the validation: the `coverage/coveralls` statuses and a coverage comment should appear from the single Maven uploader.

Closes #624. Follow-up to #622.