### PR TITLE
Isolate recoverable per-project evaluator failures from fatal VM errors

### DIFF
--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -392,7 +392,14 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 
 					// end the record.
 					resultsPrinter.printRecord(resultsRecord);
-				} catch (Exception e) {
+				} catch (Throwable e) {
+					// Per-project isolation (#689): a subject whose analysis throws, including a recoverable java.lang.Error such
+					// as wala's UnimplementedError (wala/ML#616), is recorded and skipped rather than aborting the whole run. A
+					// VirtualMachineError (OutOfMemoryError, StackOverflowError, ...) is rethrown: the JVM is then unrecoverable, so
+					// isolating one subject and continuing would be meaningless.
+					if (e instanceof VirtualMachineError vmError)
+						throw vmError;
+
 					LOG.error("Evaluation failed for project " + project.getName() + "; recording and skipping it.", e);
 					failedProjects.add(project.getName() + " (" + e.getClass().getSimpleName()
 							+ (e.getMessage() != null ? ": " + e.getMessage() : "") + ")");


### PR DESCRIPTION
The per-project isolation added in #674 catches `Exception`, so a subject whose analysis throws a `java.lang.Error` rather than an `Exception` escapes the catch and aborts the entire run instead of being recorded and skipped.

This surfaced when the input-signature corpus regeneration crashed on a subject whose `tf.keras.Input(..., sparse=True)` trips wala's `UnimplementedError` (an `Error`, upstream wala/ML#616): that one subject took down the whole run with nothing committed, rather than being skipped the way an `Exception`-failing subject already is.

The catch is broadened to `Throwable`, rethrowing only `VirtualMachineError` (`OutOfMemoryError`, `StackOverflowError`), which signals a JVM that is itself unrecoverable, where isolating one subject and continuing would be meaningless. Recoverable `Error`s are now isolated like `Exception`s.

Verified with an analysis-only run over the `sparse=True` subject plus a control: the run now completes with the failing subject recorded and skipped and the control still analyzed, where previously it aborted with nothing produced.

Closes #689
