### PR TITLE
Cover inferSpec dtype-⊤ branch with a synthesized input

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -2008,11 +2008,16 @@ public class Function {
 	 * {@link InputSignature#toTensorSpecList} to emit a {@code RaggedTensorSpec}); any other non-{@link NumericDim} context dim yields a
 	 * wildcard at that position.
 	 * </ol>
+	 * <p>
+	 * Visible (rather than {@code private}) so the reduction can be exercised directly with a hand-built context set, isolating algorithm
+	 * behavior from upstream tensor-type precision. This is the only seam for branches that upstream cannot currently produce as a fixture
+	 * (e.g., the dtype-⊤ singleton, #494); {@link #inferInputSignature()} cannot stand in because it requires a fully classified
+	 * {@link Function}.
 	 *
 	 * @param contexts The non-empty set of {@link TensorType}s Ariadne associated with the parameter across call contexts.
 	 * @return The reduced single {@link TensorType}, or {@link Optional#empty} for the dtype-⊥ and dtype-⊤ branches.
 	 */
-	private static Optional<TensorType> inferSpec(Set<TensorType> contexts) {
+	public static Optional<TensorType> inferSpec(Set<TensorType> contexts) {
 		// Step 1: dtype consensus. Walk the contexts; any disagreement drops the signature.
 		DType dtype = null;
 		for (TensorType t : contexts) {

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InferSpecTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InferSpecTest.java
@@ -1,0 +1,51 @@
+package edu.cuny.hunter.hybridize.tests;
+
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.FLOAT32;
+import static com.ibm.wala.cast.python.ml.types.TensorFlowTypes.DType.UNKNOWN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.ibm.wala.cast.python.ml.types.TensorType;
+import com.ibm.wala.cast.python.ml.types.TensorType.NumericDim;
+
+import edu.cuny.hunter.hybridize.core.analysis.Function;
+
+/**
+ * Synthesized-input tests for {@link Function#inferSpec(Set)}, the per-parameter multi-context reduction. Inputs are hand-built
+ * {@link TensorType} sets so the reduction is exercised in isolation from upstream tensor-type precision.
+ *
+ * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/494">Issue 494</a>
+ */
+@SuppressWarnings("static-method")
+public class InferSpecTest {
+
+	/**
+	 * A single context whose dtype is {@code UNKNOWN} (dtype-⊤) drops the spec. {@code tf.UNKNOWN} is not a valid runtime dtype for
+	 * {@code tf.function(input_signature=...)}, so the conservative reduction is to bottom. This branch is fixture-unreachable (upstream no
+	 * longer emits a {@code DType.UNKNOWN} singleton), so the synthesized input is the only way to exercise it.
+	 */
+	@Test
+	public void testDtypeTopSingletonDrops() {
+		Optional<TensorType> spec = Function.inferSpec(Set.of(new TensorType(UNKNOWN, List.of(new NumericDim(3)))));
+		assertTrue("A dtype-⊤ (UNKNOWN) singleton should reduce to bottom.", spec.isEmpty());
+	}
+
+	/**
+	 * Witness that the drop above is caused by the {@code UNKNOWN} dtype specifically, not by the singleton shape: an otherwise-identical
+	 * context with a concrete dtype reduces to that same concrete type.
+	 */
+	@Test
+	public void testConcreteDtypeSingletonReduces() {
+		TensorType concrete = new TensorType(FLOAT32, List.of(new NumericDim(3)));
+		Optional<TensorType> spec = Function.inferSpec(Set.of(concrete));
+		assertFalse("A concrete-dtype singleton should reduce to a spec.", spec.isEmpty());
+		assertEquals(concrete, spec.get());
+	}
+}


### PR DESCRIPTION
## Summary

`Function.inferSpec` drops the spec when the per-context dtype consensus is a single `DType.UNKNOWN` (dtype-⊤), since `tf.UNKNOWN` is not a valid runtime dtype for `tf.function(input_signature=...)`. Since Ariadne 0.47.0 (wala/ML#539) typed `tf.constant(np_array)` concretely, no Python fixture is known to produce a `DType.UNKNOWN` singleton, so this branch was unexercised.

## Changes

- Expose `Function.inferSpec` (a pure static reduction, `Set<TensorType>` to `Optional<TensorType>`) so it can be driven with synthesized inputs.
- Add `InferSpecTest`: a dtype-⊤ singleton reduces to bottom, and an otherwise-identical concrete-dtype singleton reduces, witnessing that the drop is caused by the unknown dtype rather than the shape.

## Notes

This follows project #6's synthesized-input method (invoke the algorithm with a hand-built input set). `inferInputSignature` cannot stand in as the entry point because it requires a fully Ariadne-classified `Function`, which cannot be hand-built; exposing the pure reduction is the only seam for a branch upstream cannot produce as a fixture.

## Related

Closes #494.
