### PR TITLE
Emit per-parameter input signatures as `input_signatures.csv`

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/InputSignature.java
@@ -58,25 +58,51 @@ public record InputSignature(List<TensorType> parameterTypes) {
 	public String toTensorSpecList(String tfPrefix) {
 		StringJoiner specs = new StringJoiner(", ", "[", "]");
 
-		for (TensorType t : parameterTypes) {
-			List<Dimension<?>> dims = t.getDims();
-			String shape;
-			if (dims == null) {
-				// Shape-⊤ from `Function.inferSpec` Step 2 (rank disagrees across contexts, or any context has null dims). TF's
-				// `tf.TensorSpec(shape=None, ...)` accepts any shape at runtime—the appropriate encoding when rank itself is unknown.
-				shape = "None";
-			} else {
-				StringJoiner shapeDims = new StringJoiner(", ", "(", dims.size() == 1 ? ",)" : ")");
-				for (Dimension<?> d : dims)
-					shapeDims.add(d instanceof NumericDim ? d.value().toString() : "None");
-				shape = shapeDims.toString();
-			}
-
-			String dtype = tfPrefix + dtypeName(t);
-			specs.add(tfPrefix + specTypeName(t) + "(shape=" + shape + ", dtype=" + dtype + ")");
-		}
+		for (TensorType t : parameterTypes)
+			specs.add(tfPrefix + specTypeName(t) + "(shape=" + shapeString(t) + ", dtype=" + tfPrefix + dtypeName(t) + ")");
 
 		return specs.toString();
+	}
+
+	/**
+	 * The raw shape rendering for a parameter's {@link TensorType}: {@code "None"} when the rank is unknown (null dims—shape-⊤, which
+	 * {@code tf.TensorSpec(shape=None, ...)} accepts at runtime), otherwise a tuple of the per-dimension renderings, the concrete size for
+	 * a {@link NumericDim} and {@code "None"} for every other {@link Dimension} subtype (dynamic, ragged, symbolic).
+	 *
+	 * @param t The parameter's tensor type.
+	 * @return The raw shape rendering (e.g. {@code "(None, 128)"}, {@code "(20,)"}, {@code "()"}, or {@code "None"}).
+	 */
+	private static String shapeString(TensorType t) {
+		List<Dimension<?>> dims = t.getDims();
+		if (dims == null)
+			return "None";
+
+		StringJoiner shapeDims = new StringJoiner(", ", "(", dims.size() == 1 ? ",)" : ")");
+		for (Dimension<?> d : dims)
+			shapeDims.add(d instanceof NumericDim ? d.value().toString() : "None");
+
+		return shapeDims.toString();
+	}
+
+	/**
+	 * This signature's per-parameter characteristics in declaration order (one {@link ParameterSpec} per non-{@code self} parameter), so
+	 * downstream analysis reads each parameter's dtype and shape as columns rather than parsing {@link #toTensorSpecList(String)}.
+	 *
+	 * @return The per-parameter (dtype, shape) rows.
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/665">Issue 665</a>
+	 */
+	public List<ParameterSpec> parameterSpecs() {
+		return parameterTypes.stream().map(t -> new ParameterSpec(dtypeName(t), shapeString(t))).toList();
+	}
+
+	/**
+	 * A parameter's inferred tensor characteristics at per-{@code TensorSpec} granularity: the bare dtype constant name and the raw shape
+	 * rendering this signature emits, without the spec-type wrapping of {@link #toTensorSpecList(String)}.
+	 *
+	 * @param dtype The bare dtype constant name (e.g. {@code "float32"}).
+	 * @param shape The raw shape rendering (e.g. {@code "(None, 128)"} or {@code "None"}).
+	 */
+	public record ParameterSpec(String dtype, String shape) {
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -118,27 +118,6 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 	private static final String INPUT_SIGNATURES_CSV_FILENAME = "input_signatures.csv";
 
-	// CSV column names, named so emitters that share a column (e.g. "param index" and "absence reason" across
-	// blocked_parameters.csv and input_signatures.csv, or "refactoring"/"severity"/"code"/"message" across the
-	// failed-precondition and status CSVs) stay single-sourced.
-	private static final String COLUMN_TRANSFORMATION = "transformation";
-	private static final String COLUMN_REFACTORING = "refactoring";
-	private static final String COLUMN_SEVERITY = "severity";
-	private static final String COLUMN_CODE = "code";
-	private static final String COLUMN_MESSAGE = "message";
-	private static final String COLUMN_DECORATOR = "decorator";
-	private static final String COLUMN_PARAM_INDEX = "param index";
-	private static final String COLUMN_PARAM_NAME = "param name";
-	private static final String COLUMN_ABSENCE_REASON = "absence reason";
-	private static final String COLUMN_SOURCE = "source";
-	private static final String COLUMN_DTYPE = "dtype";
-	private static final String COLUMN_SHAPE = "shape";
-
-	// The input_signatures.csv "source" column values.
-	private static final String SOURCE_INFERRED = "inferred";
-	private static final String SOURCE_SUPPLIED = "supplied";
-	private static final String SOURCE_ABSENT = "absent";
-
 	private static final String PERFORM_ANALYSIS_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.performAnalysis";
 
 	private static final String PERFORM_CHANGE_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.performChange";
@@ -259,19 +238,19 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 				CSVPrinter functionsPrinter = createCSVPrinter(FUNCTIONS_CSV_FILENAME, buildFunctionAttributeColumnNames());
 				CSVPrinter candidatesPrinter = createCSVPrinter(CANDIDATES_CSV_FILENAME, buildAttributeColumnNames());
 				CSVPrinter transformationsPrinter = createCSVPrinter(TRANSFORMATIONS_CSV_FILENAME,
-						buildAttributeColumnNames(COLUMN_TRANSFORMATION));
+						buildAttributeColumnNames("transformation"));
 				CSVPrinter optimizableFunctionPrinter = createCSVPrinter(OPTMIZABLE_CSV_FILENAME, buildAttributeColumnNames());
 				CSVPrinter nonOptimizableFunctionPrinter = createCSVPrinter(NONOPTMIZABLE_CSV_FILENAME, buildAttributeColumnNames());
 				CSVPrinter errorPrinter = createCSVPrinter(FAILED_PRECONDITIONS_CSV_FILENAME,
-						buildAttributeColumnNames(COLUMN_REFACTORING, COLUMN_SEVERITY, COLUMN_CODE, COLUMN_MESSAGE));
+						buildAttributeColumnNames("refactoring", "severity", "code", "message"));
 				CSVPrinter statusPrinter = createCSVPrinter(STATUS_CSV_FILENAME,
-						buildAttributeColumnNames(COLUMN_REFACTORING, COLUMN_SEVERITY, COLUMN_CODE, COLUMN_MESSAGE));
-				CSVPrinter decoratorPrinter = createCSVPrinter(DECORATOR_CSV_FILENAME, buildAttributeColumnNames(COLUMN_DECORATOR));
+						buildAttributeColumnNames("refactoring", "severity", "code", "message"));
+				CSVPrinter decoratorPrinter = createCSVPrinter(DECORATOR_CSV_FILENAME, buildAttributeColumnNames("decorator"));
 				CSVPrinter callPrinter = createCSVPrinter(CALL_CSV_FILENAME, CALLS_HEADER);
 				CSVPrinter blockedParametersPrinter = createCSVPrinter(BLOCKED_PARAMETERS_CSV_FILENAME,
-						buildAttributeColumnNames(COLUMN_PARAM_INDEX, COLUMN_PARAM_NAME, COLUMN_ABSENCE_REASON));
+						buildAttributeColumnNames("param index", "param name", "absence reason"));
 				CSVPrinter inputSignaturesPrinter = createCSVPrinter(INPUT_SIGNATURES_CSV_FILENAME,
-						buildAttributeColumnNames(COLUMN_PARAM_INDEX, COLUMN_SOURCE, COLUMN_ABSENCE_REASON, COLUMN_DTYPE, COLUMN_SHAPE));) {
+						buildAttributeColumnNames("param index", "source", "absence reason", "dtype", "shape"));) {
 			if (BUILD_WORKSPACE) {
 				// build the workspace.
 				monitor.beginTask("Building workspace ...", IProgressMonitor.UNKNOWN);
@@ -619,15 +598,15 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 		List<Parameter> parameters = function.getParameters().stream().filter(p -> !p.isSelf()).toList();
 
 		if (function.getInferredInputSignature().isPresent())
-			printSignatureRows(printer, function, parameters, function.getInferredInputSignature().get(), SOURCE_INFERRED);
+			printSignatureRows(printer, function, parameters, function.getInferredInputSignature().get(), "inferred");
 		else
 			for (var entry : function.getBlockingParameterReasons().entrySet())
 				printer.printRecord(
-						buildAttributeColumnValues(function, entry.getKey().getIndex(), SOURCE_ABSENT, entry.getValue(), null, null));
+						buildAttributeColumnValues(function, entry.getKey().getIndex(), "absent", entry.getValue(), null, null));
 
 		HybridizationParameters hybridizationParameters = function.getHybridizationParameters();
 		if (hybridizationParameters != null && hybridizationParameters.getSuppliedInputSignature().isPresent())
-			printSignatureRows(printer, function, parameters, hybridizationParameters.getSuppliedInputSignature().get(), SOURCE_SUPPLIED);
+			printSignatureRows(printer, function, parameters, hybridizationParameters.getSuppliedInputSignature().get(), "supplied");
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -76,8 +76,10 @@ import edu.cuny.citytech.refactoring.common.eval.handlers.EvaluateRefactoringHan
 import edu.cuny.hunter.hybridize.core.analysis.AmbiguousDeclaringModuleException;
 import edu.cuny.hunter.hybridize.core.analysis.Function;
 import edu.cuny.hunter.hybridize.core.analysis.Function.HybridizationParameters;
+import edu.cuny.hunter.hybridize.core.analysis.InputSignature;
 import edu.cuny.hunter.hybridize.core.analysis.NoDeclaringModuleException;
 import edu.cuny.hunter.hybridize.core.analysis.NoTextSelectionException;
+import edu.cuny.hunter.hybridize.core.analysis.Parameter;
 import edu.cuny.hunter.hybridize.core.analysis.PreconditionSuccess;
 import edu.cuny.hunter.hybridize.core.analysis.Refactoring;
 import edu.cuny.hunter.hybridize.core.analysis.Transformation;
@@ -113,6 +115,8 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 	private static final String[] CALLS_HEADER = { "subject", "callee", "expr" };
 
 	private static final String BLOCKED_PARAMETERS_CSV_FILENAME = "blocked_parameters.csv";
+
+	private static final String INPUT_SIGNATURES_CSV_FILENAME = "input_signatures.csv";
 
 	private static final String PERFORM_ANALYSIS_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.performAnalysis";
 
@@ -244,7 +248,9 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 				CSVPrinter decoratorPrinter = createCSVPrinter(DECORATOR_CSV_FILENAME, buildAttributeColumnNames("decorator"));
 				CSVPrinter callPrinter = createCSVPrinter(CALL_CSV_FILENAME, CALLS_HEADER);
 				CSVPrinter blockedParametersPrinter = createCSVPrinter(BLOCKED_PARAMETERS_CSV_FILENAME,
-						buildAttributeColumnNames("param index", "param name", "absence reason"));) {
+						buildAttributeColumnNames("param index", "param name", "absence reason"));
+				CSVPrinter inputSignaturesPrinter = createCSVPrinter(INPUT_SIGNATURES_CSV_FILENAME,
+						buildAttributeColumnNames("param index", "source", "absence reason", "dtype", "shape"));) {
 			if (BUILD_WORKSPACE) {
 				// build the workspace.
 				monitor.beginTask("Building workspace ...", IProgressMonitor.UNKNOWN);
@@ -300,6 +306,7 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 					for (Function func : functions) {
 						printFunction(functionsPrinter, func);
 						printBlockedParameters(blockedParametersPrinter, func);
+						printInputSignatures(inputSignaturesPrinter, func);
 					}
 
 					// optimization available functions. These are the "filtered" functions. We consider functions to be candidates iff they
@@ -570,6 +577,58 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 		for (var entry : function.getBlockingParameterReasons().entrySet())
 			printer.printRecord(
 					buildAttributeColumnValues(function, entry.getKey().getIndex(), entry.getKey().getName(), entry.getValue()));
+	}
+
+	/**
+	 * Emits the function's input signatures at per-parameter (per-{@code TensorSpec}) granularity into {@code input_signatures.csv}, so
+	 * downstream analysis is a group-by rather than a parse of the joined {@code input_signature} string in {@code functions.csv}. There is
+	 * one row per non-{@code self} parameter of the inferred signature (source {@code "inferred"}) and of the developer-supplied signature
+	 * (source {@code "supplied"}); when inference was blocked, one row per blocking parameter (source {@code "absent"}) carrying its
+	 * {@link edu.cuny.hunter.hybridize.core.analysis.InferenceResult.AbsenceReason}. The {@code dtype} and {@code shape} columns hold the
+	 * raw per-parameter values, with rank and wildcard counts left to derive downstream. Reads the memoized inference result without
+	 * recomputing, so it leaves the function's status untouched.
+	 *
+	 * @param printer The {@code input_signatures.csv} printer.
+	 * @param function The function whose per-parameter signatures to emit.
+	 * @throws IOException If a record cannot be written.
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/665">Issue 665</a>
+	 */
+	private static void printInputSignatures(CSVPrinter printer, Function function) throws IOException {
+		// The non-self parameters in declaration order, aligned position-wise with InputSignature.parameterSpecs().
+		List<Parameter> parameters = function.getParameters().stream().filter(p -> !p.isSelf()).toList();
+
+		if (function.getInferredInputSignature().isPresent())
+			printSignatureRows(printer, function, parameters, function.getInferredInputSignature().get(), "inferred");
+		else
+			for (var entry : function.getBlockingParameterReasons().entrySet())
+				printer.printRecord(
+						buildAttributeColumnValues(function, entry.getKey().getIndex(), "absent", entry.getValue(), null, null));
+
+		HybridizationParameters hybridizationParameters = function.getHybridizationParameters();
+		if (hybridizationParameters != null && hybridizationParameters.getSuppliedInputSignature().isPresent())
+			printSignatureRows(printer, function, parameters, hybridizationParameters.getSuppliedInputSignature().get(), "supplied");
+	}
+
+	/**
+	 * Emits one {@code input_signatures.csv} row per parameter of the given signature, tagging each with {@code source} and pairing it
+	 * position-wise with the function's non-{@code self} parameters for the {@code param index} join key. A signature entry beyond the
+	 * declared non-{@code self} parameter count (a parameter-count mismatch) gets a {@code null} index rather than failing the row.
+	 *
+	 * @param printer The {@code input_signatures.csv} printer.
+	 * @param function The function the signature belongs to.
+	 * @param parameters The function's non-{@code self} parameters in declaration order.
+	 * @param signature The signature whose per-parameter rows to emit.
+	 * @param source The source tag ({@code "inferred"} or {@code "supplied"}).
+	 * @throws IOException If a record cannot be written.
+	 */
+	private static void printSignatureRows(CSVPrinter printer, Function function, List<Parameter> parameters, InputSignature signature,
+			String source) throws IOException {
+		var specs = signature.parameterSpecs();
+
+		for (int i = 0; i < specs.size(); i++) {
+			Integer index = i < parameters.size() ? parameters.get(i).getIndex() : null;
+			printer.printRecord(buildAttributeColumnValues(function, index, source, null, specs.get(i).dtype(), specs.get(i).shape()));
+		}
 	}
 
 	private static void printFunction(CSVPrinter printer, Function function) throws IOException, CoreException {

--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -118,6 +118,27 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 	private static final String INPUT_SIGNATURES_CSV_FILENAME = "input_signatures.csv";
 
+	// CSV column names, named so emitters that share a column (e.g. "param index" and "absence reason" across
+	// blocked_parameters.csv and input_signatures.csv, or "refactoring"/"severity"/"code"/"message" across the
+	// failed-precondition and status CSVs) stay single-sourced.
+	private static final String COLUMN_TRANSFORMATION = "transformation";
+	private static final String COLUMN_REFACTORING = "refactoring";
+	private static final String COLUMN_SEVERITY = "severity";
+	private static final String COLUMN_CODE = "code";
+	private static final String COLUMN_MESSAGE = "message";
+	private static final String COLUMN_DECORATOR = "decorator";
+	private static final String COLUMN_PARAM_INDEX = "param index";
+	private static final String COLUMN_PARAM_NAME = "param name";
+	private static final String COLUMN_ABSENCE_REASON = "absence reason";
+	private static final String COLUMN_SOURCE = "source";
+	private static final String COLUMN_DTYPE = "dtype";
+	private static final String COLUMN_SHAPE = "shape";
+
+	// The input_signatures.csv "source" column values.
+	private static final String SOURCE_INFERRED = "inferred";
+	private static final String SOURCE_SUPPLIED = "supplied";
+	private static final String SOURCE_ABSENT = "absent";
+
 	private static final String PERFORM_ANALYSIS_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.performAnalysis";
 
 	private static final String PERFORM_CHANGE_PROPERTY_KEY = "edu.cuny.hunter.hybridize.eval.performChange";
@@ -238,19 +259,19 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 				CSVPrinter functionsPrinter = createCSVPrinter(FUNCTIONS_CSV_FILENAME, buildFunctionAttributeColumnNames());
 				CSVPrinter candidatesPrinter = createCSVPrinter(CANDIDATES_CSV_FILENAME, buildAttributeColumnNames());
 				CSVPrinter transformationsPrinter = createCSVPrinter(TRANSFORMATIONS_CSV_FILENAME,
-						buildAttributeColumnNames("transformation"));
+						buildAttributeColumnNames(COLUMN_TRANSFORMATION));
 				CSVPrinter optimizableFunctionPrinter = createCSVPrinter(OPTMIZABLE_CSV_FILENAME, buildAttributeColumnNames());
 				CSVPrinter nonOptimizableFunctionPrinter = createCSVPrinter(NONOPTMIZABLE_CSV_FILENAME, buildAttributeColumnNames());
 				CSVPrinter errorPrinter = createCSVPrinter(FAILED_PRECONDITIONS_CSV_FILENAME,
-						buildAttributeColumnNames("refactoring", "severity", "code", "message"));
+						buildAttributeColumnNames(COLUMN_REFACTORING, COLUMN_SEVERITY, COLUMN_CODE, COLUMN_MESSAGE));
 				CSVPrinter statusPrinter = createCSVPrinter(STATUS_CSV_FILENAME,
-						buildAttributeColumnNames("refactoring", "severity", "code", "message"));
-				CSVPrinter decoratorPrinter = createCSVPrinter(DECORATOR_CSV_FILENAME, buildAttributeColumnNames("decorator"));
+						buildAttributeColumnNames(COLUMN_REFACTORING, COLUMN_SEVERITY, COLUMN_CODE, COLUMN_MESSAGE));
+				CSVPrinter decoratorPrinter = createCSVPrinter(DECORATOR_CSV_FILENAME, buildAttributeColumnNames(COLUMN_DECORATOR));
 				CSVPrinter callPrinter = createCSVPrinter(CALL_CSV_FILENAME, CALLS_HEADER);
 				CSVPrinter blockedParametersPrinter = createCSVPrinter(BLOCKED_PARAMETERS_CSV_FILENAME,
-						buildAttributeColumnNames("param index", "param name", "absence reason"));
+						buildAttributeColumnNames(COLUMN_PARAM_INDEX, COLUMN_PARAM_NAME, COLUMN_ABSENCE_REASON));
 				CSVPrinter inputSignaturesPrinter = createCSVPrinter(INPUT_SIGNATURES_CSV_FILENAME,
-						buildAttributeColumnNames("param index", "source", "absence reason", "dtype", "shape"));) {
+						buildAttributeColumnNames(COLUMN_PARAM_INDEX, COLUMN_SOURCE, COLUMN_ABSENCE_REASON, COLUMN_DTYPE, COLUMN_SHAPE));) {
 			if (BUILD_WORKSPACE) {
 				// build the workspace.
 				monitor.beginTask("Building workspace ...", IProgressMonitor.UNKNOWN);
@@ -598,15 +619,15 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 		List<Parameter> parameters = function.getParameters().stream().filter(p -> !p.isSelf()).toList();
 
 		if (function.getInferredInputSignature().isPresent())
-			printSignatureRows(printer, function, parameters, function.getInferredInputSignature().get(), "inferred");
+			printSignatureRows(printer, function, parameters, function.getInferredInputSignature().get(), SOURCE_INFERRED);
 		else
 			for (var entry : function.getBlockingParameterReasons().entrySet())
 				printer.printRecord(
-						buildAttributeColumnValues(function, entry.getKey().getIndex(), "absent", entry.getValue(), null, null));
+						buildAttributeColumnValues(function, entry.getKey().getIndex(), SOURCE_ABSENT, entry.getValue(), null, null));
 
 		HybridizationParameters hybridizationParameters = function.getHybridizationParameters();
 		if (hybridizationParameters != null && hybridizationParameters.getSuppliedInputSignature().isPresent())
-			printSignatureRows(printer, function, parameters, hybridizationParameters.getSuppliedInputSignature().get(), "supplied");
+			printSignatureRows(printer, function, parameters, hybridizationParameters.getSuppliedInputSignature().get(), SOURCE_SUPPLIED);
 	}
 
 	/**

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/InputSignatureTest.java
@@ -20,6 +20,7 @@ import com.ibm.wala.cast.python.ml.types.TensorType.RaggedDim;
 import com.ibm.wala.cast.python.ml.types.TensorType.SymbolicDim;
 
 import edu.cuny.hunter.hybridize.core.analysis.InputSignature;
+import edu.cuny.hunter.hybridize.core.analysis.InputSignature.ParameterSpec;
 import edu.cuny.hunter.hybridize.core.analysis.InputSignature.Relation;
 
 /**
@@ -164,6 +165,37 @@ public class InputSignatureTest {
 		} finally {
 			Locale.setDefault(prior);
 		}
+	}
+
+	/**
+	 * {@link InputSignature#parameterSpecs()} exposes each parameter's dtype and raw shape in declaration order, the per-parameter view the
+	 * {@code input_signatures.csv} emitter consumes, matching the rendering {@link InputSignature#toTensorSpecList(String)} joins (#665).
+	 */
+	@Test
+	public void testParameterSpecs() {
+		InputSignature sig = sig(new TensorType(FLOAT32, List.of(new NumericDim(2), new NumericDim(3))),
+				new TensorType(INT32, List.of(new NumericDim(5))));
+		assertEquals(List.of(new ParameterSpec("float32", "(2, 3)"), new ParameterSpec("int32", "(5,)")), sig.parameterSpecs());
+	}
+
+	/**
+	 * {@link InputSignature#parameterSpecs()} renders a rank-0 tensor's shape as {@code "()"} and a shape-⊤ ({@code null} dims) tensor's
+	 * shape as {@code "None"}, matching {@link InputSignature#toTensorSpecList(String)}.
+	 */
+	@Test
+	public void testParameterSpecsScalarAndShapeTop() {
+		assertEquals(List.of(new ParameterSpec("int32", "()")), sig(new TensorType(INT32, List.of())).parameterSpecs());
+		assertEquals(List.of(new ParameterSpec("float32", "None")), sig(new TensorType(FLOAT32, null)).parameterSpecs());
+	}
+
+	/**
+	 * {@link InputSignature#parameterSpecs()} collapses every non-numeric dimension to {@code None} on the shape surface, as
+	 * {@link InputSignature#toTensorSpecList(String)} does.
+	 */
+	@Test
+	public void testParameterSpecsWildcardDims() {
+		assertEquals(List.of(new ParameterSpec("float32", "(None, 32)")),
+				sig(new TensorType(FLOAT32, List.of(DynamicDim.INSTANCE, new NumericDim(32)))).parameterSpecs());
 	}
 
 	private static InputSignature sig(TensorType... types) {


### PR DESCRIPTION
Adds `input_signatures.csv`, one row per function parameter and source, so downstream analysis of the input signatures is a group-by rather than a parse of the joined `input_signature` string in `functions.csv` (the re-parsing #665 calls out).

Per function, each non-`self` parameter of the inferred signature gets a row tagged source `inferred`, and each of the developer-supplied signature a row tagged `supplied`; where inference was blocked, each blocking parameter gets a row tagged `absent` carrying its `AbsenceReason`. Columns are the standard join keys (`subject`, `function`, `module`, `relative path`) plus `param index`, `source`, `absence reason`, `dtype`, and `shape`. The `dtype` and `shape` are raw, so rank and wildcard counts derive downstream and the evaluator stays a data emitter.

`InputSignature` gains a `parameterSpecs()` accessor exposing each parameter's dtype and raw shape, sharing the shape rendering with `toTensorSpecList` through an extracted helper. New `InputSignatureTest` cases cover it; the CSV emission follows the existing eval-CSV pattern, whose per-emitter test infrastructure is the separate #666.

Closes #665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuhM8SsTRB6BraLt3Ph7ZC
