### PR TITLE
Self-contained product for running the evaluator headlessly

### DIFF
--- a/edu.cuny.hunter.hybridize.eval.feature/build.properties
+++ b/edu.cuny.hunter.hybridize.eval.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/edu.cuny.hunter.hybridize.eval.feature/feature.xml
+++ b/edu.cuny.hunter.hybridize.eval.feature/feature.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature id="edu.cuny.hunter.hybridize.eval.feature" label="Hybridize Functions Evaluation (Internal)" version="1.5.0.qualifier" provider-name="City University of New York (CUNY) Hunter College">
+  <description url="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/660">Internal evaluation tooling for the Hybridize Functions refactoring. Not shipped to end users; packages the evaluator so it can be run headlessly (command line) for reproducibility.</description>
+  <copyright>2025 Raffi Khatchadourian and Tatiana Castro Vélez. All rights reserved.</copyright>
+  <license url="https://www.eclipse.org/legal/epl-2.0">Eclipse Public License - v 2.0. The full text is available at https://www.eclipse.org/legal/epl-2.0.</license>
+  <includes id="edu.cuny.hunter.hybridize.feature" version="0.0.0" />
+  <requires>
+    <import plugin="org.eclipse.equinox.app" />
+  </requires>
+  <plugin id="edu.cuny.hunter.hybridize.eval" download-size="0" install-size="0" version="0.0.0" unpack="false" />
+</feature>

--- a/edu.cuny.hunter.hybridize.eval.feature/pom.xml
+++ b/edu.cuny.hunter.hybridize.eval.feature/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>edu.cuny.hunter.hybridize</groupId>
+    <artifactId>edu.cuny.hunter.hybridize</artifactId>
+    <version>1.5.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>edu.cuny.hunter.hybridize.eval.feature</artifactId>
+  <packaging>eclipse-feature</packaging>
+  <description>Hybridize Functions evaluation feature (internal; not for end users).</description>
+</project>

--- a/edu.cuny.hunter.hybridize.eval.product/edu.cuny.hunter.hybridize.eval.product
+++ b/edu.cuny.hunter.hybridize.eval.product/edu.cuny.hunter.hybridize.eval.product
@@ -20,9 +20,11 @@
    </features>
 
    <configurations>
-      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0"/>
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1"/>
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2"/>
-      <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2"/>
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4"/>
       <plugin id="org.eclipse.equinox.app" autoStart="true" startLevel="4"/>
    </configurations>
 

--- a/edu.cuny.hunter.hybridize.eval.product/edu.cuny.hunter.hybridize.eval.product
+++ b/edu.cuny.hunter.hybridize.eval.product/edu.cuny.hunter.hybridize.eval.product
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+
+<product name="Hybridize Functions Evaluator" uid="edu.cuny.hunter.hybridize.eval.product" application="edu.cuny.hunter.hybridize.eval.evaluate" version="1.5.0.qualifier" useFeatures="true" includeLaunchers="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgs>-Xms1024m -Xmx30480m</vmArgs>
+   </launcherArgs>
+
+   <launcher name="hybridize-evaluator">
+   </launcher>
+
+   <features>
+      <feature id="edu.cuny.hunter.hybridize.eval.feature"/>
+      <feature id="org.eclipse.rcp"/>
+      <feature id="org.eclipse.equinox.executable"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0"/>
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.equinox.app" autoStart="true" startLevel="4"/>
+   </configurations>
+
+</product>

--- a/edu.cuny.hunter.hybridize.eval.product/pom.xml
+++ b/edu.cuny.hunter.hybridize.eval.product/pom.xml
@@ -15,6 +15,22 @@
     <plugins>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <!-- The product only needs a runnable launcher for the platform we evaluate/reproduce on. The
+               root pom also lists 32-bit and other-OS environments, which have no launcher in Eclipse 4.39. -->
+          <environments combine.children="override">
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>x86_64</arch>
+            </environment>
+          </environments>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-director-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/edu.cuny.hunter.hybridize.eval.product/pom.xml
+++ b/edu.cuny.hunter.hybridize.eval.product/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>edu.cuny.hunter.hybridize</groupId>
+    <artifactId>edu.cuny.hunter.hybridize</artifactId>
+    <version>1.5.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>edu.cuny.hunter.hybridize.eval.product</artifactId>
+  <packaging>eclipse-repository</packaging>
+  <description>Self-contained product for running the Hybridize Functions evaluator headlessly (internal; not for end users).</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-director-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <executions>
+          <execution>
+            <id>materialize-products</id>
+            <goals>
+              <goal>materialize-products</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>archive-products</id>
+            <goals>
+              <goal>archive-products</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/edu.cuny.hunter.hybridize.eval/META-INF/MANIFEST.MF
+++ b/edu.cuny.hunter.hybridize.eval/META-INF/MANIFEST.MF
@@ -20,6 +20,7 @@ Import-Package: com.google.common.collect,
  org.python.pydev.shared_core.string
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime;bundle-version="3.26.0",
+ org.eclipse.equinox.app,
  org.eclipse.core.resources;bundle-version="3.18.0",
  org.python.pydev;bundle-version="[9.3.3,10.0.0)",
  edu.cuny.citytech.refactoring.common.eval;bundle-version="5.2.0",

--- a/edu.cuny.hunter.hybridize.eval/plugin.xml
+++ b/edu.cuny.hunter.hybridize.eval/plugin.xml
@@ -79,4 +79,15 @@
          </toolbar>
       </menuContribution>
    </extension>
+   <extension
+         id="evaluate"
+         point="org.eclipse.core.runtime.applications">
+      <application
+            cardinality="singleton-global"
+            thread="main">
+         <run
+               class="edu.cuny.hunter.hybridize.eval.application.EvaluateHybridizeFunctionRefactoringApplication">
+         </run>
+      </application>
+   </extension>
 </plugin>

--- a/edu.cuny.hunter.hybridize.eval/run-headless-evaluator.sh
+++ b/edu.cuny.hunter.hybridize.eval/run-headless-evaluator.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Headless command-line runner for the Hybridize Functions evaluator (issue 657).
+#
+# Runs the `edu.cuny.hunter.hybridize.eval.evaluate` application over the open
+# Python projects in a workspace, without the IDE, and writes the result CSVs to
+# the workspace's working directory (the same outputs as the in-IDE evaluator).
+#
+# Prerequisites:
+#   - An Eclipse installation that contains the Hybridize eval bundle and its
+#     runtime (the ponder-lab PyDev fork, WALA, Ariadne) -- e.g. the development
+#     Eclipse, or a product built to include `edu.cuny.hunter.hybridize.eval`.
+#     Packaging a self-contained product so no pre-existing Eclipse is required
+#     is tracked separately.
+#   - A workspace already populated with the subjects as PyDev projects.
+#
+# Usage:
+#   ECLIPSE=/path/to/eclipse WORKSPACE=/path/to/workspace ./run-headless-evaluator.sh
+#
+# Configuration knobs mirror the IDE launch and can be overridden via the
+# environment (defaults shown below). Parallelization defaults to off because it
+# is nondeterministic (issue 315).
+#
+set -eu
+
+ECLIPSE="${ECLIPSE:?Set ECLIPSE to the Eclipse launcher of an install containing the eval bundle.}"
+WORKSPACE="${WORKSPACE:?Set WORKSPACE to the workspace holding the subjects as PyDev projects.}"
+
+: "${PERFORM_ANALYSIS:=true}"
+: "${PERFORM_CHANGE:=true}"
+: "${INFER_INPUT_SIGNATURES:=false}"
+: "${PROCESS_IN_PARALLEL:=false}"
+: "${FOLLOW_TYPE_HINTS:=true}"
+: "${SPECULATIVE:=true}"
+: "${TEST_ENTRYPOINTS:=true}"
+: "${OUTPUT_CALLS:=false}"
+: "${MAX_HEAP:=30480m}"
+
+exec "$ECLIPSE" \
+	-application edu.cuny.hunter.hybridize.eval.evaluate \
+	-data "$WORKSPACE" \
+	-consoleLog -nosplash \
+	-vmargs \
+	-Xms1024m "-Xmx${MAX_HEAP}" \
+	-Dedu.cuny.hunter.hybridize.eval.performAnalysis="$PERFORM_ANALYSIS" \
+	-Dedu.cuny.hunter.hybridize.eval.performChange="$PERFORM_CHANGE" \
+	-Dedu.cuny.hunter.hybridize.eval.inferInputSignatures="$INFER_INPUT_SIGNATURES" \
+	-Dedu.cuny.hunter.hybridize.eval.processFunctionsInParallel="$PROCESS_IN_PARALLEL" \
+	-Dedu.cuny.hunter.hybridize.eval.alwaysFollowTypeHints="$FOLLOW_TYPE_HINTS" \
+	-Dedu.cuny.hunter.hybridize.eval.useSpeculativeAnalysis="$SPECULATIVE" \
+	-Dedu.cuny.hunter.hybridize.eval.useTestEntrypoints="$TEST_ENTRYPOINTS" \
+	-Dedu.cuny.hunter.hybridize.eval.outputCalls="$OUTPUT_CALLS" \
+	-Dedu.cuny.hunter.hybridize.eval.alwaysCheckPythonSideEffects=false \
+	-Dedu.cuny.hunter.hybridize.eval.alwaysCheckRecursion=false

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/application/EvaluateHybridizeFunctionRefactoringApplication.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/application/EvaluateHybridizeFunctionRefactoringApplication.java
@@ -1,0 +1,81 @@
+package edu.cuny.hunter.hybridize.eval.application;
+
+import static org.eclipse.core.runtime.Platform.getLog;
+import static org.python.pydev.plugin.nature.PythonNature.PYTHON_NATURE_ID;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.equinox.app.IApplication;
+import org.eclipse.equinox.app.IApplicationContext;
+
+import edu.cuny.hunter.hybridize.eval.handlers.EvaluateHybridizeFunctionRefactoringHandler;
+
+/**
+ * Headless (command-line) entry point for the evaluator. Runs
+ * {@link EvaluateHybridizeFunctionRefactoringHandler#evaluate(IProject[], org.eclipse.core.runtime.IProgressMonitor)} over the open Python
+ * projects already in the workspace, without the IDE.
+ * <p>
+ * The workspace must be pre-populated with the subjects as PyDev projects (e.g., imported once via the UI); this application enumerates the
+ * open Python projects and evaluates them. Configuration comes from the same {@code edu.cuny.hunter.hybridize.eval.*} system properties as
+ * the IDE launch. Launch with {@code eclipse -application edu.cuny.hunter.hybridize.eval.evaluate -data <workspace> ...}. See
+ * <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/657">issue 657</a>; programmatic project import (so a
+ * workspace need not be pre-populated) is the follow-up
+ * <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/658">issue 658</a>.
+ */
+public class EvaluateHybridizeFunctionRefactoringApplication implements IApplication {
+
+	private static final ILog LOG = getLog(EvaluateHybridizeFunctionRefactoringApplication.class);
+
+	/** Exit code returned when the workspace contains no open Python project to evaluate. */
+	private static final Integer EXIT_NO_PROJECTS = Integer.valueOf(2);
+
+	/** Exit code returned when the evaluation completes but its status is not OK. */
+	private static final Integer EXIT_EVALUATION_FAILED = Integer.valueOf(1);
+
+	@Override
+	public Object start(IApplicationContext context) throws Exception {
+		IProject[] projects = getOpenPythonProjects();
+
+		if (projects.length == 0) {
+			LOG.warn("No open Python projects in the workspace to evaluate. Import the subjects as PyDev projects first.");
+			return EXIT_NO_PROJECTS;
+		}
+
+		LOG.info("Evaluating " + projects.length + " Python project(s) headlessly.");
+		IStatus status = new EvaluateHybridizeFunctionRefactoringHandler().evaluate(projects, new NullProgressMonitor());
+
+		if (!status.isOK()) {
+			LOG.log(status);
+			return EXIT_EVALUATION_FAILED;
+		}
+
+		return IApplication.EXIT_OK;
+	}
+
+	@Override
+	public void stop() {
+		// Nothing to clean up; evaluate(...) runs synchronously within start(...).
+	}
+
+	/**
+	 * Returns the open, Python-natured projects in the workspace.
+	 *
+	 * @return The open Python projects.
+	 * @throws org.eclipse.core.runtime.CoreException If a project's nature cannot be read.
+	 */
+	private static IProject[] getOpenPythonProjects() throws Exception {
+		List<IProject> pythonProjects = new ArrayList<>();
+
+		for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects())
+			if (project.isOpen() && project.hasNature(PYTHON_NATURE_ID))
+				pythonProjects.add(project);
+
+		return pythonProjects.toArray(IProject[]::new);
+	}
+}

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -42,6 +42,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
@@ -188,214 +189,228 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		Job.create("Evaluating Hybridize Functions refactoring...", monitor -> {
-			List<String> resultsHeader = new ArrayList<>(Arrays.asList("subject", "functions", "optimization available functions",
-					"optimizable functions", "failed preconditions"));
-
-			for (Refactoring refactoring : Refactoring.values())
-				resultsHeader.add(refactoring.toString());
-
-			for (PreconditionSuccess preconditionSuccess : PreconditionSuccess.values())
-				resultsHeader.add(preconditionSuccess.toString());
-
-			for (Transformation transformation : Transformation.values())
-				resultsHeader.add(transformation.toString());
-
-			String[] experimentalSettingsHeader = new String[] { "side-effects", "recursion", "type hints", "parallel", "speculative",
-					"test entrypoints", "infer input signatures", "targeted CFA depth" };
-			resultsHeader.addAll(Arrays.asList(experimentalSettingsHeader));
-
-			resultsHeader.add("time (s)");
-
-			HybridizeFunctionRefactoringProcessor processor = null;
-
-			try (CSVPrinter resultsPrinter = createCSVPrinter(RESULTS_CSV_FILENAME, resultsHeader.toArray(String[]::new));
-					CSVPrinter functionsPrinter = createCSVPrinter(FUNCTIONS_CSV_FILENAME, buildFunctionAttributeColumnNames());
-					CSVPrinter candidatesPrinter = createCSVPrinter(CANDIDATES_CSV_FILENAME, buildAttributeColumnNames());
-					CSVPrinter transformationsPrinter = createCSVPrinter(TRANSFORMATIONS_CSV_FILENAME,
-							buildAttributeColumnNames("transformation"));
-					CSVPrinter optimizableFunctionPrinter = createCSVPrinter(OPTMIZABLE_CSV_FILENAME, buildAttributeColumnNames());
-					CSVPrinter nonOptimizableFunctionPrinter = createCSVPrinter(NONOPTMIZABLE_CSV_FILENAME, buildAttributeColumnNames());
-					CSVPrinter errorPrinter = createCSVPrinter(FAILED_PRECONDITIONS_CSV_FILENAME,
-							buildAttributeColumnNames("refactoring", "severity", "code", "message"));
-					CSVPrinter statusPrinter = createCSVPrinter(STATUS_CSV_FILENAME,
-							buildAttributeColumnNames("refactoring", "severity", "code", "message"));
-					CSVPrinter decoratorPrinter = createCSVPrinter(DECORATOR_CSV_FILENAME, buildAttributeColumnNames("decorator"));
-					CSVPrinter callPrinter = createCSVPrinter(CALL_CSV_FILENAME, CALLS_HEADER);
-					CSVPrinter blockedParametersPrinter = createCSVPrinter(BLOCKED_PARAMETERS_CSV_FILENAME,
-							buildAttributeColumnNames("param index", "param name", "absence reason"));) {
-				if (BUILD_WORKSPACE) {
-					// build the workspace.
-					monitor.beginTask("Building workspace ...", IProgressMonitor.UNKNOWN);
-					ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor.slice(IProgressMonitor.UNKNOWN));
-				}
-
-				IProject[] pythonProjects = getSelectedPythonProjectsFromEvent(event);
-
-				monitor.beginTask("Analyzing projects...", pythonProjects.length);
-
-				for (IProject project : pythonProjects) {
-					if (!(project.isOpen() && project.exists() && project.hasNature(PYTHON_NATURE_ID)
-							&& project.isNatureEnabled(PYTHON_NATURE_ID)))
-						throw new IllegalStateException("Python project: " + project.getName() + " must be open and must exist.");
-
-					// subject.
-					resultsPrinter.print(project.getName());
-
-					// calls.
-					if (Boolean.getBoolean(OUTPUT_CALLS_KEY))
-						printCalls(callPrinter, project, monitor.slice(IProgressMonitor.UNKNOWN));
-
-					// set up analysis for single project.
-					int targetedCfaDepth = getTargetedCfaDepth(project);
-					TimeCollector resultsTimeCollector = new TimeCollector();
-
-					resultsTimeCollector.start();
-					processor = createHybridizeFunctionRefactoring(new IProject[] { project }, this.getAlwaysCheckPythonSideEffects(),
-							this.getProcessFunctionsInParallel(), this.getAlwaysCheckRecusion(), this.getUseTestEntrypoints(),
-							this.getAlwaysFollowTypeHints(), this.getUseSpeculativeAnalysis(), this.getInferInputSignatures());
-					processor.setTargetedCfaDepth(targetedCfaDepth);
-					resultsTimeCollector.stop();
-
-					// run the precondition checking.
-					RefactoringStatus status = null;
-					ProcessorBasedRefactoring refactoring = new ProcessorBasedRefactoring(processor);
-
-					if (shouldPerformAnalysis()) {
-						resultsTimeCollector.start();
-						status = refactoring.checkAllConditions(new NullProgressMonitor());
-						resultsTimeCollector.stop();
-
-						LOG.info("Preconditions " + (status.isOK() ? "passed" : "failed") + ".");
-					} else
-						status = new RefactoringStatus();
-
-					// functions.
-					Set<Function> functions = processor.getFunctions();
-					resultsPrinter.print(functions.size());
-
-					for (Function func : functions) {
-						printFunction(functionsPrinter, func);
-						printBlockedParameters(blockedParametersPrinter, func);
-					}
-
-					// optimization available functions. These are the "filtered" functions. We consider functions to be candidates iff they
-					// have a tensor-like parameter or are currently hybrid.
-					Set<Function> candidates = functions.stream().filter(Function::isHybridizationAvailable).filter(
-							f -> f.isHybrid() != null && f.isHybrid() || f.getHasTensorParameter() != null && f.getHasTensorParameter())
-							.collect(Collectors.toSet());
-					resultsPrinter.print(candidates.size()); // number.
-
-					// candidate functions.
-					for (Function function : candidates) {
-						candidatesPrinter.printRecord(buildAttributeColumnValues(function));
-
-						// transformations.
-						for (Transformation transformation : function.getTransformations())
-							transformationsPrinter.printRecord(buildAttributeColumnValues(function, transformation));
-					}
-
-					// optimizable candidate functions.
-					Set<Function> optimizableFunctions = Sets.intersection(candidates, processor.getOptimizableFunctions());
-					resultsPrinter.print(optimizableFunctions.size()); // number.
-
-					for (Function function : optimizableFunctions)
-						optimizableFunctionPrinter.printRecord(buildAttributeColumnValues(function));
-
-					// failed functions.
-					SetView<Function> failures = Sets.difference(candidates, optimizableFunctions);
-
-					for (Function function : failures)
-						nonOptimizableFunctionPrinter.printRecord(buildAttributeColumnValues(function));
-
-					// failed preconditions.
-					Collection<RefactoringStatusEntry> errorEntries = getRefactoringStatusEntries(failures,
-							RefactoringStatusEntry::isError);
-
-					resultsPrinter.print(errorEntries.size()); // number.
-
-					printStatuses(errorPrinter, errorEntries);
-
-					// general refactoring statuses.
-					Set<RefactoringStatusEntry> generalEntries = getRefactoringStatusEntries(functions, x -> true);
-					printStatuses(statusPrinter, generalEntries);
-
-					// decorators.
-					printDecorators(decoratorPrinter, functions, monitor.slice(IProgressMonitor.UNKNOWN));
-
-					// refactoring type counts.
-					for (Refactoring refactoringKind : Refactoring.values())
-						resultsPrinter.print(candidates.parallelStream().map(Function::getRefactoring)
-								.filter(r -> Objects.equals(r, refactoringKind)).count());
-
-					// precondition success counts.
-					for (PreconditionSuccess preconditionSuccess : PreconditionSuccess.values())
-						resultsPrinter.print(candidates.parallelStream().map(Function::getPassingPrecondition)
-								.filter(pp -> Objects.equals(pp, preconditionSuccess)).count());
-
-					// transformation counts.
-					for (Transformation transformation : Transformation.values())
-						resultsPrinter.print(candidates.parallelStream().map(Function::getTransformations).filter(Objects::nonNull)
-								.flatMap(as -> as.parallelStream()).filter(a -> Objects.equals(a, transformation)).count());
-
-					// side-effects.
-					resultsPrinter.print(this.getAlwaysCheckPythonSideEffects());
-
-					// recursion.
-					resultsPrinter.print(this.getAlwaysCheckRecusion());
-
-					// type hints.
-					resultsPrinter.print(this.getAlwaysFollowTypeHints());
-
-					// parallel.
-					resultsPrinter.print(this.getProcessFunctionsInParallel());
-
-					// speculative.
-					resultsPrinter.print(this.getUseSpeculativeAnalysis());
-
-					// test entrypoints.
-					resultsPrinter.print(this.getUseTestEntrypoints());
-
-					// infer input signatures.
-					resultsPrinter.print(this.getInferInputSignatures());
-
-					// targeted CFA depth.
-					resultsPrinter.print(targetedCfaDepth);
-
-					// actually perform the refactoring if there are no fatal
-					// errors.
-					if (shouldPerformChange() && !status.hasFatalError()) {
-						resultsTimeCollector.start();
-						Change change = refactoring.createChange(monitor.slice(IProgressMonitor.UNKNOWN));
-						change.perform(monitor.slice(IProgressMonitor.UNKNOWN));
-						resultsTimeCollector.stop();
-					}
-
-					// overall results time.
-					resultsPrinter.print(
-							(resultsTimeCollector.getCollectedTime() - processor.getExcludedTimeCollector().getCollectedTime()) / 1000.0);
-
-					// end the record.
-					resultsPrinter.println();
-
-					// clear the cache.
-					processor.clearCaches();
-
-					monitor.worked(1);
-				}
-			} catch (Exception e) {
-				return Status.error("Encountered error with evaluation.", e);
-			} finally {
-				// clear cache.
-				if (processor != null)
-					processor.clearCaches();
-
-				SubMonitor.done(monitor);
+			try {
+				return evaluate(getSelectedPythonProjectsFromEvent(event), monitor);
+			} catch (CoreException | ExecutionException e) {
+				return Status.error("Could not determine the projects to evaluate.", e);
 			}
-
-			return Status.info("Evaluation was successful.");
 		}).schedule();
 
 		return null;
+	}
+
+	/**
+	 * Runs the evaluation over the given projects, writing the result CSVs. This is the UI-independent core of {@link #execute}: the
+	 * handler supplies the workbench selection, but a headless entry point can supply an args-derived project set. Configuration is read
+	 * from the {@code edu.cuny.hunter.hybridize.eval.*} system properties, so it needs no UI.
+	 *
+	 * @param pythonProjects The Python projects to evaluate.
+	 * @param monitor The progress monitor.
+	 * @return An {@link IStatus} describing the outcome.
+	 */
+	IStatus evaluate(IProject[] pythonProjects, IProgressMonitor monitor) {
+		List<String> resultsHeader = new ArrayList<>(
+				Arrays.asList("subject", "functions", "optimization available functions", "optimizable functions", "failed preconditions"));
+
+		for (Refactoring refactoring : Refactoring.values())
+			resultsHeader.add(refactoring.toString());
+
+		for (PreconditionSuccess preconditionSuccess : PreconditionSuccess.values())
+			resultsHeader.add(preconditionSuccess.toString());
+
+		for (Transformation transformation : Transformation.values())
+			resultsHeader.add(transformation.toString());
+
+		String[] experimentalSettingsHeader = new String[] { "side-effects", "recursion", "type hints", "parallel", "speculative",
+				"test entrypoints", "infer input signatures", "targeted CFA depth" };
+		resultsHeader.addAll(Arrays.asList(experimentalSettingsHeader));
+
+		resultsHeader.add("time (s)");
+
+		HybridizeFunctionRefactoringProcessor processor = null;
+
+		try (CSVPrinter resultsPrinter = createCSVPrinter(RESULTS_CSV_FILENAME, resultsHeader.toArray(String[]::new));
+				CSVPrinter functionsPrinter = createCSVPrinter(FUNCTIONS_CSV_FILENAME, buildFunctionAttributeColumnNames());
+				CSVPrinter candidatesPrinter = createCSVPrinter(CANDIDATES_CSV_FILENAME, buildAttributeColumnNames());
+				CSVPrinter transformationsPrinter = createCSVPrinter(TRANSFORMATIONS_CSV_FILENAME,
+						buildAttributeColumnNames("transformation"));
+				CSVPrinter optimizableFunctionPrinter = createCSVPrinter(OPTMIZABLE_CSV_FILENAME, buildAttributeColumnNames());
+				CSVPrinter nonOptimizableFunctionPrinter = createCSVPrinter(NONOPTMIZABLE_CSV_FILENAME, buildAttributeColumnNames());
+				CSVPrinter errorPrinter = createCSVPrinter(FAILED_PRECONDITIONS_CSV_FILENAME,
+						buildAttributeColumnNames("refactoring", "severity", "code", "message"));
+				CSVPrinter statusPrinter = createCSVPrinter(STATUS_CSV_FILENAME,
+						buildAttributeColumnNames("refactoring", "severity", "code", "message"));
+				CSVPrinter decoratorPrinter = createCSVPrinter(DECORATOR_CSV_FILENAME, buildAttributeColumnNames("decorator"));
+				CSVPrinter callPrinter = createCSVPrinter(CALL_CSV_FILENAME, CALLS_HEADER);
+				CSVPrinter blockedParametersPrinter = createCSVPrinter(BLOCKED_PARAMETERS_CSV_FILENAME,
+						buildAttributeColumnNames("param index", "param name", "absence reason"));) {
+			if (BUILD_WORKSPACE) {
+				// build the workspace.
+				monitor.beginTask("Building workspace ...", IProgressMonitor.UNKNOWN);
+				ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor.slice(IProgressMonitor.UNKNOWN));
+			}
+
+			monitor.beginTask("Analyzing projects...", pythonProjects.length);
+
+			for (IProject project : pythonProjects) {
+				if (!(project.isOpen() && project.exists() && project.hasNature(PYTHON_NATURE_ID)
+						&& project.isNatureEnabled(PYTHON_NATURE_ID)))
+					throw new IllegalStateException("Python project: " + project.getName() + " must be open and must exist.");
+
+				// subject.
+				resultsPrinter.print(project.getName());
+
+				// calls.
+				if (Boolean.getBoolean(OUTPUT_CALLS_KEY))
+					printCalls(callPrinter, project, monitor.slice(IProgressMonitor.UNKNOWN));
+
+				// set up analysis for single project.
+				int targetedCfaDepth = getTargetedCfaDepth(project);
+				TimeCollector resultsTimeCollector = new TimeCollector();
+
+				resultsTimeCollector.start();
+				processor = createHybridizeFunctionRefactoring(new IProject[] { project }, this.getAlwaysCheckPythonSideEffects(),
+						this.getProcessFunctionsInParallel(), this.getAlwaysCheckRecusion(), this.getUseTestEntrypoints(),
+						this.getAlwaysFollowTypeHints(), this.getUseSpeculativeAnalysis(), this.getInferInputSignatures());
+				processor.setTargetedCfaDepth(targetedCfaDepth);
+				resultsTimeCollector.stop();
+
+				// run the precondition checking.
+				RefactoringStatus status = null;
+				ProcessorBasedRefactoring refactoring = new ProcessorBasedRefactoring(processor);
+
+				if (shouldPerformAnalysis()) {
+					resultsTimeCollector.start();
+					status = refactoring.checkAllConditions(new NullProgressMonitor());
+					resultsTimeCollector.stop();
+
+					LOG.info("Preconditions " + (status.isOK() ? "passed" : "failed") + ".");
+				} else
+					status = new RefactoringStatus();
+
+				// functions.
+				Set<Function> functions = processor.getFunctions();
+				resultsPrinter.print(functions.size());
+
+				for (Function func : functions) {
+					printFunction(functionsPrinter, func);
+					printBlockedParameters(blockedParametersPrinter, func);
+				}
+
+				// optimization available functions. These are the "filtered" functions. We consider functions to be candidates iff they
+				// have a tensor-like parameter or are currently hybrid.
+				Set<Function> candidates = functions.stream().filter(Function::isHybridizationAvailable)
+						.filter(f -> f.isHybrid() != null && f.isHybrid() || f.getHasTensorParameter() != null && f.getHasTensorParameter())
+						.collect(Collectors.toSet());
+				resultsPrinter.print(candidates.size()); // number.
+
+				// candidate functions.
+				for (Function function : candidates) {
+					candidatesPrinter.printRecord(buildAttributeColumnValues(function));
+
+					// transformations.
+					for (Transformation transformation : function.getTransformations())
+						transformationsPrinter.printRecord(buildAttributeColumnValues(function, transformation));
+				}
+
+				// optimizable candidate functions.
+				Set<Function> optimizableFunctions = Sets.intersection(candidates, processor.getOptimizableFunctions());
+				resultsPrinter.print(optimizableFunctions.size()); // number.
+
+				for (Function function : optimizableFunctions)
+					optimizableFunctionPrinter.printRecord(buildAttributeColumnValues(function));
+
+				// failed functions.
+				SetView<Function> failures = Sets.difference(candidates, optimizableFunctions);
+
+				for (Function function : failures)
+					nonOptimizableFunctionPrinter.printRecord(buildAttributeColumnValues(function));
+
+				// failed preconditions.
+				Collection<RefactoringStatusEntry> errorEntries = getRefactoringStatusEntries(failures, RefactoringStatusEntry::isError);
+
+				resultsPrinter.print(errorEntries.size()); // number.
+
+				printStatuses(errorPrinter, errorEntries);
+
+				// general refactoring statuses.
+				Set<RefactoringStatusEntry> generalEntries = getRefactoringStatusEntries(functions, x -> true);
+				printStatuses(statusPrinter, generalEntries);
+
+				// decorators.
+				printDecorators(decoratorPrinter, functions, monitor.slice(IProgressMonitor.UNKNOWN));
+
+				// refactoring type counts.
+				for (Refactoring refactoringKind : Refactoring.values())
+					resultsPrinter.print(candidates.parallelStream().map(Function::getRefactoring)
+							.filter(r -> Objects.equals(r, refactoringKind)).count());
+
+				// precondition success counts.
+				for (PreconditionSuccess preconditionSuccess : PreconditionSuccess.values())
+					resultsPrinter.print(candidates.parallelStream().map(Function::getPassingPrecondition)
+							.filter(pp -> Objects.equals(pp, preconditionSuccess)).count());
+
+				// transformation counts.
+				for (Transformation transformation : Transformation.values())
+					resultsPrinter.print(candidates.parallelStream().map(Function::getTransformations).filter(Objects::nonNull)
+							.flatMap(as -> as.parallelStream()).filter(a -> Objects.equals(a, transformation)).count());
+
+				// side-effects.
+				resultsPrinter.print(this.getAlwaysCheckPythonSideEffects());
+
+				// recursion.
+				resultsPrinter.print(this.getAlwaysCheckRecusion());
+
+				// type hints.
+				resultsPrinter.print(this.getAlwaysFollowTypeHints());
+
+				// parallel.
+				resultsPrinter.print(this.getProcessFunctionsInParallel());
+
+				// speculative.
+				resultsPrinter.print(this.getUseSpeculativeAnalysis());
+
+				// test entrypoints.
+				resultsPrinter.print(this.getUseTestEntrypoints());
+
+				// infer input signatures.
+				resultsPrinter.print(this.getInferInputSignatures());
+
+				// targeted CFA depth.
+				resultsPrinter.print(targetedCfaDepth);
+
+				// actually perform the refactoring if there are no fatal
+				// errors.
+				if (shouldPerformChange() && !status.hasFatalError()) {
+					resultsTimeCollector.start();
+					Change change = refactoring.createChange(monitor.slice(IProgressMonitor.UNKNOWN));
+					change.perform(monitor.slice(IProgressMonitor.UNKNOWN));
+					resultsTimeCollector.stop();
+				}
+
+				// overall results time.
+				resultsPrinter.print(
+						(resultsTimeCollector.getCollectedTime() - processor.getExcludedTimeCollector().getCollectedTime()) / 1000.0);
+
+				// end the record.
+				resultsPrinter.println();
+
+				// clear the cache.
+				processor.clearCaches();
+
+				monitor.worked(1);
+			}
+		} catch (Exception e) {
+			return Status.error("Encountered error with evaluation.", e);
+		} finally {
+			// clear cache.
+			if (processor != null)
+				processor.clearCaches();
+
+			SubMonitor.done(monitor);
+		}
+
+		return Status.info("Evaluation was successful.");
 	}
 
 	private static boolean shouldPerformChange() {

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -208,7 +208,7 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 	 * @param monitor The progress monitor.
 	 * @return An {@link IStatus} describing the outcome.
 	 */
-	IStatus evaluate(IProject[] pythonProjects, IProgressMonitor monitor) {
+	public IStatus evaluate(IProject[] pythonProjects, IProgressMonitor monitor) {
 		List<String> resultsHeader = new ArrayList<>(
 				Arrays.asList("subject", "functions", "optimization available functions", "optimizable functions", "failed preconditions"));
 

--- a/hybridize.target
+++ b/hybridize.target
@@ -17,7 +17,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<repository location="https://ponder-lab.github.io/Common-Eclipse-Refactoring-Framework/releases/"/>
-			<unit id="edu.cuny.citytech.refactoring.common.feature.feature.group" version="5.5.0"/>
+			<unit id="edu.cuny.citytech.refactoring.common.feature.feature.group" version="5.6.1"/>
 		</location>
 		<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 			<dependencies>

--- a/hybridize.target
+++ b/hybridize.target
@@ -8,6 +8,7 @@
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.rcp.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.test.feature.group" version="0.0.0"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <module>edu.cuny.hunter.hybridize.tests.report</module>
     <module>edu.cuny.hunter.hybridize.feature</module>
     <module>edu.cuny.hunter.hybridize.eval.feature</module>
+    <module>edu.cuny.hunter.hybridize.eval.product</module>
     <module>edu.cuny.hunter.hybridize.updatesite</module>
   </modules>
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <module>edu.cuny.hunter.hybridize.tests</module>
     <module>edu.cuny.hunter.hybridize.tests.report</module>
     <module>edu.cuny.hunter.hybridize.feature</module>
+    <module>edu.cuny.hunter.hybridize.eval.feature</module>
     <module>edu.cuny.hunter.hybridize.updatesite</module>
   </modules>
   <scm>


### PR DESCRIPTION
Self-contained product for running the evaluator headlessly. Closes #660.

Stacked on #659 (the `IApplication` this packages). Until #659 merges, the diff also includes its commits; the product-specific changes are `edu.cuny.hunter.hybridize.eval.feature/`, `edu.cuny.hunter.hybridize.eval.product/`, and the `hybridize.target` bumps. Rebases onto `main` once #659 merges.

Two parts:

1. **Internal eval feature** (`edu.cuny.hunter.hybridize.eval.feature`). Includes the end-user feature, reusing its plugins, and adds the `eval` bundle plus `org.eclipse.equinox.app`. The shipped end-user feature is untouched, keeping the evaluator internal.
2. **Product** (`edu.cuny.hunter.hybridize.eval.product`). An `eclipse-repository` that materializes a self-contained, runnable Eclipse (`linux/gtk/x86_64`) bound to the `edu.cuny.hunter.hybridize.eval.evaluate` application. Also adds the native-launcher feature to the target platform and bumps Common to 5.6.1.

Validated end to end: a real headless run materializes, starts, analyzes, and writes every result CSV, with no pre-existing Eclipse.
