### PR TITLE
Resolve function definitions without the UI navigator

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/utils/Util.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/utils/Util.java
@@ -11,10 +11,12 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectNature;
@@ -29,14 +31,18 @@ import org.eclipse.ltk.core.refactoring.participants.ProcessorBasedRefactoring;
 import org.python.pydev.ast.refactoring.TooManyMatchesException;
 import org.python.pydev.core.IPythonNature;
 import org.python.pydev.navigator.PythonModelProvider;
+import org.python.pydev.navigator.elements.IWrappedResource;
 import org.python.pydev.navigator.elements.PythonFile;
 import org.python.pydev.navigator.elements.PythonNode;
 import org.python.pydev.navigator.elements.PythonSourceFolder;
 import org.python.pydev.outline.ParsedItem;
+import org.python.pydev.parser.PyParser;
+import org.python.pydev.parser.PyParser.ParserInfo;
 import org.python.pydev.parser.jython.SimpleNode;
 import org.python.pydev.parser.jython.ast.FunctionDef;
 import org.python.pydev.parser.visitors.scope.ASTEntryWithChildren;
 import org.python.pydev.plugin.nature.PythonNature;
+import org.python.pydev.shared_core.parsing.BaseParser.ParseOutput;
 
 import edu.cuny.hunter.hybridize.core.analysis.FunctionDefinition;
 import edu.cuny.hunter.hybridize.core.analysis.FunctionExtractor;
@@ -74,13 +80,146 @@ public class Util {
 		Set<FunctionDefinition> ret = new HashSet<>();
 
 		for (Object obj : iterable) {
-			Set<PythonNode> nodeSet = getPythonNodes(obj);
+			IResource resource = toResource(obj);
 
-			for (PythonNode node : nodeSet)
-				ret.addAll(process(node));
+			if (resource != null)
+				ret.addAll(getFunctionDefinitions(resource));
 		}
 
 		return ret;
+	}
+
+	/**
+	 * Returns the {@link FunctionDefinition}s under the given resource, resolved without the UI navigator. A file yields itself if it is
+	 * Python; a folder yields its Python files; a project yields the Python files under its (project-local) source folders. Each file is
+	 * parsed directly, so this works headlessly (e.g., the evaluator) as well as in the IDE.
+	 *
+	 * @param resource The resource (project, folder, or file) to search.
+	 * @return The {@link FunctionDefinition}s found under the resource.
+	 */
+	public static Set<FunctionDefinition> getFunctionDefinitions(IResource resource) throws ExecutionException, CoreException, IOException {
+		Set<FunctionDefinition> ret = new HashSet<>();
+
+		for (IFile file : getPythonSourceFiles(resource))
+			ret.addAll(extractFunctionDefinitions(file));
+
+		return ret;
+	}
+
+	/**
+	 * Unwraps the given selection element to its underlying {@link IResource}. Accepts raw resources, PyDev navigator elements (which wrap
+	 * a resource), and a {@link PythonNode} (whose containing file is used).
+	 *
+	 * @param obj The selection element.
+	 * @return The underlying resource, or {@code null} if the element does not correspond to one.
+	 */
+	private static IResource toResource(Object obj) {
+		if (obj instanceof IResource resource)
+			return resource;
+
+		Object element = obj instanceof PythonNode pythonNode ? pythonNode.getPythonFile() : obj;
+
+		if (element instanceof IWrappedResource wrapped && wrapped.getActualObject() instanceof IResource resource)
+			return resource;
+
+		return null;
+	}
+
+	/**
+	 * Returns the Python source files reachable from the given resource. For a project, only the (project-local) source folders are walked,
+	 * mirroring the navigator, which resolves source folders from the same nature source-path set.
+	 *
+	 * @param resource The resource (project, folder, or file) to search.
+	 * @return The Python source files.
+	 */
+	private static Set<IFile> getPythonSourceFiles(IResource resource) throws CoreException {
+		Set<IFile> ret = new LinkedHashSet<>();
+
+		if (resource instanceof IFile file) {
+			if (isPythonFile(file))
+				ret.add(file);
+		} else if (resource instanceof IProject project && project.isOpen()) {
+			PythonNature nature = PythonNature.getPythonNature(project);
+
+			if (nature != null)
+				for (IResource sourceFolder : nature.getPythonPathNature().getProjectSourcePathFolderSet())
+					collectPythonFiles(sourceFolder, ret);
+		} else if (resource instanceof IContainer container)
+			collectPythonFiles(container, ret);
+
+		return ret;
+	}
+
+	private static void collectPythonFiles(IResource resource, Set<IFile> out) throws CoreException {
+		if (resource instanceof IFile file) {
+			if (isPythonFile(file))
+				out.add(file);
+		} else if (resource instanceof IContainer container && container.isAccessible())
+			for (IResource member : container.members())
+				collectPythonFiles(member, out);
+	}
+
+	private static boolean isPythonFile(IFile file) {
+		return "py".equalsIgnoreCase(file.getFileExtension());
+	}
+
+	/**
+	 * Parses the given Python file directly (no navigator) and returns its {@link FunctionDefinition}s.
+	 *
+	 * @param pythonFile The Python file to parse.
+	 * @return The {@link FunctionDefinition}s in the file.
+	 */
+	private static Set<FunctionDefinition> extractFunctionDefinitions(IFile pythonFile)
+			throws ExecutionException, CoreException, IOException {
+		Set<FunctionDefinition> ret = new HashSet<>();
+
+		IDocument document = getDocument(pythonFile);
+		File file = getFile(pythonFile);
+		String moduleName = getModuleName(pythonFile);
+		PythonNature nature = getPythonNature(pythonFile);
+
+		FunctionExtractor functionExtractor = new FunctionExtractor();
+
+		try {
+			ParserInfo parserInfo = new ParserInfo(document, nature, moduleName, file);
+			ParseOutput parseOutput = PyParser.reparseDocument(parserInfo);
+
+			if (!(parseOutput.ast instanceof SimpleNode node))
+				return ret;
+
+			node.accept(functionExtractor);
+		} catch (Exception e) {
+			LOG.error("Failed to extract functions from: " + pythonFile + ".", e);
+			throw new ExecutionException("Failed to extract functions from: " + pythonFile + ".", e);
+		}
+
+		for (FunctionDef def : functionExtractor.getDefinitions())
+			ret.add(new FunctionDefinition(def, moduleName, file, pythonFile, document, nature));
+
+		return ret;
+	}
+
+	public static String getModuleName(IFile file) {
+		String fileName = file.getName();
+		int separatorPos = fileName.indexOf('.');
+		return separatorPos < 0 ? fileName : fileName.substring(0, separatorPos);
+	}
+
+	public static PythonNature getPythonNature(IFile file) {
+		return PythonNature.getPythonNature(file.getProject());
+	}
+
+	public static IDocument getDocument(IFile file) throws CoreException, IOException {
+		try (InputStream contentStream = file.getContents()) {
+			byte[] bytes = contentStream.readAllBytes();
+			String content = new String(bytes, UTF_8);
+			return new Document(content);
+		}
+	}
+
+	public static File getFile(IFile file) {
+		URI uri = file.getRawLocationURI();
+		return new File(uri);
 	}
 
 	public static Set<PythonNode> getPythonNodes(Object obj) {


### PR DESCRIPTION
The headless evaluator found 0 functions for every subject because function discovery walked the PyDev navigator (`PythonModelProvider`), whose model is populated by the package explorer and is empty without the workbench.

## Approach
A navigator-independent resolver enumerates a project's project-local source files from the nature (`getProjectSourcePathFolderSet`) and parses each directly (`PyParser.reparseDocument`, `FunctionExtractor`), the same per-file path the test suite already uses. `getFunctionDefinitions` now accepts any resource (project, folder, or file) or a navigator selection wrapping one. The IDE handler shares the entry point, so the package-explorer refactoring is unaffected and becomes headless-capable; a future headless-UI plug-in can operate on arbitrary entities. The navigator-based helpers remain for the evaluator's calls feature.

## Validation
Built the headless product and ran it over the 20-project workspace: every completed subject now finds functions (GPflow 2170, TensorflowASR 847, NLPGNN 510, ResNet50 347, TensorFlow2.0-Examples 149, ...), previously all 0.

Closes #662.
