### PR TITLE
Add an opt-in flag for input-signature inference in the refactoring

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/refactorings/HybridizeFunctionRefactoringProcessor.java
@@ -80,6 +80,8 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 
 	private static final String DUMP_CALL_GRAPH_PROPERTY_KEY = "edu.cuny.hunter.hybridize.dumpCallGraph";
 
+	private static final String INFER_INPUT_SIGNATURES_PROPERTY_KEY = "edu.cuny.hunter.hybridize.inferInputSignatures";
+
 	private static final ILog LOG = getLog(HybridizeFunctionRefactoringProcessor.class);
 
 	private Set<Function> functions = new LinkedHashSet<>();
@@ -121,11 +123,14 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 	private boolean useSpeculativeAnalysis;
 
 	/**
-	 * True iff the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator.
+	 * True iff the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator. Off by default;
+	 * defaults from the {@code edu.cuny.hunter.hybridize.inferInputSignatures} system property (for headless runs), is overridden by the
+	 * value passed to the constructors, and is settable from the wizard via {@link #setInferInputSignatures(boolean)} (#481).
 	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481">Issue 481</a>
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
 	 */
-	private boolean inferInputSignatures;
+	private boolean inferInputSignatures = Boolean.getBoolean(INFER_INPUT_SIGNATURES_PROPERTY_KEY);
 
 	/**
 	 * The default targeted k-CFA depth: {@link PythonTensorAnalysisEngine#MODEL_FORWARD_CFA_DEPTH}, the depth at which the model-forward
@@ -634,6 +639,15 @@ public class HybridizeFunctionRefactoringProcessor extends RefactoringProcessor 
 	 */
 	public boolean getInferInputSignatures() {
 		return this.inferInputSignatures;
+	}
+
+	/**
+	 * Sets whether the refactoring should emit an inferred {@code input_signature} keyword into the generated decorator (#481).
+	 *
+	 * @param inferInputSignatures True iff the refactoring should emit an inferred {@code input_signature}.
+	 */
+	public void setInferInputSignatures(boolean inferInputSignatures) {
+		this.inferInputSignatures = inferInputSignatures;
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringProcessorTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringProcessorTest.java
@@ -37,4 +37,17 @@ public class HybridizeFunctionRefactoringProcessorTest {
 				false);
 		assertFalse(processor.getInferInputSignatures());
 	}
+
+	/**
+	 * {@link HybridizeFunctionRefactoringProcessor#setInferInputSignatures(boolean)} updates the flag the accessor returns (the setter the
+	 * wizard checkbox calls, #481).
+	 */
+	@Test
+	public void testSetInferInputSignatures() {
+		HybridizeFunctionRefactoringProcessor processor = new HybridizeFunctionRefactoringProcessor();
+		processor.setInferInputSignatures(true);
+		assertTrue(processor.getInferInputSignatures());
+		processor.setInferInputSignatures(false);
+		assertFalse(processor.getInferInputSignatures());
+	}
 }

--- a/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
+++ b/edu.cuny.hunter.hybridize.ui/src/edu/cuny/hunter/hybridize/ui/wizards/HybridizeFunctionRefactoringWizard.java
@@ -37,6 +37,10 @@ public class HybridizeFunctionRefactoringWizard extends RefactoringWizard {
 
 		private static final String TARGETED_CFA_DEPTH_LABEL = "Targeted k-CFA depth for tensor-type precision:";
 
+		private static final String INFER_INPUT_SIGNATURES_KEY = "inferInputSignatures"; // $NON-NLS-1$
+
+		private static final String INFER_INPUT_SIGNATURES_LABEL = "Emit an inferred input_signature into the @tf.function decorator.";
+
 		private HybridizeFunctionRefactoringProcessor processor;
 
 		public HybridizeFunctionsInputPage() {
@@ -68,6 +72,8 @@ public class HybridizeFunctionRefactoringWizard extends RefactoringWizard {
 
 		@Override
 		protected void addOptions(Composite optionComposite) {
+			this.addBooleanButton(INFER_INPUT_SIGNATURES_LABEL, INFER_INPUT_SIGNATURES_KEY, this.processor.getInferInputSignatures(),
+					this.processor::setInferInputSignatures, optionComposite);
 			this.addSpinnerButton(TARGETED_CFA_DEPTH_LABEL, TARGETED_CFA_DEPTH_KEY, DEFAULT_TARGETED_CFA_DEPTH, /* minimum */ 1,
 					this.processor::setTargetedCfaDepth, optionComposite);
 		}


### PR DESCRIPTION
Completes the opt-in flag gating input-signature emission (#481). The processor field, evaluator wiring, source-write gating (#563), and memoization (#612) already existed; this adds the two surfaces that were missing, now that #628 merged the wizard's `addOptions` hook.

- The processor's `inferInputSignatures` field defaults from a new `edu.cuny.hunter.hybridize.inferInputSignatures` system property (headless default, mirroring `dumpCallGraph`), still overridden by the constructor argument used by the evaluator; adds a `setInferInputSignatures` setter.
- The refactoring wizard gains an `inferInputSignatures` checkbox in its options (seed-safe `addBooleanButton`, seeded from the processor's current value, wired to the setter), alongside the targeted k-CFA depth spinner.

No new tests: the system-property default follows the untested `dumpCallGraph` precedent, and the SWT checkbox is not CI-testable (same as the #628 depth field); the flag's effect is already covered by the input-signature emission tests.

Closes #481.