### PR TITLE
Emit per-parameter input-signature drop attribution to a CSV in the evaluator

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -900,6 +901,14 @@ public class Function {
 	 * signature in a single pass (analysis, import injection, and the transform paths all ask for it).
 	 */
 	private InferenceResult inferredInputSignature;
+
+	/**
+	 * Per-parameter blocking reasons from the last {@link #computeInputSignature()} run, in parameter declaration order. Empty when
+	 * inference produced a signature or was never run. Where {@link #getInferredInputSignatureAbsenceReason()} reports only the first
+	 * blocking reason for the whole function, this retains every blocking parameter's reason for read-only per-parameter reporting (e.g.
+	 * the evaluator); see {@link #getBlockingParameterReasons()}.
+	 */
+	private Map<Parameter, AbsenceReason> blockingParameterReasons = new LinkedHashMap<>();
 
 	/**
 	 * The {@link FunctionDefinition} representing this {@link Function}.
@@ -1908,6 +1917,18 @@ public class Function {
 	}
 
 	/**
+	 * Returns the blocking {@link InferenceResult.AbsenceReason} for each parameter that prevented input-signature inference, in parameter
+	 * declaration order, from the memoized result without triggering inference. Where {@link #getInferredInputSignatureAbsenceReason()}
+	 * collapses the function to its first blocking reason, this surfaces every blocking parameter so a consumer can report per-parameter
+	 * attribution (#654). Empty both when inference was never run and when it produced a signature.
+	 *
+	 * @return An unmodifiable map from each blocking {@link Parameter} to its {@link InferenceResult.AbsenceReason}, in declaration order.
+	 */
+	public Map<Parameter, AbsenceReason> getBlockingParameterReasons() {
+		return Collections.unmodifiableMap(this.blockingParameterReasons);
+	}
+
+	/**
 	 * Computes the inferred input signature. Always recomputes; {@link #inferInputSignature()} memoizes the result. Emits the per-parameter
 	 * recovery INFOs as a side effect. The {@link InferenceResult.Absent} result carries the <em>first</em> blocking
 	 * {@link InferenceResult.AbsenceReason} encountered, but the loop still runs to completion so every blocking parameter surfaces its
@@ -1918,6 +1939,7 @@ public class Function {
 	private InferenceResult computeInputSignature() {
 		List<TensorType> specs = new ArrayList<>();
 		AbsenceReason firstReason = null;
+		Map<Parameter, AbsenceReason> blocking = new LinkedHashMap<>();
 
 		for (Parameter param : this.getParameters()) {
 			// `self` is excluded from the signature.
@@ -1937,6 +1959,7 @@ public class Function {
 								+ "(annotate as `" + param.getName() + ": tf.Tensor` and pass `tf.constant(...)` at call sites). "
 								+ "If the change is appropriate for this function's semantics, rerunning the refactoring will infer "
 								+ "a complete input signature including `" + param.getName() + "`.");
+				blocking.put(param, AbsenceReason.NON_TENSOR_PARAMETER);
 				if (firstReason == null)
 					firstReason = AbsenceReason.NON_TENSOR_PARAMETER;
 				continue;
@@ -1951,6 +1974,7 @@ public class Function {
 						"Parameter `" + param.getName() + "` of `" + this + "` is classified as tensor-typed via type hint or "
 								+ "container detection but has no concrete shape/dtype evidence; input-signature inference is "
 								+ "dropped. Synthesizing a TensorSpec from this signal is tracked at #509.");
+				blocking.put(param, AbsenceReason.NO_SHAPE_OR_DTYPE_EVIDENCE);
 				if (firstReason == null)
 					firstReason = AbsenceReason.NO_SHAPE_OR_DTYPE_EVIDENCE;
 				continue;
@@ -1983,6 +2007,7 @@ public class Function {
 							+ "` is sparse at some call sites and dense at others, so a single input signature cannot be inferred; it is dropped.");
 					reason = AbsenceReason.HETEROGENEOUS_SPARSITY;
 				}
+				blocking.put(param, reason);
 				if (firstReason == null)
 					firstReason = reason;
 				continue;
@@ -1990,6 +2015,8 @@ public class Function {
 
 			specs.add(spec.get());
 		}
+
+		this.blockingParameterReasons = blocking;
 
 		// A signature must be total over the parameters: any blocking reason makes the whole result Absent, even if some parameters
 		// reduced.

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -111,6 +111,8 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 	private static final String[] CALLS_HEADER = { "subject", "callee", "expr" };
 
+	private static final String BLOCKED_PARAMETERS_CSV_FILENAME = "blocked_parameters.csv";
+
 	private static final String PERFORM_ANALYSIS_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.performAnalysis";
 
 	private static final String PERFORM_CHANGE_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.performChange";
@@ -218,7 +220,9 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 					CSVPrinter statusPrinter = createCSVPrinter(STATUS_CSV_FILENAME,
 							buildAttributeColumnNames("refactoring", "severity", "code", "message"));
 					CSVPrinter decoratorPrinter = createCSVPrinter(DECORATOR_CSV_FILENAME, buildAttributeColumnNames("decorator"));
-					CSVPrinter callPrinter = createCSVPrinter(CALL_CSV_FILENAME, CALLS_HEADER);) {
+					CSVPrinter callPrinter = createCSVPrinter(CALL_CSV_FILENAME, CALLS_HEADER);
+					CSVPrinter blockedParametersPrinter = createCSVPrinter(BLOCKED_PARAMETERS_CSV_FILENAME,
+							buildAttributeColumnNames("param index", "param name", "absence reason"));) {
 				if (BUILD_WORKSPACE) {
 					// build the workspace.
 					monitor.beginTask("Building workspace ...", IProgressMonitor.UNKNOWN);
@@ -269,8 +273,10 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 					Set<Function> functions = processor.getFunctions();
 					resultsPrinter.print(functions.size());
 
-					for (Function func : functions)
+					for (Function func : functions) {
 						printFunction(functionsPrinter, func);
+						printBlockedParameters(blockedParametersPrinter, func);
+					}
 
 					// optimization available functions. These are the "filtered" functions. We consider functions to be candidates iff they
 					// have a tensor-like parameter or are currently hybrid.
@@ -518,6 +524,22 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 				"experimental_follow_type_hints", "experimental_implements", "func", "input_signature", "supplied input_signature",
 				"jit_compile", "reduce_retracing", "inferred input_signature", "input_signature relation", "input_signature absence reason",
 				"refactoring", "passing precondition", "status");
+	}
+
+	/**
+	 * Emits one row per parameter that blocked input-signature inference for the given function, naming the parameter and its
+	 * {@link edu.cuny.hunter.hybridize.core.analysis.InferenceResult.AbsenceReason}. Where the {@code functions.csv} {@code input_signature
+	 * absence reason} column reports only the function's first blocking reason, this surfaces the per-parameter attribution (#654). Reads
+	 * the memoized inference result without triggering inference, so it leaves the function's status untouched.
+	 *
+	 * @param printer The {@code blocked_parameters.csv} printer.
+	 * @param function The function whose blocking parameters to emit.
+	 * @throws IOException If a record cannot be written.
+	 */
+	private static void printBlockedParameters(CSVPrinter printer, Function function) throws IOException {
+		for (var entry : function.getBlockingParameterReasons().entrySet())
+			printer.printRecord(
+					buildAttributeColumnValues(function, entry.getKey().getIndex(), entry.getKey().getName(), entry.getValue()));
 	}
 
 	private static void printFunction(CSVPrinter printer, Function function) throws IOException, CoreException {

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -8577,6 +8577,16 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 		assertEquals("Expected one INPUT_SIGNATURE_INFERENCE INFO per blocking parameter.", 2, infoEntries.size());
 		assertTrue("Expected an INFO citing parameter `m`.", infoEntries.stream().anyMatch(e -> e.getMessage().contains("`m`")));
 		assertTrue("Expected an INFO citing parameter `n`.", infoEntries.stream().anyMatch(e -> e.getMessage().contains("`n`")));
+
+		// Per-parameter attribution (#654): both blocking parameters are recorded with their reason, in declaration order, where the
+		// function-level `absenceReason()` collapses to only the first.
+		Map<Parameter, InferenceResult.AbsenceReason> blocking = function.getBlockingParameterReasons();
+		assertEquals("Both non-tensor parameters must be recorded as blocking.", 2, blocking.size());
+		assertEquals("Parameter `m` blocks for the non-tensor-parameter reason.", InferenceResult.AbsenceReason.NON_TENSOR_PARAMETER,
+				blocking.get(m));
+		assertEquals("Parameter `n` blocks for the non-tensor-parameter reason.", InferenceResult.AbsenceReason.NON_TENSOR_PARAMETER,
+				blocking.get(n));
+		assertEquals("Blocking parameters must be in declaration order.", List.of(m, n), new ArrayList<>(blocking.keySet()));
 	}
 
 	/**


### PR DESCRIPTION
When `inferInputSignature` abandons a function to the bottom element, the evaluator records the function-level outcome in `functions.csv` via the `input_signature absence reason` column (the first blocking reason). This adds the **per-parameter** attribution: which parameter caused the drop, and why.

## Core

`Function.inferInputSignature`'s dispatch already computes a blocking `AbsenceReason` for each parameter, but only the first was retained. It now records every blocking parameter's reason in declaration order, exposed read-only via `getBlockingParameterReasons()` without triggering inference (the side-effect-free counterpart of `getInferredInputSignatureAbsenceReason()`).

## Evaluator

A new `blocked_parameters.csv` is written, one row per blocking parameter:

```
subject,function,module,relative path,param index,param name,absence reason
```

It complements the function-grain column, which cannot hold per-parameter rows. Until now the per-parameter naming existed only in the `INPUT_SIGNATURE_INFERENCE` INFO log.

## Test

`testInputSignatureMultipleNonTensorParameters` (two blocking non-tensor parameters) is extended to assert the new map records both, with their reason, in declaration order. Full suite: 540 tests, 0 failures.

Closes #654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)