### PR TITLE
Emit `SparseTensorSpec` for sparse tensor parameters

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -2023,6 +2023,11 @@ public class Function {
 			// conservative drop because `tf.UNKNOWN` isn't a valid runtime dtype for `input_signature`. Pending #494.
 			return Optional.empty();
 
+		// Sparseness consensus: preserve the sparse layout only when every context agrees the parameter is sparse, so the emission can
+		// produce a `SparseTensorSpec` rather than a dense `TensorSpec` (#533). A mixed sparse/dense parameter falls through to dense (the
+		// pre-#533 behavior); neither spec admits both layouts, so refining that case is left for later.
+		boolean sparse = contexts.stream().allMatch(TensorType::isSparse);
+
 		// Step 2: rank consensus or shape-⊤. If any context has shape = null or ranks disagree, emit `TensorType(dtype, null)`,
 		// preserving the dtype axis even when the shape axis degrades.
 		// `rank` uses -1 as a "not yet set" sentinel: dim list sizes are always non-negative, so the sentinel can't collide. A boxed
@@ -2032,11 +2037,11 @@ public class Function {
 		for (TensorType t : contexts) {
 			List<Dimension<?>> dims = t.getDims();
 			if (dims == null)
-				return Optional.of(new TensorType(dtype, null));
+				return Optional.of(withSparseness(new TensorType(dtype, null), sparse));
 			if (rank == -1)
 				rank = dims.size();
 			else if (rank != dims.size())
-				return Optional.of(new TensorType(dtype, null));
+				return Optional.of(withSparseness(new TensorType(dtype, null), sparse));
 		}
 
 		// Step 3: per-dim consensus or wildcard. If all contexts agree on a concrete value at position j, keep it; else emit a
@@ -2074,7 +2079,20 @@ public class Function {
 				shape.add(new SymbolicDim("?"));
 		}
 
-		return Optional.of(new TensorType(dtype, shape));
+		return Optional.of(withSparseness(new TensorType(dtype, shape), sparse));
+	}
+
+	/**
+	 * Returns the sparse view of the given {@link TensorType} when {@code sparse} is true, otherwise the type unchanged. Used by
+	 * {@link #inferSpec} to carry a sparse-layout consensus onto the reduced type so {@link InputSignature#toTensorSpecList} emits a
+	 * {@code SparseTensorSpec} (#533).
+	 *
+	 * @param type The reduced {@link TensorType}.
+	 * @param sparse True iff the parameter's contexts agreed it is sparse.
+	 * @return The sparse view when {@code sparse}, otherwise {@code type}.
+	 */
+	private static TensorType withSparseness(TensorType type, boolean sparse) {
+		return sparse ? type.asSparse() : type;
 	}
 
 	private boolean hasTensorContext() {

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
@@ -28,13 +28,17 @@ public record InputSignature(List<TensorType> parameterTypes) {
 	/** The {@code tf.RaggedTensorSpec} constructor name, emitted for a ragged tensor parameter (#524). */
 	private static final String RAGGED_TENSOR_SPEC = "RaggedTensorSpec";
 
+	/** The {@code tf.SparseTensorSpec} constructor name, emitted for a sparse tensor parameter (#533). */
+	private static final String SPARSE_TENSOR_SPEC = "SparseTensorSpec";
+
 	/**
 	 * Format this signature as a Python source-code expression suitable for the {@code input_signature=} keyword argument of
 	 * {@code @tf.function(...)}. Each parameter's {@link TensorType} renders as {@code tfPrefix + "<SpecType>(shape=(...), dtype=" +
-	 * tfPrefix + "<dtype>)"}, where {@code <SpecType>} is {@code RaggedTensorSpec} for a parameter with a ragged dimension and
-	 * {@code TensorSpec} otherwise ({@link #specTypeName}); shape dims render as concrete integers for {@link NumericDim} and {@code None}
-	 * for every other {@link Dimension} subtype (dynamic, ragged, symbolic—all encoded the same way on the spec surface). The whole thing
-	 * is wrapped in {@code [...]} so it can drop straight into {@code @tf.function(input_signature=...)}.
+	 * tfPrefix + "<dtype>)"}, where {@code <SpecType>} is {@code SparseTensorSpec} for a sparse parameter, {@code RaggedTensorSpec} for a
+	 * parameter with a ragged dimension, and {@code TensorSpec} otherwise ({@link #specTypeName}); shape dims render as concrete integers
+	 * for {@link NumericDim} and {@code None} for every other {@link Dimension} subtype (dynamic, ragged, symbolic—all encoded the same way
+	 * on the spec surface). The whole thing is wrapped in {@code [...]} so it can drop straight into
+	 * {@code @tf.function(input_signature=...)}.
 	 * <p>
 	 * Examples (with {@code tfPrefix = "tf."}):
 	 * <ul>
@@ -76,25 +80,31 @@ public record InputSignature(List<TensorType> parameterTypes) {
 	}
 
 	/**
-	 * The TensorFlow spec-type constructor for a parameter: {@code RaggedTensorSpec} when the parameter has a ragged dimension (it is a
-	 * {@code tf.RaggedTensor}), otherwise {@code TensorSpec}. The bare name without any module prefix.
+	 * The TensorFlow spec-type constructor for a parameter: {@code SparseTensorSpec} when the parameter is sparse (it is a
+	 * {@code tf.SparseTensor}, #533), {@code RaggedTensorSpec} when it has a ragged dimension (it is a {@code tf.RaggedTensor}, #524),
+	 * otherwise {@code TensorSpec}. The bare name without any module prefix.
 	 *
 	 * @param t The parameter's {@link TensorType}.
-	 * @return {@code "RaggedTensorSpec"} or {@code "TensorSpec"}.
+	 * @return {@code "SparseTensorSpec"}, {@code "RaggedTensorSpec"}, or {@code "TensorSpec"}.
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/524">Issue 524</a>
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Issue 533</a>
 	 */
 	private static String specTypeName(TensorType t) {
+		if (t.isSparse())
+			return SPARSE_TENSOR_SPEC;
+
 		List<Dimension<?>> dims = t.getDims();
 		boolean ragged = dims != null && dims.stream().anyMatch(RaggedDim.class::isInstance);
 		return ragged ? RAGGED_TENSOR_SPEC : TENSOR_SPEC;
 	}
 
 	/**
-	 * The set of spec-type constructor names this signature references (e.g., {@code "TensorSpec"}, {@code "RaggedTensorSpec"}), as the
-	 * bare Python identifiers emitted by {@link #toTensorSpecList(String)} (without any module prefix). The source-write verifies each is
-	 * reachable under the chosen import prefix before emitting an unqualified signature: on the {@code from tensorflow import ...}
-	 * named-import path a signature with a ragged parameter needs {@code RaggedTensorSpec} in scope, which {@code TensorSpec} being
-	 * imported does not imply, so an unguarded emission would produce a {@code NameError}-raising decorator.
+	 * The set of spec-type constructor names this signature references (e.g., {@code "TensorSpec"}, {@code "RaggedTensorSpec"},
+	 * {@code "SparseTensorSpec"}), as the bare Python identifiers emitted by {@link #toTensorSpecList(String)} (without any module prefix).
+	 * The source-write verifies each is reachable under the chosen import prefix before emitting an unqualified signature: on the
+	 * {@code from tensorflow import ...} named-import path a signature with a sparse or ragged parameter needs {@code SparseTensorSpec} or
+	 * {@code RaggedTensorSpec} in scope, which {@code TensorSpec} being imported does not imply, so an unguarded emission would produce a
+	 * {@code NameError}-raising decorator.
 	 *
 	 * @return The referenced spec-type constructor names.
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/524">Issue 524</a>

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -4190,8 +4190,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.eye`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects
-	 * {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.eye`. The parameter is inferred as a sparse {@code TensorType}, so the signature emits a
+	 * {@code SparseTensorSpec} that admits the {@code SparseTensor} arguments (#533).
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
@@ -4201,8 +4201,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.eye`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects
-	 * {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.eye`. The parameter is inferred as a sparse {@code TensorType}, so the signature emits a
+	 * {@code SparseTensorSpec} that admits the {@code SparseTensor} arguments (#533).
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
@@ -4212,8 +4212,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.eye`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec} rejects
-	 * {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.eye`. The parameter is inferred as a sparse {@code TensorType}, so the signature emits a
+	 * {@code SparseTensorSpec} that admits the {@code SparseTensor} arguments (#533).
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
@@ -4324,8 +4324,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.SparseTensor`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec}
-	 * rejects {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.SparseTensor`. The parameter is inferred as a sparse {@code TensorType}, so the signature emits a
+	 * {@code SparseTensorSpec} that admits the {@code SparseTensor} arguments (#533).
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
@@ -4335,8 +4335,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.SparseTensor`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec}
-	 * rejects {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.SparseTensor`. The parameter is inferred as a sparse {@code TensorType}, so the signature emits a
+	 * {@code SparseTensorSpec} that admits the {@code SparseTensor} arguments (#533).
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */
@@ -4346,8 +4346,8 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
-	 * Test for #2 for TF API `sparse.SparseTensor`. The shape/dtype assertion is numerically correct but the inferred {@code TensorSpec}
-	 * rejects {@code SparseTensor} arguments at runtime; the {@code SparseTensorSpec} emission flip target is tracked separately.
+	 * Test for #2 for TF API `sparse.SparseTensor`. The parameter is inferred as a sparse {@code TensorType}, so the signature emits a
+	 * {@code SparseTensorSpec} that admits the {@code SparseTensor} arguments (#533).
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Hybridize#533</a>
 	 */

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -3344,10 +3344,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter24() throws Exception {
 		// Precision audit. `add(tf.SparseTensor([[0,0],[1,2]], [1,2], [3,4]), ...)` — verified at runtime: INT32 dtype, dense shape (3, 4).
-		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
-		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
-				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse());
 	}
 
 	/**
@@ -3559,10 +3556,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter46() throws Exception {
 		// Precision audit. Two INT32 SparseTensors with dense shape (3, 4).
-		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
-		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
-				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse());
 	}
 
 	/**
@@ -3667,10 +3661,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	@Test
 	public void testHasLikelyTensorParameter57() throws Exception {
 		// Precision audit. `SparseTensor(...)` from `tensorflow` — INT32 dense shape (3, 4).
-		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
-		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
-				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse());
 	}
 
 	/**
@@ -4206,10 +4197,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter94() throws Exception {
-		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
-		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))).asSparse(),
-				new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))).asSparse());
 	}
 
 	/**
@@ -4220,10 +4208,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter95() throws Exception {
-		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
-		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))).asSparse(),
-				new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))).asSparse());
 	}
 
 	/**
@@ -4234,10 +4219,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter96() throws Exception {
-		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
-		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
-		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))).asSparse(),
-				new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))));
+		testHasLikelyTensorParameterHelper(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))).asSparse());
 	}
 
 	/**
@@ -4349,10 +4331,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter109() throws Exception {
-		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
-		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
-				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse());
 	}
 
 	/**
@@ -4363,10 +4342,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter110() throws Exception {
-		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
-		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
-				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse());
 	}
 
 	/**
@@ -4377,10 +4353,7 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	 */
 	@Test
 	public void testHasLikelyTensorParameter111() throws Exception {
-		// Layer 1 (Ariadne) types the SparseTensor param as sparse; Layer 2 (Hybridize inference) still drops sparseness to a dense
-		// TensorSpec. Pin that divergence; the signature flips to sparse when SparseTensorSpec emission lands (#533).
-		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse(),
-				new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))));
+		testHasLikelyTensorParameterHelper(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse());
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
@@ -81,17 +81,31 @@ public class InputSignatureTest {
 	}
 
 	/**
+	 * A sparse {@link TensorType} selects {@code SparseTensorSpec} over {@code TensorSpec}, since sparseness marks the parameter as a
+	 * {@code tf.SparseTensor} (#533). The shape renders the same as a dense tensor of the same dimensions.
+	 */
+	@Test
+	public void testSparseRendersAsSparseTensorSpec() {
+		InputSignature sig = new InputSignature(List.of(new TensorType(INT32, List.of(new NumericDim(3), new NumericDim(4))).asSparse()));
+		assertEquals("[tf.SparseTensorSpec(shape=(3, 4), dtype=tf.int32)]", sig.toTensorSpecList("tf."));
+	}
+
+	/**
 	 * {@link InputSignature#requiredSpecTypeNames} reports {@code TensorSpec} for a dense parameter, {@code RaggedTensorSpec} for a
-	 * parameter with a ragged dimension, and both for a mixed signature. The source-write gates emission on these being reachable (#524).
+	 * parameter with a ragged dimension, {@code SparseTensorSpec} for a sparse parameter, and the union for a mixed signature. The
+	 * source-write gates emission on these being reachable (#524, #533).
 	 */
 	@Test
 	public void testRequiredSpecTypeNames() {
 		TensorType dense = new TensorType(INT32, List.of(new NumericDim(3)));
 		TensorType ragged = new TensorType(INT32, List.of(new NumericDim(3), RaggedDim.INSTANCE));
+		TensorType sparse = new TensorType(INT32, List.of(new NumericDim(3))).asSparse();
 
 		assertEquals(Set.of("TensorSpec"), new InputSignature(List.of(dense)).requiredSpecTypeNames());
 		assertEquals(Set.of("RaggedTensorSpec"), new InputSignature(List.of(ragged)).requiredSpecTypeNames());
-		assertEquals(Set.of("TensorSpec", "RaggedTensorSpec"), new InputSignature(List.of(dense, ragged)).requiredSpecTypeNames());
+		assertEquals(Set.of("SparseTensorSpec"), new InputSignature(List.of(sparse)).requiredSpecTypeNames());
+		assertEquals(Set.of("TensorSpec", "RaggedTensorSpec", "SparseTensorSpec"),
+				new InputSignature(List.of(dense, ragged, sparse)).requiredSpecTypeNames());
 	}
 
 	/**


### PR DESCRIPTION
Routes sparse tensor parameters to `tf.SparseTensorSpec` in the inferred `input_signature`, the sparse analog of the ragged `tf.RaggedTensorSpec` path (#524), now that Ariadne 0.51.0 (#636/#643) types `SparseTensor` parameters as sparse.

## Changes
- `InputSignature.specTypeName` returns `SparseTensorSpec` when `TensorType.isSparse()`, ahead of the ragged and dense branches. `toTensorSpecList` and `requiredSpecTypeNames` follow from it; the shape renders identically to a dense tensor, only the spec-type name differs.
- `Function.inferSpec` computes a sparseness consensus (every context sparse) and preserves it on the reduced `TensorType` via `asSparse()`, so the inferred signature stays sparse instead of collapsing to a dense `TensorSpec`. A mixed sparse/dense parameter falls through to dense (the pre-#533 behavior; neither spec admits both layouts).

## Tests
- The nine `testHasLikelyTensorParameter*` sparse audits flip from the `(sparse, dense)` divergence pinned in #636 to a single sparse expectation, now that Layer 1 (Ariadne) and Layer 2 (Hybridize inference) agree.
- `InputSignatureTest` gains `testSparseRendersAsSparseTensorSpec` (emits `tf.SparseTensorSpec(shape=(3, 4), dtype=tf.int32)`) and an extended `testRequiredSpecTypeNames` covering sparse.

Closes #533.