### PR TITLE
Align the update site Eclipse repository reference to 4.39

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Eclipse PDE refactoring plug-ins (Tycho-built) that automate hybridization of Python TensorFlow functions — i.e., deciding when to add/remove `@tf.function` and applying the transformation. Runs inside Eclipse on top of PyDev and uses WALA/Ariadne for static analysis of Python.
 
-The tool is **not compatible with stock PyDev**: it depends on the ponder-lab fork (`pydev_9_3` branch). See `hybridize.target` for the active target platform (Eclipse 4.25, PyDev 9.3.x, WALA 1.7, Ariadne via `maven.pkg.github.com/ponder-lab/ML`).
+The tool is **not compatible with stock PyDev**: it depends on the ponder-lab fork (`pydev_9_3` branch). See `hybridize.target` for the active target platform (Eclipse 4.39, PyDev 9.3.x, WALA 1.7, Ariadne via `maven.pkg.github.com/ponder-lab/ML`).
 
 ## Build / test commands
 

--- a/edu.cuny.hunter.hybridize.updatesite/category.xml
+++ b/edu.cuny.hunter.hybridize.updatesite/category.xml
@@ -7,7 +7,7 @@
     <description> Refactorings for optimizing imperative TensorFlow clients for greater efficiency.
     </description>
   </category-def>
-  <repository-reference location="http://download.eclipse.org/eclipse/updates/4.25" enabled="true" />
+  <repository-reference location="https://download.eclipse.org/eclipse/updates/4.39" enabled="true" />
   <repository-reference location="https://raw.githubusercontent.com/ponder-lab/Common-Eclipse-Refactoring-Framework/master/edu.cuny.citytech.refactoring.common.updatesite" enabled="true" />
   <repository-reference location="https://raw.githubusercontent.com/ponder-lab/Pydev/pydev_9_3/org.python.pydev.updatesite" enabled="true" />
 </site>


### PR DESCRIPTION
## Summary

`edu.cuny.hunter.hybridize.updatesite/category.xml` pinned its Eclipse `repository-reference` to 4.25, while `hybridize.target` and the feature's discovery URL are on 4.39 (since the target bump in afabff33). A p2 reference to an older Eclipse stream than the target can pull older platform units at install time. This aligns the reference to the target's URL (https, 4.39) and updates the stale 4.25 mention in `CLAUDE.md`.

## Context

Surfaced by an automated review note on #633; pre-existing and outside that PR's de-vendor scope (which touches only `feature.xml`), so handled here.
