### PR TITLE
Abandon the input signature for a mixed sparse/dense parameter

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -1960,20 +1960,31 @@ public class Function {
 			if (spec.isEmpty()) {
 				/*
 				 * `inferSpec` reduced to bottom. With the per-context reduction
-				 * (https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/480) it now drops for only two reasons:
-				 * heterogeneous dtype (|D| ≠ 1) or dtype-⊤ (a single agreed `UNKNOWN`). Shape-⊤ and symbolic-dim no longer drop here—it
-				 * emits a coarse `TensorType(dtype, null)` or a `SymbolicDim` wildcard instead. Emit a per-parameter INFO naming the
-				 * reason; see https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/510.
+				 * (https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/480) it drops for three reasons: heterogeneous
+				 * dtype (|D| ≠ 1), dtype-⊤ (a single agreed `UNKNOWN`), or mixed sparse/dense
+				 * (https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/642). Shape-⊤ and symbolic-dim no longer drop
+				 * here—it emits a coarse `TensorType(dtype, null)` or a `SymbolicDim` wildcard instead. Classify in `inferSpec`'s own
+				 * precedence order (dtype before sparseness) so the reason is exact, and emit a per-parameter INFO naming it; see
+				 * https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/510.
 				 */
-				boolean heterogeneous = contexts.stream().map(TensorType::getDType).distinct().count() > 1;
-				if (heterogeneous)
+				boolean heterogeneousDtype = contexts.stream().map(TensorType::getDType).distinct().count() > 1;
+				boolean unknownDtype = !heterogeneousDtype && contexts.stream().anyMatch(t -> t.getDType() == DType.UNKNOWN);
+				AbsenceReason reason;
+				if (heterogeneousDtype) {
 					this.addInfo(INPUT_SIGNATURE_INFERENCE, "Parameter `" + param.getName() + "` of `" + this
 							+ "` receives tensors with conflicting dtypes across call sites, so a single input signature cannot be inferred; it is dropped.");
-				else
+					reason = AbsenceReason.HETEROGENEOUS_DTYPE;
+				} else if (unknownDtype) {
 					this.addInfo(INPUT_SIGNATURE_INFERENCE, "Parameter `" + param.getName() + "` of `" + this
 							+ "` receives a tensor whose dtype cannot be determined, so a single input signature cannot be inferred; it is dropped.");
+					reason = AbsenceReason.UNKNOWN_DTYPE;
+				} else {
+					this.addInfo(INPUT_SIGNATURE_INFERENCE, "Parameter `" + param.getName() + "` of `" + this
+							+ "` is sparse at some call sites and dense at others, so a single input signature cannot be inferred; it is dropped.");
+					reason = AbsenceReason.HETEROGENEOUS_SPARSITY;
+				}
 				if (firstReason == null)
-					firstReason = heterogeneous ? AbsenceReason.HETEROGENEOUS_DTYPE : AbsenceReason.UNKNOWN_DTYPE;
+					firstReason = reason;
 				continue;
 			}
 
@@ -2033,10 +2044,15 @@ public class Function {
 			// conservative drop because `tf.UNKNOWN` isn't a valid runtime dtype for `input_signature`. Pending #494.
 			return Optional.empty();
 
-		// Sparseness consensus: preserve the sparse layout only when every context agrees the parameter is sparse, so the emission can
-		// produce a `SparseTensorSpec` rather than a dense `TensorSpec` (#533). A mixed sparse/dense parameter falls through to dense (the
-		// pre-#533 behavior); neither spec admits both layouts, so refining that case is left for later.
-		boolean sparse = contexts.stream().allMatch(TensorType::isSparse);
+		// Sparseness consensus: a parameter must be uniformly sparse or uniformly dense across contexts. A `SparseTensorSpec` admits only
+		// sparse tensors and a dense `TensorSpec` admits only dense tensors (#533), so a parameter that is sparse at some call sites and
+		// dense at others has no single spec that accepts both layouts. Emitting either would reject traffic the function accepts, so the
+		// conservative reduction is bottom—the same `|sparseness| ≠ 1 ⇒ ⊥` discipline the dtype axis uses above (#642).
+		boolean anySparse = contexts.stream().anyMatch(TensorType::isSparse);
+		boolean allSparse = contexts.stream().allMatch(TensorType::isSparse);
+		if (anySparse && !allSparse)
+			return Optional.empty();
+		boolean sparse = allSparse;
 
 		// Step 2: rank consensus or shape-⊤. If any context has shape = null or ranks disagree, emit `TensorType(dtype, null)`,
 		// preserving the dtype axis even when the shape axis degrades.

--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InferenceResult.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InferenceResult.java
@@ -43,7 +43,14 @@ public sealed interface InferenceResult {
 		 * A parameter receives a tensor whose dtype cannot be determined (dtype-⊤: a single agreed {@code UNKNOWN}), which is not a valid
 		 * runtime dtype for {@code tf.function(input_signature=...)} (#494).
 		 */
-		UNKNOWN_DTYPE
+		UNKNOWN_DTYPE,
+
+		/**
+		 * A parameter is sparse at some call sites and dense at others. A {@code SparseTensorSpec} admits only sparse tensors and a dense
+		 * {@code TensorSpec} admits only dense tensors, so no single spec accepts both layouts; emitting either would reject traffic the
+		 * function accepts, so the reduction is bottom (#642). Checked after the dtype axis, mirroring {@link Function#inferSpec}.
+		 */
+		HETEROGENEOUS_SPARSITY
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InferSpecTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InferSpecTest.java
@@ -50,23 +50,20 @@ public class InferSpecTest {
 	}
 
 	/**
-	 * Pinning test: a parameter that is sparse at one call site and dense at another (same dtype, same shape) does not abandon. The dtype
-	 * consensus holds, the sparseness consensus fails, and the reduction falls through to a <em>dense</em> spec. A dense {@code TensorSpec}
-	 * would reject the {@code SparseTensor} the function accepts at the sparse call site, so the emission is unsound; abandoning to bottom
-	 * instead is tracked by issue 642. Invert when the sparse/dense axis is taught to drop on disagreement.
+	 * A parameter that is sparse at one call site and dense at another (same dtype, same shape) abandons to bottom. The dtype consensus
+	 * holds but the sparseness consensus fails, and no single spec is sound: a dense {@code TensorSpec} rejects the {@code SparseTensor}
+	 * the function accepts at the sparse call site, while a {@code SparseTensorSpec} rejects the dense tensor it accepts at the dense call
+	 * site. So the reduction drops (#642). This is the inversion of the former dense fall-through, which #650 pinned with a TODO.
 	 *
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/642">Issue 642</a>
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/533">Issue 533</a>
 	 */
 	@Test
-	public void testMixedSparseDenseFallsThroughToDense() {
+	public void testMixedSparseDenseDrops() {
 		TensorType dense = new TensorType(FLOAT32, List.of(new NumericDim(3), new NumericDim(3)));
 		TensorType sparse = new TensorType(FLOAT32, List.of(new NumericDim(3), new NumericDim(3))).asSparse();
 		Optional<TensorType> spec = Function.inferSpec(Set.of(dense, sparse));
 
-		// TODO: Invert to a drop once the sparse/dense axis abandons on disagreement rather than emitting an unsound dense spec (#642).
-		assertFalse("A mixed sparse/dense parameter currently reduces to a spec rather than abandoning.", spec.isEmpty());
-		assertFalse("The reduced spec is currently dense, which would reject the sparse calls the function accepts (#642).",
-				spec.get().isSparse());
+		assertTrue("A mixed sparse/dense parameter has no sound single spec, so it abandons to bottom (#642).", spec.isEmpty());
 	}
 }


### PR DESCRIPTION
A parameter that is sparse at some call sites and dense at others now reduces to bottom in `inferSpec`, matching the discipline the dtype axis already uses.

## Soundness

Previously the sparseness consensus failed silently and the reduction fell through to a dense `TensorSpec` (pinned by #650). That dense spec rejects the `SparseTensor` the function accepts at the sparse call site, and a `SparseTensorSpec` would symmetrically reject the dense tensor, so no single spec is sound. Emitting one would change the function's accepted inputs, a behavior change a refactoring must not introduce. Abandoning the whole signature is the correct conservative outcome for an irreducibly-polymorphic parameter.

A uniformly-sparse parameter still emits a `SparseTensorSpec` via the existing path; only the genuinely mixed case (exercised by the synthesized `InferSpecTest`) drops.

## Attribution

To report the drop precisely rather than mis-attributing it as a dtype problem, the per-parameter drop diagnostic in `inferInputSignature` is now three-way (heterogeneous dtype, dtype-⊤, mixed sparse/dense), classified in `inferSpec`'s own precedence order (dtype before sparseness). A new `AbsenceReason.HETEROGENEOUS_SPARSITY` carries the reason, and the `INPUT_SIGNATURE_INFERENCE` INFO names the parameter (#510).

## Test

The #650 pinning test is inverted (`testMixedSparseDenseFallsThroughToDense` becomes `testMixedSparseDenseDrops`) to assert the drop. Full suite: 539 tests, 0 failures.

## Out Of Scope

Call-site-precise recovery (emitting a tight spec when the polymorphism is only apparent, with one branch live at the real call sites) is a separate enhancement gated on Ariadne resolving the parameter's concrete type per call site, tracked separately.

Closes #642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
