### PR TITLE
Remove the entire `@tf.function` when de-hybridizing a parameterized decorator

### DIFF
--- a/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
+++ b/edu.cuny.hunter.hybridize.core/src/edu/cuny/hunter/hybridize/core/analysis/Function.java
@@ -2290,6 +2290,27 @@ public class Function {
 				String fullRepresentationString = getFullRepresentationString(decorator.func);
 				int length = fullRepresentationString.length() + 1;
 
+				// A called decorator (`@tf.function(...)`) carries an argument list past its name; `getFullRepresentationString`
+				// yields only the dotted name, so extend the span through the matching close bracket. Otherwise the delete strips
+				// just `@tf.function` and orphans the arguments as an invalid bare `(...)` (issue #681). A bare `@tf.function` has no
+				// `(` here, so its span is unchanged.
+				int afterName = offset + length;
+				if (afterName < doc.getLength() && doc.getChar(afterName) == '(') {
+					int depth = 0;
+					int end = afterName;
+					for (; end < doc.getLength(); end++) {
+						char c = doc.getChar(end);
+						if (c == '(' || c == '[' || c == '{')
+							++depth;
+						else if (c == ')' || c == ']' || c == '}') {
+							--depth;
+							if (depth == 0)
+								break;
+						}
+					}
+					length = end - offset + 1;
+				}
+
 				int newline = offset + length;
 				char charAtEnd = doc.getChar(newline);
 

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testConvertToEagerParameterizedDecorator/in/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testConvertToEagerParameterizedDecorator/in/A.py
@@ -1,0 +1,13 @@
+# From https://www.tensorflow.org/guide/function#usage.
+
+import tensorflow as tf
+
+
+@tf.function(reduce_retracing=True)
+def add(t):
+    return t[0] + t[1]
+
+
+arg = (tf.ones([2, 2]), 1)  #  [[2., 2.], [2., 2.]]
+assert type(arg) == tuple
+result = add(arg)

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testConvertToEagerParameterizedDecorator/in/requirements.txt
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testConvertToEagerParameterizedDecorator/in/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow==2.9.3

--- a/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testConvertToEagerParameterizedDecorator/out/A.py
+++ b/edu.cuny.hunter.hybridize.tests/resources/HybridizeFunction/testConvertToEagerParameterizedDecorator/out/A.py
@@ -1,0 +1,12 @@
+# From https://www.tensorflow.org/guide/function#usage.
+
+import tensorflow as tf
+
+
+def add(t):
+    return t[0] + t[1]
+
+
+arg = (tf.ones([2, 2]), 1)  #  [[2., 2.], [2., 2.]]
+assert type(arg) == tuple
+result = add(arg)

--- a/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
+++ b/edu.cuny.hunter.hybridize.tests/test cases/edu/cuny/hunter/hybridize/tests/HybridizeFunctionRefactoringTest.java
@@ -1687,6 +1687,32 @@ public class HybridizeFunctionRefactoringTest extends RefactoringTest {
 	}
 
 	/**
+	 * Test that de-hybridizing a function whose {@code @tf.function} decorator carries arguments removes the ENTIRE decorator, not just its
+	 * name. Regression for #681: {@code Function.convertToEager()} computed the delete span from the decorator name alone, orphaning a
+	 * parameterized decorator's argument list as an invalid bare {@code (...)}.
+	 *
+	 * @see <a href="https://github.com/ponder-lab/Hybridize-Functions-Refactoring/issues/681">Issue 681</a>
+	 */
+	@Test
+	public void testConvertToEagerParameterizedDecorator() throws Exception {
+		Set<Function> functions = this.getFunctions();
+		assertEquals(1, functions.size());
+		Function f = functions.iterator().next();
+		assertTrue("Fixture function should be hybrid pre-refactoring.", f.isHybrid());
+		assertTrue("Fixture function should select CONVERT_TO_EAGER.", f.getTransformations().contains(CONVERT_TO_EAGER));
+
+		IDocument doc = f.getContainingDocument();
+
+		List<TextEdit> edits = new ArrayList<>(f.transform());
+		edits.sort(Comparator.comparingInt(TextEdit::getOffset).reversed());
+
+		for (TextEdit edit : edits)
+			edit.apply(doc);
+
+		assertEqualLines(this.getFileContents(this.getOutputTestFileName("A")), doc.get());
+	}
+
+	/**
 	 * Test that {@code RECONFIGURE} adds an inferred {@code input_signature=[tf.TensorSpec(...)]} to an already-hybrid function whose bare
 	 * {@code @tf.function} decorator (no parentheses) carries no signature. The remaining half of #563: the eager case is
 	 * {@code CONVERT_TO_HYBRID} (#565); this is the already-hybrid case. The source-write appends a parenthesized argument list right after


### PR DESCRIPTION
`convertToEager()` removed only the decorator name when de-hybridizing a function whose `@tf.function` carries arguments, leaving an invalid bare `(...)` (issue #681).

## The Bug

The delete span was computed from the decorator name length alone (`getFullRepresentationString(decorator.func).length() + 1`, the `@` plus the dotted name). For a bare `@tf.function` that spans the whole decorator; for a parameterized one (`input_signature=`, `reduce_retracing=`, `experimental_relax_shapes=`) it deleted `@tf.function` and orphaned the argument list as an invalid bare `(...)`, producing unparseable source.

## The Fix

Extend the delete span through the decorator's argument list with a matching-bracket scan, the same approach `reconfigure()` already uses for its in-place value replacement. A bare `@tf.function` has no following `(`, so its span is unchanged.

## Test

`testConvertToEagerParameterizedDecorator` de-hybridizes `@tf.function(reduce_retracing=True)` and asserts, via the in-memory output comparison against `out/A.py`, that the entire decorator is removed. It fails without the fix (the output would retain the orphaned `(reduce_retracing=True)`).

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuhM8SsTRB6BraLt3Ph7ZC
