### PR TITLE
Forward a configurable targeted k-CFA depth to the analysis engine

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
@@ -128,13 +128,18 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 	private boolean inferInputSignatures;
 
 	/**
-	 * The targeted k-CFA depth forwarded to the analysis engine (#600). Defaults to
-	 * {@link PythonTensorAnalysisEngine#MODEL_FORWARD_CFA_DEPTH}, the depth at which the model-forward archetype (chained-layer calls)
-	 * recovers precise per-context tensor shapes.
+	 * The default targeted k-CFA depth: {@link PythonTensorAnalysisEngine#MODEL_FORWARD_CFA_DEPTH}, the depth at which the model-forward
+	 * archetype (chained-layer calls) recovers precise per-context tensor shapes (#600). Single source for the field default below and the
+	 * evaluator's property default.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/600">Issue 600</a>
 	 */
-	private int targetedCfaDepth = PythonTensorAnalysisEngine.MODEL_FORWARD_CFA_DEPTH;
+	public static final int DEFAULT_TARGETED_CFA_DEPTH = PythonTensorAnalysisEngine.MODEL_FORWARD_CFA_DEPTH;
+
+	/**
+	 * The targeted k-CFA depth forwarded to the analysis engine (#600), defaulting to {@link #DEFAULT_TARGETED_CFA_DEPTH}.
+	 */
+	private int targetedCfaDepth = DEFAULT_TARGETED_CFA_DEPTH;
 
 	public HybridizeFunctionRefactoringProcessor() {
 		// Force the use of typeshed. It's an experimental feature of PyDev.

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
@@ -45,6 +45,7 @@ import com.ibm.wala.cast.python.ipa.callgraph.PytestEntrypointBuilder;
 import com.ibm.wala.cast.python.ipa.callgraph.PytesttEntrypoint;
 import com.ibm.wala.cast.python.ipa.callgraph.PythonSSAPropagationCallGraphBuilder;
 import com.ibm.wala.cast.python.ml.analysis.TensorTypeAnalysis;
+import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
 import com.ibm.wala.ide.util.ProgressMonitorDelegate;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -125,6 +126,15 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
 	 */
 	private boolean inferInputSignatures;
+
+	/**
+	 * The targeted k-CFA depth forwarded to the analysis engine (#600). Defaults to
+	 * {@link PythonTensorAnalysisEngine#MODEL_FORWARD_CFA_DEPTH}, the depth at which the model-forward archetype (chained-layer calls)
+	 * recovers precise per-context tensor shapes.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/600">Issue 600</a>
+	 */
+	private int targetedCfaDepth = PythonTensorAnalysisEngine.MODEL_FORWARD_CFA_DEPTH;
 
 	public HybridizeFunctionRefactoringProcessor() {
 		// Force the use of typeshed. It's an experimental feature of PyDev.
@@ -304,7 +314,8 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 			assert pythonPath.stream().allMatch(File::exists) : "PYTHONPATH should exist.";
 
 			// create the analysis engine for the project.
-			EclipsePythonProjectTensorAnalysisEngine engine = new EclipsePythonProjectTensorAnalysisEngine(project, pythonPath);
+			EclipsePythonProjectTensorAnalysisEngine engine = new EclipsePythonProjectTensorAnalysisEngine(project, pythonPath,
+					this.getTargetedCfaDepth());
 
 			// build the call graph for the project.
 			PythonSSAPropagationCallGraphBuilder builder;
@@ -618,6 +629,24 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 	 */
 	public boolean getInferInputSignatures() {
 		return this.inferInputSignatures;
+	}
+
+	/**
+	 * The targeted k-CFA depth forwarded to the analysis engine (#600).
+	 *
+	 * @return The targeted k-CFA depth.
+	 */
+	public int getTargetedCfaDepth() {
+		return this.targetedCfaDepth;
+	}
+
+	/**
+	 * Sets the targeted k-CFA depth forwarded to the analysis engine (#600).
+	 *
+	 * @param targetedCfaDepth The targeted k-CFA depth.
+	 */
+	public void setTargetedCfaDepth(int targetedCfaDepth) {
+		this.targetedCfaDepth = targetedCfaDepth;
 	}
 
 	public Set<Function> getOptimizableFunctions() {

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/wala/ml/EclipsePythonProjectTensorAnalysisEngine.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/wala/ml/EclipsePythonProjectTensorAnalysisEngine.java
@@ -55,6 +55,21 @@ public class EclipsePythonProjectTensorAnalysisEngine extends PythonTensorAnalys
 		this.initialize(project);
 	}
 
+	/**
+	 * Constructs an engine that selects framework methods, {@code tf.keras.Model} subclasses, and user model-forward methods with the given
+	 * targeted k-CFA depth, rather than the default {@link PythonTensorAnalysisEngine#DEFAULT_TARGETED_CFA_DEPTH}. A deeper depth recovers
+	 * precise per-context tensor shapes for the model-forward archetype (chained-layer calls), at a cost confined to those targeted methods
+	 * (#600).
+	 *
+	 * @param project The project to analyze.
+	 * @param pythonPath The Python path entries.
+	 * @param targetedCfaDepth The targeted k-CFA depth to forward to the analysis engine.
+	 */
+	public EclipsePythonProjectTensorAnalysisEngine(IProject project, List<File> pythonPath, int targetedCfaDepth) {
+		super(pythonPath, TENSORFLOW, targetedCfaDepth);
+		this.initialize(project);
+	}
+
 	public EclipsePythonProjectTensorAnalysisEngine(IProject project) {
 		this.initialize(project);
 	}

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -126,6 +126,8 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 	private static final String OUTPUT_CALLS_KEY = "edu.cuny.hunter.hybridize.eval.outputCalls";
 
+	private static final String TARGETED_CFA_DEPTH_KEY = "edu.cuny.hunter.hybridize.eval.targetedCfaDepth";
+
 	private static String[] buildAttributeColumnNames(String... additionalColumnNames) {
 		String[] primaryColumns = new String[] { "subject", "function", "module", "relative path" };
 		List<String> ret = new ArrayList<>(Arrays.asList(primaryColumns));
@@ -164,6 +166,16 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 	 */
 	private boolean inferInputSignatures = Boolean.getBoolean(INFER_INPUT_SIGNATURES_KEY);
 
+	/**
+	 * The targeted k-CFA depth forwarded to the analysis engine, defaulting to
+	 * {@link HybridizeFunctionRefactoringProcessor#DEFAULT_TARGETED_CFA_DEPTH}; set via the
+	 * {@code edu.cuny.hunter.hybridize.eval.targetedCfaDepth} system property.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/600">Issue 600</a>
+	 */
+	private int targetedCfaDepth = Integer.getInteger(TARGETED_CFA_DEPTH_KEY,
+			HybridizeFunctionRefactoringProcessor.DEFAULT_TARGETED_CFA_DEPTH);
+
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		Job.create("Evaluating Hybridize Functions refactoring...", monitor -> {
@@ -180,7 +192,7 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 				resultsHeader.add(transformation.toString());
 
 			String[] experimentalSettingsHeader = new String[] { "side-effects", "recursion", "type hints", "parallel", "speculative",
-					"test entrypoints", "infer input signatures" };
+					"test entrypoints", "infer input signatures", "targeted CFA depth" };
 			resultsHeader.addAll(Arrays.asList(experimentalSettingsHeader));
 
 			resultsHeader.add("time (s)");
@@ -229,6 +241,7 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 					processor = createHybridizeFunctionRefactoring(new IProject[] { project }, this.getAlwaysCheckPythonSideEffects(),
 							this.getProcessFunctionsInParallel(), this.getAlwaysCheckRecusion(), this.getUseTestEntrypoints(),
 							this.getAlwaysFollowTypeHints(), this.getUseSpeculativeAnalysis(), this.getInferInputSignatures());
+					processor.setTargetedCfaDepth(this.getTargetedCfaDepth());
 					resultsTimeCollector.stop();
 
 					// run the precondition checking.
@@ -330,6 +343,9 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 					// infer input signatures.
 					resultsPrinter.print(this.getInferInputSignatures());
+
+					// targeted CFA depth.
+					resultsPrinter.print(this.getTargetedCfaDepth());
 
 					// actually perform the refactoring if there are no fatal
 					// errors.
@@ -617,5 +633,9 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 	public boolean getInferInputSignatures() {
 		return this.inferInputSignatures;
+	}
+
+	public int getTargetedCfaDepth() {
+		return this.targetedCfaDepth;
 	}
 }

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testTargetedCfaDepthSoundness/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testTargetedCfaDepthSoundness/in/A.py
@@ -1,0 +1,188 @@
+# From https://github.com/aymericdamien/TensorFlow-Examples/blob/6dcbe14649163814e72a22a999f20c5e247ce988/tensorflow_v2/notebooks/3_NeuralNetworks/neural_network.ipynb.
+
+# %%
+# # Neural Network Example
+
+# Build a 2-hidden layers fully connected neural network (a.k.a multilayer perceptron) with TensorFlow v2.
+
+# This example is using a low-level approach to better understand all mechanics behind building neural networks and the training process.
+
+# - Author: Aymeric Damien
+# - Project: https://github.com/aymericdamien/TensorFlow-Examples/
+# """
+
+# %%
+# ## Neural Network Overview
+
+# <img src="http://cs231n.github.io/assets/nn1/neural_net2.jpeg" alt="nn" style="width: 400px;"/>
+
+# ## MNIST Dataset Overview
+
+# This example is using MNIST handwritten digits. The dataset contains 60,000 examples for training and 10,000 examples for testing. The digits have been size-normalized and centered in a fixed-size image (28x28 pixels) with values from 0 to 255.
+
+# In this example, each image will be converted to float32, normalized to [0, 1] and flattened to a 1-D array of 784 features (28*28).
+
+# ![MNIST Dataset](http://neuralnetworksanddeeplearning.com/images/mnist_100_digits.png)
+
+# More info: http://yann.lecun.com/exdb/mnist/
+
+# %%
+from __future__ import absolute_import, division, print_function
+
+import tensorflow as tf
+
+print("TensorFlow version:", tf.__version__)
+assert tf.__version__ == "2.9.3"
+from tensorflow.keras import Model, layers
+import numpy as np
+import timeit
+
+start_time = timeit.default_timer()
+skipped_time = 0
+
+# %%
+# MNIST dataset parameters.
+num_classes = 10  # total classes (0-9 digits).
+num_features = 784  # data features (img shape: 28*28).
+
+# Training parameters.
+learning_rate = 0.1
+training_steps = 1
+batch_size = 256
+display_step = 100
+
+# Network parameters.
+n_hidden_1 = 128  # 1st layer number of neurons.
+n_hidden_2 = 256  # 2nd layer number of neurons.
+
+# %%
+# Prepare MNIST data.
+from tensorflow.keras.datasets import mnist
+
+(x_train, y_train), (x_test, y_test) = mnist.load_data()
+# Convert to float32.
+x_train, x_test = np.array(x_train, np.float32), np.array(x_test, np.float32)
+# Flatten images to 1-D vector of 784 features (28*28).
+x_train, x_test = x_train.reshape([-1, num_features]), x_test.reshape(
+    [-1, num_features]
+)
+# Normalize images value from [0, 255] to [0, 1].
+x_train, x_test = x_train / 255.0, x_test / 255.0
+
+# %%
+# Use tf.data API to shuffle and batch data.
+train_data = tf.data.Dataset.from_tensor_slices((x_train, y_train))
+train_data = train_data.repeat().shuffle(5000).batch(batch_size).prefetch(1)
+
+
+# %%
+# Create TF Model.
+class NeuralNet(Model):
+
+    # Set layers.
+    def __init__(self):
+        super(NeuralNet, self).__init__()
+        # First fully-connected hidden layer.
+        self.fc1 = layers.Dense(n_hidden_1, activation=tf.nn.relu)
+        # First fully-connected hidden layer.
+        self.fc2 = layers.Dense(n_hidden_2, activation=tf.nn.relu)
+        # Second fully-connecter hidden layer.
+        self.out = layers.Dense(num_classes)
+
+    # Set forward pass.
+    def call(self, x, is_training=False):
+        x = self.fc1(x)
+        x = self.fc2(x)
+        x = self.out(x)
+        if not is_training:
+            # tf cross entropy expect logits without softmax, so only
+            # apply softmax when not training.
+            x = tf.nn.softmax(x)
+        return x
+
+
+# Build neural network model.
+neural_net = NeuralNet()
+
+
+# %%
+# Cross-Entropy Loss.
+# Note that this will apply 'softmax' to the logits.
+def cross_entropy_loss(x, y):
+    # Convert labels to int 64 for tf cross-entropy function.
+    y = tf.cast(y, tf.int64)
+    # Apply softmax to logits and compute cross-entropy.
+    loss = tf.nn.sparse_softmax_cross_entropy_with_logits(labels=y, logits=x)
+    # Average loss across the batch.
+    return tf.reduce_mean(loss)
+
+
+# Accuracy metric.
+def accuracy(y_pred, y_true):
+    # Predicted class is the index of highest score in prediction vector (i.e. argmax).
+    correct_prediction = tf.equal(tf.argmax(y_pred, 1), tf.cast(y_true, tf.int64))
+    return tf.reduce_mean(tf.cast(correct_prediction, tf.float32), axis=-1)
+
+
+# Stochastic gradient descent optimizer.
+optimizer = tf.optimizers.SGD(learning_rate)
+
+
+# %%
+# Optimization process.
+def run_optimization(x, y):
+    # Wrap computation inside a GradientTape for automatic differentiation.
+    with tf.GradientTape() as g:
+        # Forward pass.
+        pred = neural_net(x, is_training=True)
+        # Compute loss.
+        loss = cross_entropy_loss(pred, y)
+
+    # Variables to update, i.e. trainable variables.
+    trainable_variables = neural_net.trainable_variables
+
+    # Compute gradients.
+    gradients = g.gradient(loss, trainable_variables)
+
+    # Update W and b following gradients.
+    optimizer.apply_gradients(zip(gradients, trainable_variables))
+
+
+# %%
+# Run training for the given number of steps.
+for step, (batch_x, batch_y) in enumerate(train_data.take(training_steps), 1):
+    # Run the optimization to update W and b values.
+    run_optimization(batch_x, batch_y)
+
+    if step % display_step == 0:
+        pred = neural_net(batch_x, is_training=True)
+        loss = cross_entropy_loss(pred, batch_y)
+        acc = accuracy(pred, batch_y)
+        print_time = timeit.default_timer()
+        print("step: %i, loss: %f, accuracy: %f" % (step, loss, acc))
+        skipped_time += timeit.default_timer() - print_time
+
+# %%
+# Test model on validation set.
+pred = neural_net(x_test, is_training=False)
+print_time = timeit.default_timer()
+print("Test Accuracy: %f" % accuracy(pred, y_test))
+skipped_time += timeit.default_timer() - print_time
+
+# %%
+# Visualize predictions.
+import matplotlib.pyplot as plt
+
+# %%
+# Predict 5 images from validation set.
+n_images = 5
+test_images = x_test[:n_images]
+predictions = neural_net(test_images)
+
+print("Elapsed time: ", timeit.default_timer() - start_time - skipped_time)
+
+# Display image and model prediction.
+for i in range(n_images):
+    # plt.imshow(np.reshape(test_images[i], [28, 28]), cmap='gray')
+    # plt.show()
+    print("Model prediction: %i" % np.argmax(predictions.numpy()[i]))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testTargetedCfaDepthSoundness/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testTargetedCfaDepthSoundness/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -541,8 +541,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	protected boolean inferInputSignatures;
 
 	/**
-	 * The targeted k-CFA depth the harness forwards to the analysis engine, defaulting to
-	 * {@link HybridizeFunctionRefactoringProcessor#DEFAULT_TARGETED_CFA_DEPTH} so the suite's behavior is unchanged. A test sets it via
+	 * The targeted k-CFA depth the harness forwards to the analysis engine, defaulting to the refactoring's own
+	 * {@link HybridizeFunctionRefactoringProcessor#DEFAULT_TARGETED_CFA_DEPTH} so the harness does not override it. A test sets it via
 	 * {@link #setTargetedCfaDepth(int)} to analyze a fixture at a chosen depth (#600).
 	 */
 	private int targetedCfaDepth = HybridizeFunctionRefactoringProcessor.DEFAULT_TARGETED_CFA_DEPTH;

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -539,6 +539,13 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	protected boolean inferInputSignatures;
 
+	/**
+	 * The targeted k-CFA depth the harness forwards to the analysis engine, defaulting to
+	 * {@link HybridizeFunctionRefactoringProcessor#DEFAULT_TARGETED_CFA_DEPTH} so the suite's behavior is unchanged. A test sets it via
+	 * {@link #setTargetedCfaDepth(int)} to analyze a fixture at a chosen depth (#600).
+	 */
+	private int targetedCfaDepth = HybridizeFunctionRefactoringProcessor.DEFAULT_TARGETED_CFA_DEPTH;
+
 	private Entry<SimpleNode, IDocument> createPythonNodeFromTestFile(String fileNameWithoutExtension)
 			throws IOException, MisconfigurationException {
 		return this.createPythonNodeFromTestFile(fileNameWithoutExtension, true);
@@ -603,6 +610,15 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	public void setInferInputSignatures(boolean inferInputSignatures) {
 		this.inferInputSignatures = inferInputSignatures;
+	}
+
+	/**
+	 * Sets the targeted k-CFA depth the harness forwards to the analysis engine (#600).
+	 *
+	 * @param targetedCfaDepth The targeted k-CFA depth.
+	 */
+	public void setTargetedCfaDepth(int targetedCfaDepth) {
+		this.targetedCfaDepth = targetedCfaDepth;
 	}
 
 	@Override
@@ -741,6 +757,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		HybridizeFunctionRefactoringProcessor processor = new HybridizeFunctionRefactoringProcessor(inputFunctionDefinitions,
 				ALWAYS_CHECK_PYTHON_SIDE_EFFECTS, PROCESS_FUNCTIONS_IN_PARALLEL, ALWAYS_CHECK_RECURSION, USE_TEST_ENTRYPOINTS,
 				ALWAYS_FOLLOW_TYPE_HINTS, USE_SPECULATIVE_ANALYSIS, this.getInferInputSignatures());
+		processor.setTargetedCfaDepth(this.targetedCfaDepth);
 
 		ProcessorBasedRefactoring refactoring = new ProcessorBasedRefactoring(processor);
 

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -131,6 +131,7 @@ import org.python.pydev.shared_core.string.CoreTextSelection;
 import org.python.pydev.shared_core.string.StringUtils;
 import org.python.pydev.ui.BundleInfoStub;
 
+import com.ibm.wala.cast.python.ml.client.PythonTensorAnalysisEngine;
 import com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType;
 import com.ibm.wala.cast.python.ml.types.TensorType;
 import com.ibm.wala.cast.python.ml.types.TensorType.DynamicDim;
@@ -7003,6 +7004,55 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 				throw new IllegalStateException("Not expecting: " + function.getIdentifier() + ".");
 			}
 		}
+	}
+
+	/**
+	 * Pins the soundness gain of forwarding {@link PythonTensorAnalysisEngine#MODEL_FORWARD_CFA_DEPTH} to the analysis engine (#600).
+	 * {@code accuracy}'s {@code y_pred} is bound to a model-forward output ({@code pred = neural_net(...)}) reached from two call sites
+	 * that carry different shapes ({@code (256, 10)} from training, {@code (10000, 10)} from test). At the shallow
+	 * {@link PythonTensorAnalysisEngine#DEFAULT_TARGETED_CFA_DEPTH} the two contexts collapse and the training shape leaks into the test
+	 * call site, so the inferred {@link TensorType} set is a single, unsound concrete shape. At {@code MODEL_FORWARD_CFA_DEPTH} the
+	 * contexts separate and the test context falls to a wildcard ({@code null}-dims) over-approximation, so the set strictly grows. A
+	 * consumer emitting {@code input_signature} from the shallow result would unsoundly assert {@code y_pred} is always {@code (256, 10)}
+	 * when the test path can pass {@code (10000, 10)}. Parameters bound directly to call-site arguments (e.g. {@code NeuralNet.call}'s
+	 * {@code x}) are depth-invariant; this output-bound parameter is the one whose type set is depth-sensitive (wala/ML#587).
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/600">Issue 600</a>
+	 */
+	@Test
+	public void testTargetedCfaDepthSoundness() throws Exception {
+		Set<TensorType> shallow = this.analyzeAccuracyYPredAtDepth(PythonTensorAnalysisEngine.DEFAULT_TARGETED_CFA_DEPTH);
+		Set<TensorType> deep = this.analyzeAccuracyYPredAtDepth(PythonTensorAnalysisEngine.MODEL_FORWARD_CFA_DEPTH);
+
+		// The shallow targeted depth collapses the two call-site contexts into a single, concrete (unsound) shape.
+		assertEquals("Shallow targeted depth should collapse `y_pred` to a single shape.", 1, shallow.size());
+		assertTrue("The collapsed shape should be concrete.", shallow.stream().allMatch(t -> t.getDims() != null));
+
+		// The deeper targeted depth separates the contexts: it keeps the concrete shape and adds the wildcard over-approximation.
+		assertTrue("Deeper targeted depth must retain every shallow shape.", deep.containsAll(shallow));
+		assertEquals("Deeper targeted depth should add exactly the wildcard over-approximation.", shallow.size() + 1, deep.size());
+
+		Set<TensorType> added = new HashSet<>(deep);
+		added.removeAll(shallow);
+		assertTrue("The added type should be a wildcard (unconstrained-shape) over-approximation.",
+				added.stream().allMatch(t -> t.getDims() == null));
+	}
+
+	/**
+	 * Analyzes the soundness fixture at the given targeted k-CFA depth and returns the inferred {@link TensorType} set for
+	 * {@code accuracy}'s {@code y_pred} parameter. Clears the analysis caches first so each depth gets a fresh call graph.
+	 *
+	 * @param targetedCfaDepth The targeted k-CFA depth to analyze at.
+	 * @return The {@link TensorType}s inferred for {@code accuracy}'s {@code y_pred} parameter.
+	 */
+	private Set<TensorType> analyzeAccuracyYPredAtDepth(int targetedCfaDepth) throws Exception {
+		Function.clearCaches();
+		this.setTargetedCfaDepth(targetedCfaDepth);
+		Function accuracy = this.getFunctions().stream().filter(f -> f.getIdentifier().equals("accuracy")).findFirst()
+				.orElseThrow(() -> new AssertionError("Expected an `accuracy` function."));
+		Parameter yPred = accuracy.getParameters().stream().filter(p -> "y_pred".equals(p.getName())).findFirst()
+				.orElseThrow(() -> new AssertionError("Expected a `y_pred` parameter."));
+		return yPred.getTensorTypes();
 	}
 
 	@Test


### PR DESCRIPTION
Threads a configurable targeted k-CFA depth from the refactoring through to Ariadne's `PythonTensorAnalysisEngine` (#600), defaulting to `MODEL_FORWARD_CFA_DEPTH` (4).

## What It Does
- `EclipsePythonProjectTensorAnalysisEngine` gains a depth-forwarding constructor over the 0.50.0 3-arg `PythonTensorAnalysisEngine(List<File>, String, int)`.
- `HybridizeFunctionRefactoringProcessor` carries a `targetedCfaDepth` (getter/setter), defaulting to a public `DEFAULT_TARGETED_CFA_DEPTH` constant, and forwards it when building the engine.
- The evaluator reads the depth from the `edu.cuny.hunter.hybridize.eval.targetedCfaDepth` system property and emits it as a `targeted CFA depth` column in `results.csv`.
- The test harness can forward a chosen depth, mirroring how it forwards `inferInputSignatures`.

## Why Default 4
Confirmed via wala/ML#587: for a parameter bound to a model-forward output across multiple call sites, the shallow `DEFAULT_TARGETED_CFA_DEPTH` (2) collapses the contexts and leaks one call site's shape into another, an unsound single-shape result; depth 4 separates the contexts and the set gains the safe over-approximation. `testTargetedCfaDepthSoundness` pins this on `accuracy`'s `y_pred` in `neural_network.py`: `{(256, 10)}` at depth 2 (unsound) versus `{(256, 10), ?}` at depth 4 (sound). Parameters bound to direct call-site arguments (e.g. `NeuralNet.call`'s `x`) are depth-invariant.

## Deferred Follow-ups
- A UI wizard field for the depth (the shared `InputPage` base exposes no extension hook, and the field is not CI-testable).
- The broader model-forward corpus (gcn_proj/nlpgnn) as additional coverage.

Closes #600.
