### PR TITLE
Emit a symmetric succeeded/failed project count from the evaluator

### DIFF
--- a/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
+++ b/edu.cuny.hunter.hybridize.eval/src/edu/cuny/hunter/hybridize/eval/handlers/EvaluateHybridizeFunctionRefactoringHandler.java
@@ -420,11 +420,14 @@ public class EvaluateHybridizeFunctionRefactoringHandler extends EvaluateRefacto
 			SubMonitor.done(monitor);
 		}
 
-		if (!failedProjects.isEmpty())
-			return Status.warning("Evaluation completed; " + failedProjects.size() + " of " + pythonProjects.length
-					+ " project(s) failed and were skipped: " + String.join(", ", failedProjects));
+		int failedCount = failedProjects.size();
+		int succeededCount = pythonProjects.length - failedCount;
 
-		return Status.info("Evaluation was successful.");
+		if (failedCount > 0)
+			return Status.warning("Evaluation completed: " + succeededCount + " of " + pythonProjects.length + " project(s) succeeded, "
+					+ failedCount + " failed and were skipped: " + String.join(", ", failedProjects));
+
+		return Status.info("Evaluation completed: all " + pythonProjects.length + " project(s) succeeded.");
 	}
 
 	private static boolean shouldPerformChange() {


### PR DESCRIPTION
The evaluator's final status quantified only the failure path (`N of M project(s) failed and were skipped`) and reported no figures on a clean run. With per-project isolation (#690) making a partial-success run the normal outcome, the final status now always reports both sides:
- with failures: `Evaluation completed: X of M project(s) succeeded, N failed and were skipped: [names]`
- clean: `Evaluation completed: all M project(s) succeeded`

Closes #692
