### PR TITLE
Bump the Ariadne dependency to 0.51.0 for the sparse-tensor API

### DIFF
--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3344,7 +3344,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter24() throws Exception {
 		// Precision audit. `add(tf.SparseTensor([[0,0],[1,2]], [1,2], [3,4]), ...)` — verified at runtime: INT32 dtype, dense shape (3, 4).
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
+		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
+				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
@@ -3556,7 +3559,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter46() throws Exception {
 		// Precision audit. Two INT32 SparseTensors with dense shape (3, 4).
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
+		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
+				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
@@ -3661,7 +3667,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter57() throws Exception {
 		// Precision audit. `SparseTensor(...)` from `tensorflow` — INT32 dense shape (3, 4).
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
+		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
+				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
@@ -4197,7 +4206,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
+		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
+		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))).asSparse(),
+				new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
@@ -4208,7 +4220,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
+		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
+		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))).asSparse(),
+				new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
@@ -4219,7 +4234,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
+		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
+		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))).asSparse(),
+				new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
 	}
 
 	/**
@@ -4331,7 +4349,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
+		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
+				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
@@ -4342,7 +4363,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
+		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
+				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**
@@ -4353,7 +4377,10 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
+		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
+				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
 	}
 
 	/**

--- a/hybridize.target
+++ b/hybridize.target
@@ -57,7 +57,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.50.0</version>
+					<version>0.51.0</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
Bumps the Ariadne dependency from 0.50.0 to 0.51.0 in `hybridize.target`, picking up the sparse-tensor type API (`SparseTensorType`, `isSparse()`, `layout()`, `asSparse()`) that #533 needs to emit `tf.SparseTensorSpec`.

## Test impact

0.51.0 now types `SparseTensor` parameters as sparse. That surfaces a divergence the dense-only audit pins did not show: the nine `testHasLikelyTensorParameter*` sparse-fixture tests asserted dense types at both layers. They are re-pinned to:
- Layer 1 (raw Ariadne param type): **sparse** (`.asSparse()`).
- Layer 2 (Hybridize `inferInputSignature`): **dense**, because inference still drops sparseness to a dense `TensorSpec`.

The Layer 2 expectation flips to sparse when `SparseTensorSpec` emission lands (#533); the divergence is now visible and pinned rather than silent.

No production code references the removed 3-arg `TensorType(dtype, dims, sparse)` constructor or `sparse` field, so no production change was needed.

Closes #636. Unblocks #533.