### PR TITLE
Filter the headless evaluator to named projects and refresh the workspace on startup

### DIFF
--- a/edu.cuny.hunter.hybridize.eval/run-headless-evaluator.sh
+++ b/edu.cuny.hunter.hybridize.eval/run-headless-evaluator.sh
@@ -22,9 +22,11 @@
 # only the flags you set in the environment and lets the tool default the rest,
 # so a useful run sets at least PERFORM_ANALYSIS=true. Recognized knobs:
 # PERFORM_ANALYSIS, PERFORM_CHANGE, INFER_INPUT_SIGNATURES, PROCESS_IN_PARALLEL,
-# FOLLOW_TYPE_HINTS, SPECULATIVE, TEST_ENTRYPOINTS, OUTPUT_CALLS. PERFORM_CHANGE
-# applies the transformation; leave it off except in special cases (e.g. the
-# performance evaluation). PROCESS_IN_PARALLEL is nondeterministic (issue 315).
+# FOLLOW_TYPE_HINTS, SPECULATIVE, TEST_ENTRYPOINTS, OUTPUT_CALLS, PROJECTS.
+# PERFORM_CHANGE applies the transformation; leave it off except in special cases
+# (e.g. the performance evaluation). PROCESS_IN_PARALLEL is nondeterministic
+# (issue 315). PROJECTS is a comma-separated list of project names to evaluate a
+# subset; unset evaluates all open Python projects.
 #
 # JVM arguments (heap, GC, modules) come from the product launcher's own
 # configuration; this script appends to them with --launcher.appendVmargs rather
@@ -49,4 +51,5 @@ exec "$ECLIPSE" \
 	${FOLLOW_TYPE_HINTS+-Dedu.cuny.hunter.hybridize.eval.alwaysFollowTypeHints="$FOLLOW_TYPE_HINTS"} \
 	${SPECULATIVE+-Dedu.cuny.hunter.hybridize.eval.useSpeculativeAnalysis="$SPECULATIVE"} \
 	${TEST_ENTRYPOINTS+-Dedu.cuny.hunter.hybridize.eval.useTestEntrypoints="$TEST_ENTRYPOINTS"} \
-	${OUTPUT_CALLS+-Dedu.cuny.hunter.hybridize.eval.outputCalls="$OUTPUT_CALLS"}
+	${OUTPUT_CALLS+-Dedu.cuny.hunter.hybridize.eval.outputCalls="$OUTPUT_CALLS"} \
+	${PROJECTS+-Dedu.cuny.hunter.hybridize.eval.projects="$PROJECTS"}

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/application/EvaluateHybridizeFunctionRefactoringApplication.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/application/EvaluateHybridizeFunctionRefactoringApplication.java
@@ -4,9 +4,12 @@ import static org.eclipse.core.runtime.Platform.getLog;
 import static org.python.pydev.plugin.nature.PythonNature.PYTHON_NATURE_ID;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
@@ -23,7 +26,9 @@ import edu.cuny.hunter.hybridize.eval.handlers.EvaluateHybridizeFunctionRefactor
  * <p>
  * The workspace must be pre-populated with the subjects as PyDev projects (e.g., imported once via the UI); this application enumerates the
  * open Python projects and evaluates them. Configuration comes from the same {@code edu.cuny.hunter.hybridize.eval.*} system properties as
- * the IDE launch. Launch with {@code eclipse -application edu.cuny.hunter.hybridize.eval.evaluate -data <workspace> ...}. See
+ * the IDE launch. By default all open Python projects are evaluated; set {@code edu.cuny.hunter.hybridize.eval.projects} to a
+ * comma-separated list of project names to evaluate only a subset. Launch with
+ * {@code eclipse -application edu.cuny.hunter.hybridize.eval.evaluate -data <workspace> ...}. See
  * <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/657">issue 657</a>; programmatic project import (so a
  * workspace need not be pre-populated) is the follow-up
  * <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/658">issue 658</a>.
@@ -38,8 +43,17 @@ public class EvaluateHybridizeFunctionRefactoringApplication implements IApplica
 	/** Exit code returned when the evaluation completes but its status is not OK. */
 	private static final Integer EXIT_EVALUATION_FAILED = Integer.valueOf(1);
 
+	/**
+	 * System property naming a comma-separated subset of project names to evaluate; when unset or blank, all open Python projects in the
+	 * workspace are evaluated.
+	 */
+	private static final String PROJECTS_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.projects";
+
 	@Override
 	public Object start(IApplicationContext context) throws Exception {
+		// Refresh so the workspace reflects the subjects' current on-disk state (e.g., after a git checkout of the evaluated branch).
+		ResourcesPlugin.getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
+
 		IProject[] projects = getOpenPythonProjects();
 
 		if (projects.length == 0) {
@@ -64,16 +78,28 @@ public class EvaluateHybridizeFunctionRefactoringApplication implements IApplica
 	}
 
 	/**
-	 * Returns the open, Python-natured projects in the workspace.
+	 * Returns the open, Python-natured projects in the workspace, restricted to the names listed in the {@value #PROJECTS_PROPERTY_KEY}
+	 * system property when it is set.
 	 *
-	 * @return The open Python projects.
+	 * @return The open Python projects to evaluate.
 	 * @throws org.eclipse.core.runtime.CoreException If a project's nature cannot be read.
 	 */
 	private static IProject[] getOpenPythonProjects() throws Exception {
+		String filter = System.getProperty(PROJECTS_PROPERTY_KEY);
+		Set<String> wanted = null;
+
+		if (filter != null && !filter.isBlank()) {
+			wanted = new HashSet<>();
+
+			for (String name : filter.split(","))
+				if (!name.isBlank())
+					wanted.add(name.strip());
+		}
+
 		List<IProject> pythonProjects = new ArrayList<>();
 
 		for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects())
-			if (project.isOpen() && project.hasNature(PYTHON_NATURE_ID))
+			if (project.isOpen() && project.hasNature(PYTHON_NATURE_ID) && (wanted == null || wanted.contains(project.getName())))
 				pythonProjects.add(project);
 
 		return pythonProjects.toArray(IProject[]::new);


### PR DESCRIPTION
Adds two headless-evaluator enhancements for running reproducibly over a curated subset of subjects.

- Project-name filter via `edu.cuny.hunter.hybridize.eval.projects` (comma-separated); unset evaluates all open Python projects, as before.
- Startup workspace refresh so the evaluator reflects the subjects' current on-disk state after a branch checkout, rather than a stale cached tree.

Closes #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)