### PR TITLE
Add a wizard spinner for the targeted k-CFA depth

### DIFF
--- a/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
+++ b/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
@@ -11,6 +11,7 @@ import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
 import org.eclipse.ltk.core.refactoring.Refactoring;
 import org.eclipse.ltk.core.refactoring.participants.RefactoringProcessor;
 import org.eclipse.ltk.ui.refactoring.RefactoringWizard;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
 import org.python.pydev.ast.refactoring.TooManyMatchesException;
 
@@ -31,7 +32,8 @@ public class HybridizeFunctionRefactoringWizard extends RefactoringWizard {
 
 		public static final String PAGE_NAME = "HybridizeFunctionsInputPage"; // $NON-NLS-1$
 
-		@SuppressWarnings("unused")
+		private static final String TARGETED_CFA_DEPTH_KEY = "targetedCfaDepth"; // $NON-NLS-1$
+
 		private HybridizeFunctionRefactoringProcessor processor;
 
 		public HybridizeFunctionsInputPage() {
@@ -59,6 +61,12 @@ public class HybridizeFunctionRefactoringWizard extends RefactoringWizard {
 			if (!(processor instanceof HybridizeFunctionRefactoringProcessor))
 				throw new IllegalArgumentException("Expecing HybridizeFunctionRefactoringProcessor.");
 			this.processor = (HybridizeFunctionRefactoringProcessor) processor;
+		}
+
+		@Override
+		protected void addOptions(Composite optionComposite) {
+			this.addIntegerButton("Targeted k-CFA depth for tensor-type precision:", TARGETED_CFA_DEPTH_KEY,
+					HybridizeFunctionRefactoringProcessor.DEFAULT_TARGETED_CFA_DEPTH, this.processor::setTargetedCfaDepth, optionComposite);
 		}
 	}
 

--- a/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
+++ b/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
@@ -62,13 +62,13 @@ public class HybridizeFunctionRefactoringWizard extends RefactoringWizard {
 		@Override
 		protected void setProcessor(RefactoringProcessor processor) {
 			if (!(processor instanceof HybridizeFunctionRefactoringProcessor))
-				throw new IllegalArgumentException("Expecting HybridizeFunctionRefactoringProcessor.");
+				throw new IllegalArgumentException("Expecting " + HybridizeFunctionRefactoringProcessor.class.getSimpleName() + ".");
 			this.processor = (HybridizeFunctionRefactoringProcessor) processor;
 		}
 
 		@Override
 		protected void addOptions(Composite optionComposite) {
-			this.addIntegerButton(TARGETED_CFA_DEPTH_LABEL, TARGETED_CFA_DEPTH_KEY, DEFAULT_TARGETED_CFA_DEPTH,
+			this.addSpinnerButton(TARGETED_CFA_DEPTH_LABEL, TARGETED_CFA_DEPTH_KEY, DEFAULT_TARGETED_CFA_DEPTH, /* minimum */ 1,
 					this.processor::setTargetedCfaDepth, optionComposite);
 		}
 	}

--- a/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
+++ b/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
@@ -35,6 +35,8 @@ public class HybridizeFunctionRefactoringWizard extends RefactoringWizard {
 
 		private static final String TARGETED_CFA_DEPTH_KEY = "targetedCfaDepth"; // $NON-NLS-1$
 
+		private static final String TARGETED_CFA_DEPTH_LABEL = "Targeted k-CFA depth for tensor-type precision:";
+
 		private HybridizeFunctionRefactoringProcessor processor;
 
 		public HybridizeFunctionsInputPage() {
@@ -66,7 +68,7 @@ public class HybridizeFunctionRefactoringWizard extends RefactoringWizard {
 
 		@Override
 		protected void addOptions(Composite optionComposite) {
-			this.addIntegerButton("Targeted k-CFA depth for tensor-type precision:", TARGETED_CFA_DEPTH_KEY, DEFAULT_TARGETED_CFA_DEPTH,
+			this.addIntegerButton(TARGETED_CFA_DEPTH_LABEL, TARGETED_CFA_DEPTH_KEY, DEFAULT_TARGETED_CFA_DEPTH,
 					this.processor::setTargetedCfaDepth, optionComposite);
 		}
 	}

--- a/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
+++ b/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
@@ -59,7 +59,7 @@ public class HybridizeFunctionRefactoringWizard extends RefactoringWizard {
 		@Override
 		protected void setProcessor(RefactoringProcessor processor) {
 			if (!(processor instanceof HybridizeFunctionRefactoringProcessor))
-				throw new IllegalArgumentException("Expecing HybridizeFunctionRefactoringProcessor.");
+				throw new IllegalArgumentException("Expecting HybridizeFunctionRefactoringProcessor.");
 			this.processor = (HybridizeFunctionRefactoringProcessor) processor;
 		}
 

--- a/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
+++ b/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
@@ -1,6 +1,7 @@
 package edu.cuny.hunter.hybridize.ui.wizards;
 
 import static edu.cuny.hunter.hybridize.core.messages.Messages.Name;
+import static edu.cuny.hunter.hybridize.core.refactorings.HybridizeFunctionRefactoringProcessor.DEFAULT_TARGETED_CFA_DEPTH;
 import static edu.cuny.hunter.hybridize.core.utils.Util.createRefactoring;
 
 import java.util.Set;
@@ -65,8 +66,8 @@ public class HybridizeFunctionRefactoringWizard extends RefactoringWizard {
 
 		@Override
 		protected void addOptions(Composite optionComposite) {
-			this.addIntegerButton("Targeted k-CFA depth for tensor-type precision:", TARGETED_CFA_DEPTH_KEY,
-					HybridizeFunctionRefactoringProcessor.DEFAULT_TARGETED_CFA_DEPTH, this.processor::setTargetedCfaDepth, optionComposite);
+			this.addIntegerButton("Targeted k-CFA depth for tensor-type precision:", TARGETED_CFA_DEPTH_KEY, DEFAULT_TARGETED_CFA_DEPTH,
+					this.processor::setTargetedCfaDepth, optionComposite);
 		}
 	}
 

--- a/hybridize.target
+++ b/hybridize.target
@@ -16,7 +16,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://raw.githubusercontent.com/ponder-lab/Common-Eclipse-Refactoring-Framework/master/edu.cuny.citytech.refactoring.common.updatesite"/>
-			<unit id="edu.cuny.citytech.refactoring.common.feature.feature.group" version="5.2.0"/>
+			<unit id="edu.cuny.citytech.refactoring.common.feature.feature.group" version="5.3.0"/>
 		</location>
 		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 			<dependencies>

--- a/hybridize.target
+++ b/hybridize.target
@@ -15,8 +15,8 @@
 			<unit id="org.python.pydev.feature.feature.group" version="9.3.3.202403291807"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://raw.githubusercontent.com/ponder-lab/Common-Eclipse-Refactoring-Framework/master/edu.cuny.citytech.refactoring.common.updatesite"/>
-			<unit id="edu.cuny.citytech.refactoring.common.feature.feature.group" version="5.3.0"/>
+			<repository location="https://ponder-lab.github.io/Common-Eclipse-Refactoring-Framework/releases/"/>
+			<unit id="edu.cuny.citytech.refactoring.common.feature.feature.group" version="5.5.0"/>
 		</location>
 		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 			<dependencies>


### PR DESCRIPTION
Adds the targeted k-CFA depth as a refactoring wizard field, completing the configurable-depth surface from #600, and integrates Common Eclipse Refactoring Framework 5.5.0 (#639).

- Bumps the Common-Eclipse-Refactoring-Framework target to **5.5.0** and migrates the repository URL from the legacy `raw.githubusercontent` in-repo update site to the CI-published **composite p2 site** (`https://ponder-lab.github.io/Common-Eclipse-Refactoring-Framework/releases/`); 5.5.0 is published there, not committed to `master`.
- Overrides `addOptions` in `HybridizeFunctionsInputPage` to expose the depth via `addSpinnerButton(..., DEFAULT_TARGETED_CFA_DEPTH, /* minimum */ 1, ...)` (ponder-lab/Common-Eclipse-Refactoring-Framework#56) wired to `setTargetedCfaDepth`: integer-only entry with steppers and a floor of 1.
- Uses `HybridizeFunctionRefactoringProcessor.class.getSimpleName()` in the processor-type guard message.

The wizard field itself is not CI-testable (no SWT test harness); CI covers that the target resolves against the composite site and the whole reactor compiles against 5.5.0.

## Wizard Field

_Screenshot of the new spinner on the refactoring wizard page to follow._

Closes #627, closes #639.