### PR TITLE
Consolidate the evaluator configuration keys into a shared enum

### DIFF
--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/application/EvaluateHybridizeFunctionRefactoringApplication.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/application/EvaluateHybridizeFunctionRefactoringApplication.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
 
+import edu.cuny.hunter.hybridize.eval.config.EvaluationOption;
 import edu.cuny.hunter.hybridize.eval.handlers.EvaluateHybridizeFunctionRefactoringHandler;
 
 /**
@@ -48,24 +49,6 @@ public class EvaluateHybridizeFunctionRefactoringApplication implements IApplica
 
 	/** Exit code returned when a command-line argument is unrecognized. */
 	private static final int EXIT_BAD_ARGUMENTS = 3;
-
-	/** Common prefix of the evaluator's configuration system properties. */
-	private static final String EVAL_PROPERTY_PREFIX = "edu.cuny.hunter.hybridize.eval.";
-
-	/**
-	 * The configuration names settable from the command line, each backing the {@code edu.cuny.hunter.hybridize.eval.}<i>name</i> system
-	 * property of the same name. On the command line they are passed in kebab-case (e.g. {@code --perform-change}). The per-project
-	 * {@code targetedCfaDepth} is intentionally excluded: it is read from {@code eval.properties}, not a system property.
-	 */
-	private static final Set<String> CONFIG_NAMES = Set.of("performAnalysis", "performChange", "inferInputSignatures",
-			"alwaysCheckPythonSideEffects", "alwaysCheckRecursion", "processFunctionsInParallel", "useTestEntrypoints",
-			"alwaysFollowTypeHints", "useSpeculativeAnalysis", "outputCalls", "projects");
-
-	/**
-	 * System property naming a comma-separated subset of project names to evaluate; when unset or blank, all open Python projects in the
-	 * workspace are evaluated.
-	 */
-	private static final String PROJECTS_PROPERTY_KEY = EVAL_PROPERTY_PREFIX + "projects";
 
 	@Override
 	public Object start(IApplicationContext context) throws Exception {
@@ -122,13 +105,13 @@ public class EvaluateHybridizeFunctionRefactoringApplication implements IApplica
 			String value = separator < 0 ? Boolean.TRUE.toString() : body.substring(separator + 1);
 			String name = toCamelCase(flag);
 
-			if (!CONFIG_NAMES.contains(name)) {
+			if (!EvaluationOption.propertyNames().contains(name)) {
 				LOG.error("Unrecognized evaluator option --" + flag + ". Recognized configuration names (pass as --kebab-case): "
-						+ new TreeSet<>(CONFIG_NAMES));
+						+ new TreeSet<>(EvaluationOption.propertyNames()));
 				return false;
 			}
 
-			System.setProperty(EVAL_PROPERTY_PREFIX + name, value);
+			System.setProperty(EvaluationOption.PREFIX + name, value);
 		}
 
 		return true;
@@ -152,14 +135,14 @@ public class EvaluateHybridizeFunctionRefactoringApplication implements IApplica
 	}
 
 	/**
-	 * Returns the open, Python-natured projects in the workspace, restricted to the names listed in the {@value #PROJECTS_PROPERTY_KEY}
-	 * system property when it is set.
+	 * Returns the open, Python-natured projects in the workspace, restricted to the names listed in the {@link EvaluationOption#PROJECTS
+	 * projects} system property when it is set.
 	 *
 	 * @return The open Python projects to evaluate.
 	 * @throws org.eclipse.core.runtime.CoreException If a project's nature cannot be read.
 	 */
 	private static IProject[] getOpenPythonProjects() throws Exception {
-		String filter = System.getProperty(PROJECTS_PROPERTY_KEY);
+		String filter = System.getProperty(EvaluationOption.PROJECTS.key());
 		Set<String> wanted = null;
 
 		if (filter != null && !filter.isBlank()) {

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/config/EvaluationOption.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/config/EvaluationOption.java
@@ -1,0 +1,60 @@
+package edu.cuny.hunter.hybridize.eval.config;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The evaluator's command-line and system-property configuration options, single-sourced so the argument parser
+ * ({@code EvaluateHybridizeFunctionRefactoringApplication}) and the readers ({@code EvaluateHybridizeFunctionRefactoringHandler}) cannot
+ * drift: each option contributes both its camelCase name (the canonical form of its {@code --kebab-case} flag) and its full system-property
+ * key. Adding an option is one entry here.
+ * <p>
+ * The per-project {@code targetedCfaDepth} is deliberately not an option: it is an integer read from {@code eval.properties} (with a global
+ * system-property fallback), not a {@code --kebab-case} boolean flag. Its key still shares {@link #PREFIX}.
+ */
+public enum EvaluationOption {
+
+	PERFORM_ANALYSIS("performAnalysis"), PERFORM_CHANGE("performChange"), ALWAYS_CHECK_PYTHON_SIDE_EFFECTS("alwaysCheckPythonSideEffects"),
+	ALWAYS_CHECK_RECURSION("alwaysCheckRecursion"), PROCESS_FUNCTIONS_IN_PARALLEL("processFunctionsInParallel"),
+	USE_TEST_ENTRYPOINTS("useTestEntrypoints"), ALWAYS_FOLLOW_TYPE_HINTS("alwaysFollowTypeHints"),
+	USE_SPECULATIVE_ANALYSIS("useSpeculativeAnalysis"), INFER_INPUT_SIGNATURES("inferInputSignatures"), OUTPUT_CALLS("outputCalls"),
+	PROJECTS("projects");
+
+	/** Common prefix of the evaluator's configuration system properties. */
+	public static final String PREFIX = "edu.cuny.hunter.hybridize.eval.";
+
+	private final String propertyName;
+
+	EvaluationOption(String propertyName) {
+		this.propertyName = propertyName;
+	}
+
+	/**
+	 * Returns this option's camelCase configuration name, the canonical form of its {@code --kebab-case} flag and the suffix of its
+	 * system-property key.
+	 *
+	 * @return This option's camelCase configuration name.
+	 */
+	public String propertyName() {
+		return this.propertyName;
+	}
+
+	/**
+	 * Returns this option's full system-property key: {@link #PREFIX} followed by {@link #propertyName()}.
+	 *
+	 * @return This option's full system-property key.
+	 */
+	public String key() {
+		return PREFIX + this.propertyName;
+	}
+
+	/**
+	 * Returns the camelCase names of all options, for validating the configuration names given on the command line.
+	 *
+	 * @return The camelCase names of all options.
+	 */
+	public static Set<String> propertyNames() {
+		return Arrays.stream(values()).map(EvaluationOption::propertyName).collect(Collectors.toUnmodifiableSet());
+	}
+}

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/config/EvaluationOption.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/config/EvaluationOption.java
@@ -1,43 +1,41 @@
 package edu.cuny.hunter.hybridize.eval.config;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * The evaluator's command-line and system-property configuration options, single-sourced so the argument parser
  * ({@code EvaluateHybridizeFunctionRefactoringApplication}) and the readers ({@code EvaluateHybridizeFunctionRefactoringHandler}) cannot
- * drift: each option contributes both its camelCase name (the canonical form of its {@code --kebab-case} flag) and its full system-property
- * key. Adding an option is one entry here.
+ * drift: each constant yields both its camelCase name (the canonical form of its {@code --kebab-case} flag) and its full system-property
+ * key, both derived from the constant itself. Adding an option is one entry here.
  * <p>
  * The per-project {@code targetedCfaDepth} is deliberately not an option: it is an integer read from {@code eval.properties} (with a global
  * system-property fallback), not a {@code --kebab-case} boolean flag. Its key still shares {@link #PREFIX}.
  */
 public enum EvaluationOption {
 
-	PERFORM_ANALYSIS("performAnalysis"), PERFORM_CHANGE("performChange"), ALWAYS_CHECK_PYTHON_SIDE_EFFECTS("alwaysCheckPythonSideEffects"),
-	ALWAYS_CHECK_RECURSION("alwaysCheckRecursion"), PROCESS_FUNCTIONS_IN_PARALLEL("processFunctionsInParallel"),
-	USE_TEST_ENTRYPOINTS("useTestEntrypoints"), ALWAYS_FOLLOW_TYPE_HINTS("alwaysFollowTypeHints"),
-	USE_SPECULATIVE_ANALYSIS("useSpeculativeAnalysis"), INFER_INPUT_SIGNATURES("inferInputSignatures"), OUTPUT_CALLS("outputCalls"),
-	PROJECTS("projects");
+	PERFORM_ANALYSIS, PERFORM_CHANGE, ALWAYS_CHECK_PYTHON_SIDE_EFFECTS, ALWAYS_CHECK_RECURSION, PROCESS_FUNCTIONS_IN_PARALLEL,
+	USE_TEST_ENTRYPOINTS, ALWAYS_FOLLOW_TYPE_HINTS, USE_SPECULATIVE_ANALYSIS, INFER_INPUT_SIGNATURES, OUTPUT_CALLS, PROJECTS;
 
 	/** Common prefix of the evaluator's configuration system properties. */
 	public static final String PREFIX = "edu.cuny.hunter.hybridize.eval.";
 
-	private final String propertyName;
-
-	EvaluationOption(String propertyName) {
-		this.propertyName = propertyName;
-	}
-
 	/**
 	 * Returns this option's camelCase configuration name, the canonical form of its {@code --kebab-case} flag and the suffix of its
-	 * system-property key.
+	 * system-property key, derived from the constant name (e.g. {@code PERFORM_ANALYSIS} yields {@code performAnalysis}).
 	 *
 	 * @return This option's camelCase configuration name.
 	 */
 	public String propertyName() {
-		return this.propertyName;
+		String[] words = name().toLowerCase(Locale.ROOT).split("_");
+		StringBuilder camelCase = new StringBuilder(words[0]);
+
+		for (int word = 1; word < words.length; word++)
+			camelCase.append(Character.toUpperCase(words[word].charAt(0))).append(words[word].substring(1));
+
+		return camelCase.toString();
 	}
 
 	/**
@@ -46,7 +44,7 @@ public enum EvaluationOption {
 	 * @return This option's full system-property key.
 	 */
 	public String key() {
-		return PREFIX + this.propertyName;
+		return PREFIX + propertyName();
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -83,6 +83,7 @@ import edu.cuny.hunter.hybridize.core.analysis.Refactoring;
 import edu.cuny.hunter.hybridize.core.analysis.Transformation;
 import edu.cuny.hunter.hybridize.core.refactorings.HybridizeFunctionRefactoringProcessor;
 import edu.cuny.hunter.hybridize.core.utils.Util;
+import edu.cuny.hunter.hybridize.eval.config.EvaluationOption;
 
 public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefactoringHandler {
 
@@ -114,29 +115,13 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 	private static final String BLOCKED_PARAMETERS_CSV_FILENAME = "blocked_parameters.csv";
 
-	private static final String PERFORM_ANALYSIS_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.performAnalysis";
-
-	private static final String PERFORM_CHANGE_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.performChange";
-
-	private static final String ALWAYS_CHECK_PYTHON_SIDE_EFFECTS_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.alwaysCheckPythonSideEffects";
-
-	private static final String ALWAYS_CHECK_RECURSION_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.alwaysCheckRecursion";
-
-	private static final String PROCESS_FUNCTIONS_IN_PARALLEL_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.processFunctionsInParallel";
-
-	private static final String USE_TEST_ENTRYPOINTS_KEY = "edu.cuny.hunter.hybridize.eval.useTestEntrypoints";
-
-	private static final String ALWAYS_FOLLOW_TYPE_HINTS_KEY = "edu.cuny.hunter.hybridize.eval.alwaysFollowTypeHints";
-
-	private static final String USE_SPECULATIVE_ANALYSIS_KEY = "edu.cuny.hunter.hybridize.eval.useSpeculativeAnalysis";
-
-	private static final String INFER_INPUT_SIGNATURES_KEY = "edu.cuny.hunter.hybridize.eval.inferInputSignatures";
-
-	private static final String OUTPUT_CALLS_KEY = "edu.cuny.hunter.hybridize.eval.outputCalls";
-
-	private static final String TARGETED_CFA_DEPTH_KEY = "edu.cuny.hunter.hybridize.eval.targetedCfaDepth";
-
+	/** The {@code eval.properties} key for the targeted k-CFA depth; also the suffix of its system-property key. */
 	private static final String TARGETED_CFA_DEPTH_PROPERTY_KEY = "targetedCfaDepth";
+
+	/**
+	 * The targeted k-CFA depth system-property key: {@link EvaluationOption#PREFIX} prepended to {@link #TARGETED_CFA_DEPTH_PROPERTY_KEY}.
+	 */
+	private static final String TARGETED_CFA_DEPTH_KEY = EvaluationOption.PREFIX + TARGETED_CFA_DEPTH_PROPERTY_KEY;
 
 	private static String[] buildAttributeColumnNames(String... additionalColumnNames) {
 		String[] primaryColumns = new String[] { "subject", "function", "module", "relative path" };
@@ -155,17 +140,17 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 		return ret.toArray(Object[]::new);
 	}
 
-	private boolean alwaysCheckPythonSideEffects = Boolean.getBoolean(ALWAYS_CHECK_PYTHON_SIDE_EFFECTS_PROPERTY_KEY);
+	private boolean alwaysCheckPythonSideEffects = Boolean.getBoolean(EvaluationOption.ALWAYS_CHECK_PYTHON_SIDE_EFFECTS.key());
 
-	private boolean alwaysCheckRecursion = Boolean.getBoolean(ALWAYS_CHECK_RECURSION_PROPERTY_KEY);
+	private boolean alwaysCheckRecursion = Boolean.getBoolean(EvaluationOption.ALWAYS_CHECK_RECURSION.key());
 
-	private boolean processFunctionsInParallel = Boolean.getBoolean(PROCESS_FUNCTIONS_IN_PARALLEL_PROPERTY_KEY);
+	private boolean processFunctionsInParallel = Boolean.getBoolean(EvaluationOption.PROCESS_FUNCTIONS_IN_PARALLEL.key());
 
-	private boolean useTestEntrypoints = Boolean.getBoolean(USE_TEST_ENTRYPOINTS_KEY);
+	private boolean useTestEntrypoints = Boolean.getBoolean(EvaluationOption.USE_TEST_ENTRYPOINTS.key());
 
-	private boolean alwaysFollowTypeHints = Boolean.getBoolean(ALWAYS_FOLLOW_TYPE_HINTS_KEY);
+	private boolean alwaysFollowTypeHints = Boolean.getBoolean(EvaluationOption.ALWAYS_FOLLOW_TYPE_HINTS.key());
 
-	private boolean useSpeculativeAnalysis = Boolean.getBoolean(USE_SPECULATIVE_ANALYSIS_KEY);
+	private boolean useSpeculativeAnalysis = Boolean.getBoolean(EvaluationOption.USE_SPECULATIVE_ANALYSIS.key());
 
 	/**
 	 * True iff the refactoring should emit an inferred {@code input_signature=...} keyword into the generated {@code @tf.function}
@@ -174,7 +159,7 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/481">Issue 481</a>
 	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/563">Issue 563</a>
 	 */
-	private boolean inferInputSignatures = Boolean.getBoolean(INFER_INPUT_SIGNATURES_KEY);
+	private boolean inferInputSignatures = Boolean.getBoolean(EvaluationOption.INFER_INPUT_SIGNATURES.key());
 
 	/**
 	 * The global targeted k-CFA depth, set via the {@code edu.cuny.hunter.hybridize.eval.targetedCfaDepth} system property and defaulting
@@ -266,7 +251,7 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 					resultsRecord.add(project.getName());
 
 					// calls.
-					if (Boolean.getBoolean(OUTPUT_CALLS_KEY))
+					if (Boolean.getBoolean(EvaluationOption.OUTPUT_CALLS.key()))
 						printCalls(callPrinter, project, monitor.slice(IProgressMonitor.UNKNOWN));
 
 					// set up analysis for single project.
@@ -429,11 +414,11 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 	}
 
 	private static boolean shouldPerformChange() {
-		return Boolean.getBoolean(PERFORM_CHANGE_PROPERTY_KEY);
+		return Boolean.getBoolean(EvaluationOption.PERFORM_CHANGE.key());
 	}
 
 	private static boolean shouldPerformAnalysis() {
-		return Boolean.getBoolean(PERFORM_ANALYSIS_PROPERTY_KEY);
+		return Boolean.getBoolean(EvaluationOption.PERFORM_ANALYSIS.key());
 	}
 
 	private static Set<RefactoringStatusEntry> getRefactoringStatusEntries(Set<Function> functionSet,


### PR DESCRIPTION
Single-sources the evaluator's configuration options in a new `EvaluationOption` enum, so the argument parser (`EvaluateHybridizeFunctionRefactoringApplication`) and the readers (`EvaluateHybridizeFunctionRefactoringHandler`) can no longer drift, the duplication noted in #677.

Each option contributes both its camelCase name (the canonical form of its `--kebab-case` flag, used to validate command-line arguments) and its full system-property key (read via `Boolean.getBoolean`). The handler's eleven per-key constants and the application's `CONFIG_NAMES` set and repeated prefix are removed; adding an option is now one enum entry. The `targetedCfaDepth` key, which is not a `--kebab-case` flag, stays in the handler but derives its prefix from the same holder.

Behavior is unchanged: each `EvaluationOption` key resolves to the identical string the removed constant held.

Closes #677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuhM8SsTRB6BraLt3Ph7ZC
