### PR TITLE
Bump Ariadne to 0.52.10

### DIFF
--- a/hybridize.target
+++ b/hybridize.target
@@ -58,7 +58,7 @@
 				<dependency>
 					<groupId>com.ibm.wala</groupId>
 					<artifactId>com.ibm.wala.cast.python.ml</artifactId>
-					<version>0.52.9</version>
+					<version>0.52.10</version>
 					<classifier>fat</classifier>
 					<type>jar</type>
 				</dependency>


### PR DESCRIPTION
Bumps Ariadne to 0.52.10, which carries the base-class name-collision fix (ML#491, closing wala/ML#657) and a `FixedLenFeature` regression guard (ML#490).

wala/ML#657: a bare-name `class Model` collision across modules (e.g. `from tensorflow.keras import Model; class MyModel(Model)` in `CNN.py`, with another module also defining `class Model`) left `MyModel` with a null superclass, so `MyModel.call` got no call-graph node and failed its call-graph-dependent preconditions. ML#491 falls back to `object` when no non-missing supertype resolves locally, restoring the linkage.

No test changes. The full suite is green on 0.52.10 (582 tests, 0 failures, 11 skipped). wala/ML#657 is whole-project-emergent (it does not reproduce as a single-file fixture), so there is no unit fixture here; ML#491's `testModelSubclassNameCollision` guards it upstream, and a corpus run confirms `MyModel.call` recovers its node and returns to P1 ([confirmation](https://github.com/wala/ML/issues/657#issuecomment-4850192796)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)