### PR TITLE
Skip the Coveralls upload when no token is available

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -73,4 +73,7 @@ jobs:
     - name: Test with Maven
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      run: ./mvnw -U -s .travis.settings.xml -Dgithub.username=${{ github.actor }} -Dgithub.password=${{ secrets.GITHUB_TOKEN }} -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties -DtrimStackTrace=true -Dtycho.showEclipseLog=false -B verify -Pjacoco coveralls:report
+      # Skip the Coveralls upload when no token is available (Dependabot and fork PRs do not receive repository secrets), so coverage
+      # reporting stays best-effort and a token-less run does not fail the build. Runs with the token (including Dependabot once the token
+      # is also added as a Dependabot secret) still upload.
+      run: ./mvnw -U -s .travis.settings.xml -Dgithub.username=${{ github.actor }} -Dgithub.password=${{ secrets.GITHUB_TOKEN }} -Dlogging.config.file=\${maven.multiModuleProjectDirectory}/logging.ci.properties -DtrimStackTrace=true -Dtycho.showEclipseLog=false -B verify -Pjacoco coveralls:report -Dcoveralls.skip=${{ secrets.COVERALLS_REPO_TOKEN == '' }}


### PR DESCRIPTION
Dependabot and fork PRs do not receive repository secrets. Since #625 moved the Coveralls token into a secret, the `coveralls:report` goal fails those builds with "Either repository token or service with job id must be defined" (seen on #637 and #638), even though all tests pass.

Pass `-Dcoveralls.skip=${{ secrets.COVERALLS_REPO_TOKEN == '' }}` to the `Test with Maven` step. When the token is absent the upload is skipped (coverage stays best-effort and the build is green); when the token is present the upload runs as before.

This is the fail-safe half. Adding `COVERALLS_REPO_TOKEN` as a Dependabot secret (Settings, Secrets and variables, Dependabot) is the complementary admin step that lets Dependabot runs actually upload coverage rather than skip it.

Toward #622.