### PR TITLE
Bump the Ariadne dependency to 0.52.3

### DIFF
--- a/hybridize.target
+++ b/hybridize.target
@@ -58,7 +58,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.52.2</version>
+					<version>0.52.3</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>

--- a/hybridize.target
+++ b/hybridize.target
@@ -58,7 +58,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.52.1</version>
+					<version>0.52.2</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
Bumps Ariadne (`com.ibm.wala.cast.python.ml`) from 0.52.1 to 0.52.2.

0.52.2 clears the `getGeneratorBody` null-source NPE (wala/ML#614) that blocked the input-signature corpus regeneration, plus a ragged-generator floor, graceful degrade on non-numeric and null-row dimensions, and a three-bug tensor-generator audit fix (see the [0.52.2 release](https://github.com/ponder-lab/ML/releases/tag/0.52.2)).

A headless dry-run over the corpus confirms the prior NPE holdouts `MusicTransformer-tensorflow2.0` and `TensorFlow2.0-Examples` now analyze clean. The full test suite passes locally with no signature-pin fallout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
