### PR TITLE
Classify type-hinted keyword-only parameters as tensors

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -982,6 +982,11 @@ public class Function {
 		if (args != null && args.args != null)
 			for (int i = 0; i < args.args.length; i++)
 				built.add(new Parameter(args, i, this));
+		// Keyword-only parameters (declared after a bare `*`) are a sibling array; tensor parameters declared keyword-only (idiomatic in
+		// Keras `call()` methods) would otherwise be missed (#607). `vararg`/`kwarg` remain unwrapped (#465).
+		if (args != null && args.kwonlyargs != null)
+			for (int i = 0; i < args.kwonlyargs.length; i++)
+				built.add(new Parameter(args, i, this, true));
 		this.parameters = Collections.unmodifiableList(built);
 	}
 

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Parameter.java
@@ -110,14 +110,22 @@ public final class Parameter {
 
 	/**
 	 * Parent Jython AST node carrying every positional name expression (in {@link argumentsType#args}) and per-position annotation (in
-	 * {@link argumentsType#annotation}) of the owning function. Shared across all {@link Parameter}s of the same function.
+	 * {@link argumentsType#annotation}) of the owning function, plus the sibling keyword-only arrays ({@link argumentsType#kwonlyargs} and
+	 * {@link argumentsType#kwonlyargannotation}). Shared across all {@link Parameter}s of the same function.
 	 */
 	private final argumentsType arguments;
 
 	/**
-	 * Zero-based position of this parameter within {@link #arguments}{@code .args}. Bounded at construction time to be a valid index.
+	 * Zero-based position of this parameter within {@link #arguments}{@code .args} (positional) or {@link #arguments}{@code .kwonlyargs}
+	 * (keyword-only, see {@link #keywordOnly}). Bounded at construction time to be a valid index for the relevant array.
 	 */
 	private final int index;
+
+	/**
+	 * True iff this parameter is keyword-only (declared after a bare {@code *}), indexing into {@link #arguments}{@code .kwonlyargs} rather
+	 * than {@code .args} (#607).
+	 */
+	private final boolean keywordOnly;
 
 	/**
 	 * The possible {@link TensorType}s of this {@link Parameter}.
@@ -160,11 +168,27 @@ public final class Parameter {
 	 * @throws IndexOutOfBoundsException If {@code index} is out of range for {@code arguments.args}.
 	 */
 	Parameter(argumentsType arguments, int index, Function function) {
+		this(arguments, index, function, false);
+	}
+
+	/**
+	 * Package-private constructor allowing keyword-only parameters (#607). Positional parameters index into {@code arguments.args};
+	 * keyword-only parameters (declared after a bare {@code *}) index into {@code arguments.kwonlyargs}.
+	 *
+	 * @param arguments The parent {@link argumentsType} node. Non-null.
+	 * @param index The zero-based index within the relevant name array ({@code args} or {@code kwonlyargs}).
+	 * @param function The owning {@link Function}. Non-null.
+	 * @param keywordOnly True iff this is a keyword-only parameter (indexing into {@code arguments.kwonlyargs}).
+	 * @throws IndexOutOfBoundsException If {@code index} is out of range for the relevant name array.
+	 */
+	Parameter(argumentsType arguments, int index, Function function, boolean keywordOnly) {
 		this.arguments = Objects.requireNonNull(arguments);
 		this.function = Objects.requireNonNull(function);
-		if (index < 0 || arguments.args == null || index >= arguments.args.length)
-			throw new IndexOutOfBoundsException("Parameter index " + index + " out of bounds for arguments of length "
-					+ (arguments.args == null ? 0 : arguments.args.length) + ".");
+		this.keywordOnly = keywordOnly;
+		exprType[] names = keywordOnly ? arguments.kwonlyargs : arguments.args;
+		if (index < 0 || names == null || index >= names.length)
+			throw new IndexOutOfBoundsException("Parameter index " + index + " out of bounds for " + (keywordOnly ? "kwonlyargs" : "args")
+					+ " of length " + (names == null ? 0 : names.length) + ".");
 		this.index = index;
 	}
 
@@ -194,7 +218,7 @@ public final class Parameter {
 	 * @return True iff this parameter is at index {@code 0} and is named {@code self}.
 	 */
 	public boolean isSelf() {
-		return this.getIndex() == 0 && SELF_PARAMETER_NAME.equals(this.getName());
+		return !this.keywordOnly && this.getIndex() == 0 && SELF_PARAMETER_NAME.equals(this.getName());
 	}
 
 	/**
@@ -204,6 +228,15 @@ public final class Parameter {
 	 * @return The {@link TypeInfo} for this parameter, or {@code null} if no type hint is present.
 	 */
 	protected TypeInfo getTypeInfo() {
+		// PyDev's by-name resolver (NodeUtils.getTypeForParameterFromStaticTyping) scans only `args.args`/`args.annotation`, so it never
+		// finds a keyword-only parameter's annotation (ponder-lab/Pydev#11). Read `kwonlyargannotation` directly for keyword-only
+		// parameters (#607).
+		if (this.keywordOnly) {
+			exprType[] kwonlyAnnotations = this.arguments.kwonlyargannotation;
+			if (kwonlyAnnotations != null && this.index < kwonlyAnnotations.length && kwonlyAnnotations[this.index] != null)
+				return new TypeInfo(kwonlyAnnotations[this.index]);
+			return null;
+		}
 		return getTypeForParameterFromAST(this.getName(), this.function.getFunctionDefinition().getFunctionDef());
 	}
 
@@ -557,7 +590,7 @@ public final class Parameter {
 	}
 
 	private exprType getNameExpr() {
-		return this.arguments.args[this.index];
+		return (this.keywordOnly ? this.arguments.kwonlyargs : this.arguments.args)[this.index];
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testKwonlyTensorParameter/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testKwonlyTensorParameter/in/A.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+
+def f(x, *, y: tf.Tensor):
+    return y
+
+
+f(tf.constant(1), y=tf.ones([2, 3]))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testKwonlyTensorParameter/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testKwonlyTensorParameter/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testKwonlyTensorParameterCallSite/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testKwonlyTensorParameterCallSite/in/A.py
@@ -1,0 +1,8 @@
+import tensorflow as tf
+
+
+def f(x, *, y):
+    return y
+
+
+f(tf.constant(1), y=tf.ones([2, 3]))

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testKwonlyTensorParameterCallSite/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testKwonlyTensorParameterCallSite/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -7082,6 +7082,46 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		return yPred.getTensorTypes();
 	}
 
+	/**
+	 * A keyword-only parameter (declared after a bare {@code *}) is wrapped as a {@link Parameter} and, when it carries a tensor-typed type
+	 * hint, classifies as a tensor. PyDev's by-name type-hint resolver scans only the positional argument array, so {@link Parameter} reads
+	 * the keyword-only annotation array directly.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/607">Issue 607</a>
+	 */
+	@Test
+	public void testKwonlyTensorParameter() throws Exception {
+		Function f = getFunction("f");
+
+		Parameter y = f.getParameters().stream().filter(p -> "y".equals(p.getName())).findFirst()
+				.orElseThrow(() -> new AssertionError("Expected the keyword-only parameter `y` to be wrapped."));
+
+		assertEquals("tf.Tensor", y.getTypeHintName());
+		assertTrue("Keyword-only parameter `y` should have a tensor type hint.", y.hasTensorTypeHint(new NullProgressMonitor()));
+		assertTrue("Keyword-only parameter `y` should classify as a tensor via its type hint.", y.isTensor());
+		assertTrue(f.getHasTensorParameter());
+	}
+
+	/**
+	 * Pinning test: a keyword-only parameter whose tensor value arrives only through a keyword argument at the call site (no type hint)
+	 * does not yet classify as a tensor. WALA's Python frontend does not model keyword-only parameters as formal parameters in the IR, so
+	 * no pointer key corresponds to the parameter and the call-site (Phase 2) path contributes no tensor type. Invert this assertion when
+	 * that upstream gap is closed.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/607">Issue 607</a>
+	 * @see <a href="https://github.com/wala/ML/issues/596">WALA ML issue 596</a>
+	 */
+	@Test
+	public void testKwonlyTensorParameterCallSite() throws Exception {
+		Function f = getFunction("f");
+
+		Parameter y = f.getParameters().stream().filter(p -> "y".equals(p.getName())).findFirst()
+				.orElseThrow(() -> new AssertionError("Expected the keyword-only parameter `y` to be wrapped."));
+
+		// TODO: Invert once WALA models keyword-only parameters as formal parameters (wala/ML#596).
+		assertFalse("Keyword-only parameter `y` does not yet classify from a call-site keyword argument alone.", y.isTensor());
+	}
+
 	@Test
 	public void testAutoEncoder() throws Exception {
 		Set<Function> functions = getFunctions();


### PR DESCRIPTION
## Summary

Keyword-only parameters (declared after a bare `*`) were absent from the per-function parameter model, so keyword-only tensor parameters (idiomatic in Keras `call()` methods) were missed entirely. This wraps them as `Parameter`s and classifies a keyword-only parameter as a tensor from its type hint.

## Changes

- `Function` wraps `argumentsType.kwonlyargs` into `getParameters()` alongside the positional parameters.
- `Parameter` carries a keyword-only flag and reads `kwonlyargannotation` directly when resolving a type hint, since PyDev's by-name resolver scans only the positional arrays.
- Tests: `testKwonlyTensorParameter` asserts a type-hinted keyword-only tensor parameter classifies; `testKwonlyTensorParameterCallSite` pins the still-blocked call-site path.

## Upstream

- ponder-lab/Pydev#11: PyDev's type-hint resolver ignores keyword-only annotations, worked around here by reading `kwonlyargannotation` directly.
- wala/ML#596: keyword-only parameters are not modeled as formal parameters in the IR, so classifying one purely from a call-site keyword argument is not yet possible. The pinning test inverts when this lands.

## Related

Part of #607.
