### PR TITLE
Prepare next development version (1.5.0-SNAPSHOT)

### DIFF
--- a/edu.cuny.hunter.hybridize.core/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.hybridize.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: edu.cuny.hunter.hybridize.core;singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.5.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-ClassPath: .
 Automatic-Module-Name: edu.cuny.hunter.hybridize.core

--- a/edu.cuny.hunter.hybridize.core/pom.xml
+++ b/edu.cuny.hunter.hybridize.core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>edu.cuny.hunter.hybridize</groupId>
     <artifactId>edu.cuny.hunter.hybridize</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>edu.cuny.hunter.hybridize.core</artifactId>

--- a/edu.cuny.hunter.hybridize.eval/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.hybridize.eval/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: edu.cuny.hunter.hybridize.eval;singleton:=true
 Bundle-Vendor: %Bundle-Vendor
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.5.0.qualifier
 Export-Package: edu.cuny.hunter.hybridize.eval.handlers,
  edu.cuny.hunter.hybridize.eval.ui.plugins
 Import-Package: com.google.common.collect,

--- a/edu.cuny.hunter.hybridize.eval/pom.xml
+++ b/edu.cuny.hunter.hybridize.eval/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>edu.cuny.hunter.hybridize</groupId>
     <artifactId>edu.cuny.hunter.hybridize</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>edu.cuny.hunter.hybridize.eval</artifactId>

--- a/edu.cuny.hunter.hybridize.feature/feature.xml
+++ b/edu.cuny.hunter.hybridize.feature/feature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="edu.cuny.hunter.hybridize.feature" label="Hybridize Functions Refactoring" version="1.4.0.qualifier" provider-name="City University of New York (CUNY) Hunter College" plugin="edu.cuny.hunter.hybridize.core">
+<feature id="edu.cuny.hunter.hybridize.feature" label="Hybridize Functions Refactoring" version="1.5.0.qualifier" provider-name="City University of New York (CUNY) Hunter College" plugin="edu.cuny.hunter.hybridize.core">
   <description url="https://github.com/ponder-lab/Hybridize-Functions-Refactoring"> Refactorings for optimizing imperative TensorFlow clients for greater efficiency.</description>
   <copyright>2025 Raffi Khatchadourian and Tatiana Castro Vélez. All rights reserved.</copyright>
   <license url="https://www.eclipse.org/legal/epl-2.0">

--- a/edu.cuny.hunter.hybridize.feature/pom.xml
+++ b/edu.cuny.hunter.hybridize.feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>edu.cuny.hunter.hybridize</groupId>
     <artifactId>edu.cuny.hunter.hybridize</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>edu.cuny.hunter.hybridize.feature</artifactId>

--- a/edu.cuny.hunter.hybridize.tests.report/pom.xml
+++ b/edu.cuny.hunter.hybridize.tests.report/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>edu.cuny.hunter.hybridize</groupId>
     <artifactId>edu.cuny.hunter.hybridize</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>edu.cuny.hunter.hybridize.tests.report</artifactId>
@@ -13,19 +13,19 @@
     <dependency>
       <groupId>edu.cuny.hunter.hybridize</groupId>
       <artifactId>edu.cuny.hunter.hybridize.core</artifactId>
-      <version>1.4.0-SNAPSHOT</version>
+      <version>1.5.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>edu.cuny.hunter.hybridize</groupId>
       <artifactId>edu.cuny.hunter.hybridize.ui</artifactId>
-      <version>1.4.0-SNAPSHOT</version>
+      <version>1.5.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>edu.cuny.hunter.hybridize</groupId>
       <artifactId>edu.cuny.hunter.hybridize.tests</artifactId>
-      <version>1.4.0-SNAPSHOT</version>
+      <version>1.5.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/edu.cuny.hunter.hybridize.tests/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.hybridize.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: edu.cuny.hunter.hybridize.tests;singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.5.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor
 Automatic-Module-Name: edu.cuny.hunter.hybridize.tests

--- a/edu.cuny.hunter.hybridize.tests/pom.xml
+++ b/edu.cuny.hunter.hybridize.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>edu.cuny.hunter.hybridize</groupId>
     <artifactId>edu.cuny.hunter.hybridize</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>edu.cuny.hunter.hybridize.tests</artifactId>

--- a/edu.cuny.hunter.hybridize.ui/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.hybridize.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: edu.cuny.hunter.hybridize.ui;singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.5.0.qualifier
 Automatic-Module-Name: edu.cuny.hunter.hybridize.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-25
 Bundle-Activator: edu.cuny.hunter.hybridize.ui.plugins.HybridizeFunctionRefactoringPlugin

--- a/edu.cuny.hunter.hybridize.ui/pom.xml
+++ b/edu.cuny.hunter.hybridize.ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>edu.cuny.hunter.hybridize</groupId>
     <artifactId>edu.cuny.hunter.hybridize</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>edu.cuny.hunter.hybridize.ui</artifactId>

--- a/edu.cuny.hunter.hybridize.updatesite/pom.xml
+++ b/edu.cuny.hunter.hybridize.updatesite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>edu.cuny.hunter.hybridize</groupId>
     <artifactId>edu.cuny.hunter.hybridize</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>edu.cuny.hunter.hybridize.updatesite</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>edu.cuny.hunter.hybridize</groupId>
   <artifactId>edu.cuny.hunter.hybridize</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.5.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Hybridize Function Refactoring</name>
   <description>This prototype refactoring plug-in for Eclipse PyDev represents ongoing work in developing an automated refactoring tool that would assist developers in hybridizing their Python functions.</description>


### PR DESCRIPTION
The post-release "prepare next development version" bump after v1.4.0 was missed, so `main` was left on `1.4.0-SNAPSHOT` even though `v1.4.0` is tagged. This applies the bump to `1.5.0-SNAPSHOT` (matching the minor-version release history) across all poms, manifests, and the feature.

`tycho-versions:set-version` only; no update-site binaries touched. If you intended a patch line instead (`1.4.1-SNAPSHOT`), say so and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)