### PR TITLE
Publish the p2 update site from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,135 @@
+name: Release (CI-published p2 site)
+
+# PROTOTYPE of a CI-published release flow that replaces the in-repo,
+# cumulative P2 update site (see docs/RELEASING.md).
+#
+# What it does, on manual dispatch:
+#   1. set the release version, build + test (Tycho), producing a complete
+#      per-version p2 repo at .../updatesite/target/repository
+#      (the updatesite module already has a category.xml, so the build is
+#      non-empty; no GUI / p2 publisher needed)
+#   2. tag vX.Y.Z and create a GitHub Release with the p2 repo zipped as an asset
+#   3. publish that repo to the gh-pages branch under /releases/X.Y.Z and
+#      regenerate the p2 *composite* indexes so the single Pages URL exposes
+#      every released version
+#   4. bump main to the next development version
+#
+# No binaries are ever committed to main. The gh-pages branch holds the
+# published site (an orphan branch independent of source history).
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Release version (X.Y.Z)"
+        required: true
+      next_version:
+        description: "Next dev version (X.Y.Z, -SNAPSHOT added). Blank = bump minor."
+        required: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  UPDATESITE: edu.cuny.hunter.hybridize.updatesite
+  PAGES_URL: https://ponder-lab.github.io/Hybridize-Functions-Refactoring
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "25"
+          distribution: temurin
+          cache: maven
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute versions
+        id: v
+        run: |
+          REL="${{ github.event.inputs.release_version }}"
+          NEXT="${{ github.event.inputs.next_version }}"
+          [[ "$REL" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "bad release version"; exit 1; }
+          if [[ -z "$NEXT" ]]; then IFS=. read -r MA MI PA <<<"$REL"; NEXT="${MA}.$((MI+1)).0"; fi
+          echo "rel=$REL"            >> "$GITHUB_OUTPUT"
+          echo "next=${NEXT}-SNAPSHOT" >> "$GITHUB_OUTPUT"
+
+      - name: Set release version
+        run: ./mvnw -B -q org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=${{ steps.v.outputs.rel }}
+
+      - name: Build, test, verify formatting
+        run: |
+          ./mvnw -B spotless:check
+          ./mvnw -B -U -DtrimStackTrace=true clean install
+
+      - name: Sanity-check the built p2 repo is non-empty
+        run: |
+          test -f "$UPDATESITE/target/repository/content.jar"
+          test -n "$(find "$UPDATESITE/target/repository/features" -name '*.jar')"
+
+      - name: Zip the p2 repo for the release asset
+        run: |
+          # write OUTSIDE the working tree so the release commit's `git add -A` can't capture it
+          (cd "$UPDATESITE/target/repository" && zip -qr "$RUNNER_TEMP/p2-repo-${{ steps.v.outputs.rel }}.zip" .)
+
+      - name: Commit release version, tag, push, and create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REL="${{ steps.v.outputs.rel }}"
+          git add -A
+          git commit -q -m "Release v${REL}."
+          git tag -a "v${REL}" -m "Release v${REL}."
+          git push origin main
+          git push origin "v${REL}"
+          gh release create "v${REL}" \
+            --title "v${REL}" --generate-notes \
+            "$RUNNER_TEMP/p2-repo-${REL}.zip#p2 update site (zip)"
+
+      - name: Publish to gh-pages as a composite repository
+        run: |
+          REL="${{ steps.v.outputs.rel }}"
+          PAGES="$RUNNER_TEMP/pages"   # OUTSIDE the working tree
+          git fetch origin gh-pages || true
+          rm -rf "$PAGES"
+          git worktree add -B gh-pages "$PAGES" "origin/gh-pages" 2>/dev/null \
+            || git worktree add --orphan -B gh-pages "$PAGES"
+          rm -rf "$PAGES/releases/$REL"
+          mkdir -p "$PAGES/releases/$REL"
+          cp -r "$UPDATESITE/target/repository/." "$PAGES/releases/$REL/"
+          bash "$GITHUB_WORKSPACE/tools/p2-composite.sh" "$PAGES/releases" "Hybridize Functions Refactoring" "$(date +%s000)"
+          # root index.html -> composite under /releases
+          printf '<meta http-equiv="refresh" content="0; url=releases/">\n' > "$PAGES/index.html"
+          ( cd "$PAGES"
+            git add -A
+            git commit -q -m "Publish v$REL to composite p2 site" || echo "nothing to commit"
+            git push origin gh-pages )
+          git worktree remove --force "$PAGES"
+
+      - name: Prepare next development version
+        run: |
+          ./mvnw -B -q org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=${{ steps.v.outputs.next }}
+          git add -A
+          git commit -q -m "Prepare next development version."
+          git push origin main
+
+      - name: Summary
+        run: |
+          echo "Released v${{ steps.v.outputs.rel }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Update site: ${PAGES_URL}/releases/" >> "$GITHUB_STEP_SUMMARY"
+          echo "main now on ${{ steps.v.outputs.next }}" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,45 @@
+# Releasing
+
+This documents a **prototype** CI-published release flow, proposed as a replacement for the in-repo, cumulative P2 update site. It mirrors the approach proven in [ponder-lab/Common-Eclipse-Refactoring-Framework](https://github.com/ponder-lab/Common-Eclipse-Refactoring-Framework) (see ponder-lab/Hybridize-Functions-Refactoring#629).
+
+## Current Model (Committed Update Site)
+
+The P2 update site lives **inside the source repo** (`edu.cuny.hunter.hybridize.updatesite/`) and is **cumulative**: every release commits its feature/plugin jars and rewrites `artifacts.jar`/`content.jar`, served from `raw.githubusercontent.com/.../main/...updatesite`. It currently holds tens of MB of binaries (it also bundles dependency jars such as WALA and PyDev).
+
+Trade-offs:
+
+- ➖ Binaries accumulate in `main` history **forever**—every release grows every clone, unrecoverably.
+- ➖ `raw.githubusercontent.com` is not a real artifact host (no CDN/SLA).
+- ➕ Zero infra; everything is in one repo.
+
+## Prototype Model (This Branch: CI→GitHub Pages Composite Repo)
+
+The update site is **built in CI and published to the `gh-pages` branch**, never committed to `main`. Each release publishes its **own** small p2 repo under `releases/X.Y.Z/`, and a p2 **composite repository** at the root ties them all together—so one stable URL exposes every version without a monolithic index.
+
+Stable update-site URL (composite):
+
+```
+https://ponder-lab.github.io/Hybridize-Functions-Refactoring/releases/
+```
+
+Pieces added on this branch:
+
+- **`.github/workflows/release.yml`**—manual-dispatch pipeline: set-version→build/test→tag + GitHub Release (with the p2 repo zipped as an asset)→publish to `gh-pages` as a composite→next-dev bump.
+- **`tools/p2-composite.sh`**—regenerates `compositeContent.xml`/`compositeArtifacts.xml` from the per-version child dirs.
+
+Unlike Common, this repo already has a `category.xml`, so the Tycho `eclipse-repository` build already produces a non-empty p2 repo—no `category.xml` fix is needed.
+
+Trade-offs:
+
+- ➕ **No binaries in `main`**—source history stays lean. The published bits live on the orphan `gh-pages` branch, independent of source clones.
+- ➕ One CLI build produces the repo; no hand-assembled index.
+- ➕ Composite layout scales to any number of versions; each release is an isolated, immutable child.
+- ➕ Released p2 repo is also attached to the GitHub Release as a zip.
+- ➖ Relies on GitHub Pages + Actions (infra, perms).
+
+## Migration Notes (Not Done on This Branch)
+
+1. Enable GitHub Pages for the `gh-pages` branch.
+2. Seed `gh-pages` with the existing committed update site as `releases/archive/` (one child holding all versions through the latest release) so the Pages URL exposes all history alongside the old URL during transition.
+3. Update the README's update-site URL to the Pages composite URL.
+4. Drop the committed `edu.cuny.hunter.hybridize.updatesite` binaries from `main` (history preserved on `gh-pages`).

--- a/tools/p2-composite.sh
+++ b/tools/p2-composite.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# p2-composite.sh — (re)generate p2 composite repository indexes.
+#
+# A composite p2 repository is just two XML files that reference per-version
+# child repositories. This lets a single, stable update-site URL expose every
+# released version without a monolithic cumulative index and without keeping
+# any binaries in the source repo.
+#
+# Usage:  p2-composite.sh <site-root> <repo-name> <epoch-millis>
+#   <site-root>   directory whose immediate subdirectories are child p2 repos
+#                 (each containing content.jar / artifacts.jar)
+#   <repo-name>   human-readable repository name
+#   <epoch-millis> timestamp to stamp (pass in; CI provides it)
+#
+set -euo pipefail
+ROOT="${1:?site-root}"; NAME="${2:?repo-name}"; TS="${3:?epoch-millis}"
+
+# children = immediate subdirs that look like a p2 repo
+mapfile -t CHILDREN < <(
+	find "$ROOT" -mindepth 2 -maxdepth 2 -name content.jar -printf '%h\n' \
+		| sed "s#^$ROOT/##" | sort -V
+)
+
+emit() { # $1 = filename, $2 = processing-instruction, $3 = repo type
+	local out="$ROOT/$1" pi="$2" type="$3"
+	{
+		echo "<?xml version='1.0' encoding='UTF-8'?>"
+		echo "<?$pi version='1.0.0'?>"
+		echo "<repository name='$NAME' type='$type' version='1.0.0'>"
+		echo "  <properties size='1'>"
+		echo "    <property name='p2.timestamp' value='$TS'/>"
+		echo "  </properties>"
+		echo "  <children size='${#CHILDREN[@]}'>"
+		for c in "${CHILDREN[@]}"; do echo "    <child location='$c'/>"; done
+		echo "  </children>"
+		echo "</repository>"
+	} > "$out"
+	echo "wrote $out (${#CHILDREN[@]} children)"
+}
+
+emit compositeContent.xml   compositeMetadataRepository \
+	org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository
+emit compositeArtifacts.xml compositeArtifactRepository \
+	org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository


### PR DESCRIPTION
Addresses #629: replace the in-repo, cumulative committed P2 update site with a CI-built, GitHub Pages-published p2 composite repository. Mirrors the approach proven in [ponder-lab/Common-Eclipse-Refactoring-Framework](https://github.com/ponder-lab/Common-Eclipse-Refactoring-Framework) (where v5.4.0 shipped this way with a 0-jar release commit). See `docs/RELEASING.md`.

## What This Adds
- **`.github/workflows/release.yml`**—manual-dispatch pipeline: set-version→build/test→tag + GitHub Release (p2 repo attached as a zip)→publish to `gh-pages` as a composite repo→next-dev bump. No binaries touch `main`.
- **`tools/p2-composite.sh`**—generates the p2 `compositeContent.xml`/`compositeArtifacts.xml`.

## Verified Locally
- `release.yml` is valid YAML; `spotless:check` green (with the `Formatting` submodule). ✅
- Seeding the existing committed update site as `releases/archive/` and generating the composite: **the Eclipse p2 director resolves all 8 historical feature versions (1.0.0→1.4.0) through the composite**. ✅
- Not run locally: the full Tycho `clean install` (heavy: WALA/PyDev/target platform). The build path is identical to Common's proven flow, and this repo already has a `category.xml`, so `eclipse-repository` produces a non-empty repo (no `category.xml` fix needed). The CI run will exercise it.

## Why
The committed update site is cumulative and currently ~39 MB of feature/plugin jars in `main` (it also bundles WALA/PyDev), growing every release and served from `raw.githubusercontent.com`. This keeps **no binaries in `main`** (they live on the orphan `gh-pages` branch) and uses a composite layout that scales to any number of versions as isolated children.

Composite URL would become:
```
https://ponder-lab.github.io/Hybridize-Functions-Refactoring/releases/
```

## Not Done Here (Migration)
Enable Pages for `gh-pages`; seed `gh-pages` with the existing site as `releases/archive/` (so the URL exposes all history alongside the old URL); repoint the README; then drop the committed `edu.cuny.hunter.hybridize.updatesite` binaries from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
