### PR TITLE
Bump the Ariadne dependency to 0.52.0

### DIFF
--- a/hybridize.target
+++ b/hybridize.target
@@ -58,7 +58,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.51.1</version>
+					<version>0.52.0</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
Bumps the Ariadne dependency (`com.ibm.wala.cast.python.ml`) from 0.51.1 to 0.52.0 in `hybridize.target`.

0.52.0 fixes the three Ariadne crashes that blocked the corpus regeneration, each localized earlier this cycle:
- the `SliceBuiltinOperation.getDefaultDTypes` NPE (ponder-lab/ML#429, with the `reshape(pad(x))` slice-receiver dtype recovery in ponder-lab/ML#432 and a chained-slice guard in ponder-lab/ML#431),
- the `getFieldIndex` `read_data`-not-an-integer crash (ponder-lab/ML#433),
- the `TensorTypeAllocator.getDefaultShapes` "Shape is mandatory" throw across the Zeros/Ones/RandomDistribution allocators (ponder-lab/ML#430, ponder-lab/ML#436, ponder-lab/ML#440).

The full suite stays green on the new target (568 tests, 0 failures, 11 pre-existing skips), so the release's shape/dtype precision improvements introduce no signature-pin regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuhM8SsTRB6BraLt3Ph7ZC
