### PR TITLE
Suppress launcher dialogs and default `performChange` off for the headless evaluator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ These update sites are also listed in the [target definition file]. Thus, you sh
 
 Use the `edu.cuny.hunter.hybridize.evaluator` plug-in project to run the evaluation. The evaluation process will produce several CSVs, as well as perform the transformation if desired (see below for details). For convenience, there is an [Eclipse launch configuration](https://wiki.eclipse.org/FAQ_What_is_a_launch_configuration%3F) that can be used to run the evaluation. The run configuration is named [`edu.cuny.hunter.hybridize.eval/Evaluate Hybridize Functions.launch`](https://github.com/ponder-lab/Hybridize-Functions-Refactoring/blob/691cbeb87be805b8bfc336e799d938a9064a5e0e/edu.cuny.hunter.hybridize.eval/Evaluate%20Hybridize%20Functions.launch). In the run configuration dialog, you can specify several arguments to the evaluator as system properties.
 
-You can run the evaluator in several different ways, including as a command or as a menu item, which is shown in the menu bar. Either way, you must evaluate *entire* projects, as the evaluator will collect project-level data. Information on configuring the evaluator can be found on [this wiki page][evaluator wiki].
+You can run the evaluator in several different ways: as a command or menu item in the IDE, or *headlessly* from the command line (without the IDE), which is convenient for batch or reproducible runs. Either way, you must evaluate *entire* projects, as the evaluator collects project-level data. See [the wiki][evaluator wiki] for the headless launcher, the wrapper script, and configuration.
 
 #### Configuring the Evaluation
 

--- a/edu.cuny.hunter.hybridize.eval.product/edu.cuny.hunter.hybridize.eval.product
+++ b/edu.cuny.hunter.hybridize.eval.product/edu.cuny.hunter.hybridize.eval.product
@@ -7,6 +7,7 @@
    </configIni>
 
    <launcherArgs>
+      <programArgs>--launcher.suppressErrors</programArgs>
       <vmArgs>-Xms1024m -Xmx30480m</vmArgs>
    </launcherArgs>
 

--- a/edu.cuny.hunter.hybridize.eval.product/edu.cuny.hunter.hybridize.eval.product
+++ b/edu.cuny.hunter.hybridize.eval.product/edu.cuny.hunter.hybridize.eval.product
@@ -8,7 +8,7 @@
 
    <launcherArgs>
       <programArgs>--launcher.suppressErrors</programArgs>
-      <vmArgs>-Xms1024m -Xmx30480m</vmArgs>
+      <vmArgs>-XX:+UseG1GC -XX:+UseStringDeduplication -Xms1024m -Xmx30480m</vmArgs>
    </launcherArgs>
 
    <launcher name="hybridize-evaluator">

--- a/edu.cuny.hunter.hybridize.eval.product/edu.cuny.hunter.hybridize.eval.product
+++ b/edu.cuny.hunter.hybridize.eval.product/edu.cuny.hunter.hybridize.eval.product
@@ -8,7 +8,7 @@
 
    <launcherArgs>
       <programArgs>--launcher.suppressErrors</programArgs>
-      <vmArgs>-XX:+UseG1GC -XX:+UseStringDeduplication -Xms1024m -Xmx30480m</vmArgs>
+      <vmArgs>--add-modules=ALL-SYSTEM -XX:+UseG1GC -XX:+UseStringDeduplication -Xms1024m -Xmx30480m</vmArgs>
    </launcherArgs>
 
    <launcher name="hybridize-evaluator">

--- a/edu.cuny.hunter.hybridize.eval/run-headless-evaluator.sh
+++ b/edu.cuny.hunter.hybridize.eval/run-headless-evaluator.sh
@@ -7,19 +7,22 @@
 # the workspace's working directory (the same outputs as the in-IDE evaluator).
 #
 # Prerequisites:
-#   - An Eclipse installation that contains the Hybridize eval bundle and its
-#     runtime (the ponder-lab PyDev fork, WALA, Ariadne) -- e.g. the development
-#     Eclipse, or a product built to include `edu.cuny.hunter.hybridize.eval`.
-#     Packaging a self-contained product so no pre-existing Eclipse is required
-#     is tracked separately.
+#   - The headless evaluator: either the self-contained product
+#     (`edu.cuny.hunter.hybridize.eval.product`; set ECLIPSE to its materialized
+#     `hybridize-evaluator` launcher), or an Eclipse install containing the eval
+#     bundle and its runtime (the ponder-lab PyDev fork, WALA, Ariadne).
 #   - A workspace already populated with the subjects as PyDev projects.
 #
 # Usage:
-#   ECLIPSE=/path/to/eclipse WORKSPACE=/path/to/workspace ./run-headless-evaluator.sh
+#   ECLIPSE=/path/to/hybridize-evaluator WORKSPACE=/path/to/workspace ./run-headless-evaluator.sh
 #
-# Configuration knobs mirror the IDE launch and can be overridden via the
-# environment (defaults shown below). Parallelization defaults to off because it
-# is nondeterministic (issue 315).
+# The knobs below are this script's defaults for a typical run; the tool itself
+# defaults every flag off (it reads them as system properties), so the script
+# sets the ones a normal run wants. Override via the environment. PERFORM_CHANGE
+# defaults off -- the evaluation applies the transformation only in special cases
+# (e.g. the performance evaluation); analysis-only runs leave the subjects
+# untouched. Parallelization defaults to off because it is nondeterministic
+# (issue 315).
 #
 set -eu
 
@@ -27,7 +30,7 @@ ECLIPSE="${ECLIPSE:?Set ECLIPSE to the Eclipse launcher of an install containing
 WORKSPACE="${WORKSPACE:?Set WORKSPACE to the workspace holding the subjects as PyDev projects.}"
 
 : "${PERFORM_ANALYSIS:=true}"
-: "${PERFORM_CHANGE:=true}"
+: "${PERFORM_CHANGE:=false}"
 : "${INFER_INPUT_SIGNATURES:=false}"
 : "${PROCESS_IN_PARALLEL:=false}"
 : "${FOLLOW_TYPE_HINTS:=true}"
@@ -39,7 +42,7 @@ WORKSPACE="${WORKSPACE:?Set WORKSPACE to the workspace holding the subjects as P
 exec "$ECLIPSE" \
 	-application edu.cuny.hunter.hybridize.eval.evaluate \
 	-data "$WORKSPACE" \
-	-consoleLog -nosplash \
+	-consoleLog -nosplash --launcher.suppressErrors \
 	-vmargs \
 	-Xms1024m "-Xmx${MAX_HEAP}" \
 	-Dedu.cuny.hunter.hybridize.eval.performAnalysis="$PERFORM_ANALYSIS" \

--- a/edu.cuny.hunter.hybridize.eval/run-headless-evaluator.sh
+++ b/edu.cuny.hunter.hybridize.eval/run-headless-evaluator.sh
@@ -14,44 +14,39 @@
 #   - A workspace already populated with the subjects as PyDev projects.
 #
 # Usage:
-#   ECLIPSE=/path/to/hybridize-evaluator WORKSPACE=/path/to/workspace ./run-headless-evaluator.sh
+#   ECLIPSE=/path/to/hybridize-evaluator WORKSPACE=/path/to/workspace \
+#     PERFORM_ANALYSIS=true ./run-headless-evaluator.sh
 #
-# The knobs below are this script's defaults for a typical run; the tool itself
-# defaults every flag off (it reads them as system properties), so the script
-# sets the ones a normal run wants. Override via the environment. PERFORM_CHANGE
-# defaults off -- the evaluation applies the transformation only in special cases
-# (e.g. the performance evaluation); analysis-only runs leave the subjects
-# untouched. Parallelization defaults to off because it is nondeterministic
-# (issue 315).
+# The evaluator reads its configuration as JVM system properties, every one
+# defaulting to off. This script does not restate those defaults; it forwards
+# only the flags you set in the environment and lets the tool default the rest,
+# so a useful run sets at least PERFORM_ANALYSIS=true. Recognized knobs:
+# PERFORM_ANALYSIS, PERFORM_CHANGE, INFER_INPUT_SIGNATURES, PROCESS_IN_PARALLEL,
+# FOLLOW_TYPE_HINTS, SPECULATIVE, TEST_ENTRYPOINTS, OUTPUT_CALLS. PERFORM_CHANGE
+# applies the transformation; leave it off except in special cases (e.g. the
+# performance evaluation). PROCESS_IN_PARALLEL is nondeterministic (issue 315).
+#
+# JVM arguments (heap, GC, modules) come from the product launcher's own
+# configuration; this script appends to them with --launcher.appendVmargs rather
+# than restating them. Set MAX_HEAP to override the heap when pointing ECLIPSE at
+# a non-product Eclipse.
 #
 set -eu
 
-ECLIPSE="${ECLIPSE:?Set ECLIPSE to the Eclipse launcher of an install containing the eval bundle.}"
+ECLIPSE="${ECLIPSE:?Set ECLIPSE to the headless evaluator launcher, e.g. the product hybridize-evaluator binary.}"
 WORKSPACE="${WORKSPACE:?Set WORKSPACE to the workspace holding the subjects as PyDev projects.}"
-
-: "${PERFORM_ANALYSIS:=true}"
-: "${PERFORM_CHANGE:=false}"
-: "${INFER_INPUT_SIGNATURES:=false}"
-: "${PROCESS_IN_PARALLEL:=false}"
-: "${FOLLOW_TYPE_HINTS:=true}"
-: "${SPECULATIVE:=true}"
-: "${TEST_ENTRYPOINTS:=true}"
-: "${OUTPUT_CALLS:=false}"
-: "${MAX_HEAP:=30480m}"
 
 exec "$ECLIPSE" \
 	-application edu.cuny.hunter.hybridize.eval.evaluate \
 	-data "$WORKSPACE" \
-	-consoleLog -nosplash --launcher.suppressErrors \
+	-consoleLog -nosplash --launcher.suppressErrors --launcher.appendVmargs \
 	-vmargs \
-	-Xms1024m "-Xmx${MAX_HEAP}" \
-	-Dedu.cuny.hunter.hybridize.eval.performAnalysis="$PERFORM_ANALYSIS" \
-	-Dedu.cuny.hunter.hybridize.eval.performChange="$PERFORM_CHANGE" \
-	-Dedu.cuny.hunter.hybridize.eval.inferInputSignatures="$INFER_INPUT_SIGNATURES" \
-	-Dedu.cuny.hunter.hybridize.eval.processFunctionsInParallel="$PROCESS_IN_PARALLEL" \
-	-Dedu.cuny.hunter.hybridize.eval.alwaysFollowTypeHints="$FOLLOW_TYPE_HINTS" \
-	-Dedu.cuny.hunter.hybridize.eval.useSpeculativeAnalysis="$SPECULATIVE" \
-	-Dedu.cuny.hunter.hybridize.eval.useTestEntrypoints="$TEST_ENTRYPOINTS" \
-	-Dedu.cuny.hunter.hybridize.eval.outputCalls="$OUTPUT_CALLS" \
-	-Dedu.cuny.hunter.hybridize.eval.alwaysCheckPythonSideEffects=false \
-	-Dedu.cuny.hunter.hybridize.eval.alwaysCheckRecursion=false
+	${MAX_HEAP+-Xmx"$MAX_HEAP"} \
+	${PERFORM_ANALYSIS+-Dedu.cuny.hunter.hybridize.eval.performAnalysis="$PERFORM_ANALYSIS"} \
+	${PERFORM_CHANGE+-Dedu.cuny.hunter.hybridize.eval.performChange="$PERFORM_CHANGE"} \
+	${INFER_INPUT_SIGNATURES+-Dedu.cuny.hunter.hybridize.eval.inferInputSignatures="$INFER_INPUT_SIGNATURES"} \
+	${PROCESS_IN_PARALLEL+-Dedu.cuny.hunter.hybridize.eval.processFunctionsInParallel="$PROCESS_IN_PARALLEL"} \
+	${FOLLOW_TYPE_HINTS+-Dedu.cuny.hunter.hybridize.eval.alwaysFollowTypeHints="$FOLLOW_TYPE_HINTS"} \
+	${SPECULATIVE+-Dedu.cuny.hunter.hybridize.eval.useSpeculativeAnalysis="$SPECULATIVE"} \
+	${TEST_ENTRYPOINTS+-Dedu.cuny.hunter.hybridize.eval.useTestEntrypoints="$TEST_ENTRYPOINTS"} \
+	${OUTPUT_CALLS+-Dedu.cuny.hunter.hybridize.eval.outputCalls="$OUTPUT_CALLS"}


### PR DESCRIPTION
The product launcher showed a GUI "JVM terminated. Exit code=N" dialog whenever the application exited non-zero, which is wrong for a headless tool and disruptive on a machine with a display.

## Changes
- Add `--launcher.suppressErrors` to the product launcher (`*.product`) and the run script, so the native launcher no longer shows error dialogs. Diagnostics are unaffected: errors still reach the console (`-consoleLog`), the workspace `.log`, and the non-zero exit code.
- Default `PERFORM_CHANGE` off in the run script, matching the tool's own default. The evaluation applies the transformation only in special cases (e.g. the performance evaluation); analysis-only runs leave subjects untouched.
- Refresh the run-script header for the now-built self-contained product (`hybridize-evaluator`).

A UI-free product (dropping `org.eclipse.rcp`) would remove the dialog possibility entirely; tracked in #667.

Relates to #657 and #664.
