### PR TITLE
Bump the Ariadne dependency to 0.52.4

### DIFF
--- a/hybridize.target
+++ b/hybridize.target
@@ -58,7 +58,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.52.3</version>
+					<version>0.52.4</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
Bumps the Ariadne dependency to 0.52.4 (from 0.52.3) in `hybridize.target`.

0.52.4 includes ponder-lab/ML#450 (model `sparse`/`tensor`/`ragged`/`type_spec` in `Input`), #454 (`experimental_distribute_dataset` pass-through), and #456 (`padded_batch` element typing). Verified locally that these restore tensor-parameter typing through batched tf.data pipelines that 0.52.3 dropped.

Does not fully close wala/ML#618: parameters that receive tensors interprocedurally at a direct call site still aren't typed. That remaining call-site-to-parameter gap is tracked there.
