### PR TITLE
Bump the Ariadne dependency to 0.52.1

### DIFF
--- a/hybridize.target
+++ b/hybridize.target
@@ -58,7 +58,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.52.0</version>
+					<version>0.52.1</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
Bumps the Ariadne dependency (`com.ibm.wala.cast.python.ml`) from 0.52.0 to 0.52.1 in `hybridize.target`.

0.52.1 guards against a null points-to variable in `TensorGeneratorFactory.findCreator` (ponder-lab/ML#442, closing wala/ML#613). That NPE surfaced once 0.52.0's slice-dtype fixes let `getDefaultDTypes` walk the SSA dtype chain past the original crashes, blocking the tensor analysis on the subjects that exercise that path.

The full suite stays green on the new target (572 tests, 0 failures, 11 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuhM8SsTRB6BraLt3Ph7ZC
