### PR TITLE
Bump Ariadne to 0.52.5

### DIFF
--- a/hybridize.target
+++ b/hybridize.target
@@ -58,7 +58,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.52.4</version>
+					<version>0.52.5</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
Bumps the Ariadne dependency in `hybridize.target` from 0.52.4 to 0.52.5.

0.52.5 bundles two fixes:
- wala/ML#628: the analysis interpreter no longer imports `site.py` (which pulled `jline`), so it stops throwing `NoClassDefFoundError` and aborting module analysis under the published fat-jar, the crash tracked here as #429 and fixed test-side in #696.
- wala/ML#618: the distributed training reach (`tf.distribute.Strategy.run`) types its callback parameters.

Verified locally against the evaluator product: `jline` `NoClassDefFoundError` count 0 and `frozen_importlib` fallback count 0, and the multi-subject corpus run completes where 0.52.4 aborted every subject at the site import.
